### PR TITLE
Deep link parsers and tests

### DIFF
--- a/Microsoft.Toolkit.Uwp/Helpers/CollectionFormingDeepLinkParser.cs
+++ b/Microsoft.Toolkit.Uwp/Helpers/CollectionFormingDeepLinkParser.cs
@@ -1,0 +1,54 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.Toolkit.Uwp
+{
+    /// <summary>
+    /// A version of <see cref="DeepLinkParser" /> which generates a comma-separated-list as the value for any option that is repeated in the query string
+    /// </summary>
+    /// <example>
+    /// in OnLaunched of App.xaml.cs:
+    /// <code lang="c#">
+    /// if (e.PrelaunchActivated == false)
+    /// {
+    ///     if (rootFrame.Content == null)
+    ///     {
+    ///         var parser = CollectionFormingDeepLinkParser.Create(args);
+    ///         if (parser["username"] == "John Doe")
+    ///         {
+    ///             // do work here
+    ///         }
+    ///         if (parser.Root == "Signup")
+    ///         {
+    ///             var preferences = parser["pref"].Split(',');    // now a string[] of all 'pref' querystring values passed in URI
+    ///             rootFrame.Navigate(typeof(Signup));
+    ///         }
+    /// </code>
+    /// </example>
+    public class CollectionFormingDeepLinkParser : DeepLinkParser
+    {
+        /// <inheritdoc/>
+        protected override void ParseUriString(string uri)
+        {
+            var validatedUri = ValidateSourceUri(uri);
+
+            var queryStringStart = validatedUri.OriginalString.IndexOf('?');
+            this.Root = validatedUri.OriginalString.Substring(0, queryStringStart);
+
+            var queryString = validatedUri.OriginalString.Substring(queryStringStart + 1);
+
+            // split up in to key-value pairs
+            var pairs = queryString.Split('&').Select(param =>
+             {
+                 var kvp = param.Split('=');
+                 return new KeyValuePair<string, string>(kvp[0], kvp[1]);
+             });
+
+            var grouped = pairs.GroupBy(pair => pair.Key);
+            foreach (var group in grouped)
+            { // adds the group to the base with ',' separating each item within a group
+                Add(group.Key, string.Join(",", group.Select(item => item.Value)));
+            }
+        }
+    }
+}

--- a/Microsoft.Toolkit.Uwp/Helpers/DeepLinkParser.cs
+++ b/Microsoft.Toolkit.Uwp/Helpers/DeepLinkParser.cs
@@ -1,0 +1,122 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Windows.ApplicationModel.Activation;
+
+namespace Microsoft.Toolkit.Uwp
+{
+    /// <summary>
+    /// Provides assistance with parsing <see cref="ILaunchActivatedEventArgs"/> and its .Arguments property in to a key-value set and target path
+    /// </summary>
+    /// <example>
+    /// in OnLaunched of App.xaml.cs:
+    /// <code lang="c#">
+    /// if (e.PrelaunchActivated == false)
+    /// {
+    ///     if (rootFrame.Content == null)
+    ///     {
+    ///         var parser = DeepLinkParser.Create(args);
+    ///         if (parser["username"] == "John Doe")
+    ///         {
+    ///             // do work here
+    ///         }
+    ///         if (parser.Root == "Signup")
+    ///         {
+    ///             rootFrame.Navigate(typeof(Signup));
+    ///         }
+    /// </code>
+    /// </example>
+    public class DeepLinkParser : Dictionary<string, string>
+    {
+        /// <summary>
+        /// Creates an instance of <see cref="DeepLinkParser"/> for the given <see cref="IActivatedEventArgs"/>
+        /// </summary>
+        /// <param name="args">The <see cref="IActivatedEventArgs"/> instance containing the launch Uri data.</param>
+        /// <returns>An instance of <see cref="DeepLinkParser"/></returns>
+        /// <remarks><paramref name="args"/> will be cast to <see cref="ILaunchActivatedEventArgs"/> </remarks>
+        public static DeepLinkParser Create(IActivatedEventArgs args) => new DeepLinkParser(args);
+
+        /// <summary>
+        /// Validates the source URI.
+        /// </summary>
+        /// <param name="uri">The URI.</param>
+        /// <returns><paramref name="uri"/> as a <c>System.Uri</c> instance</returns>
+        /// <exception cref="System.ArgumentException">Not a valid URI format</exception>
+        protected static Uri ValidateSourceUri(string uri)
+        {
+            Uri validatedUri;
+            if (!Uri.TryCreate(uri, UriKind.RelativeOrAbsolute, out validatedUri)
+                || !validatedUri.IsWellFormedOriginalString())
+            {
+                throw new ArgumentException("Not a valid URI format", nameof(uri));
+            }
+
+            return validatedUri;
+        }
+
+        private readonly ILaunchActivatedEventArgs inputArgs;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DeepLinkParser"/> class.
+        /// </summary>
+        protected DeepLinkParser()
+        {
+        }
+
+        private DeepLinkParser(IActivatedEventArgs args)
+        {
+            inputArgs = args as ILaunchActivatedEventArgs;
+
+            if (inputArgs == null)
+            {
+                throw new ArgumentException("'args' is not a LaunchActivatedEventArgs instance", nameof(args));
+            }
+
+            ParseUriString(inputArgs.Arguments);
+        }
+
+        /// <summary>
+        /// Parses the URI string in to components.
+        /// </summary>
+        /// <param name="uri">The URI.</param>
+        protected virtual void ParseUriString(string uri)
+        {
+            Uri validatedUri = ValidateSourceUri(uri);
+
+            var origString = validatedUri.OriginalString;
+            int queryStartPosition = origString.IndexOf('?');
+            if (queryStartPosition == -1)
+            { // No querystring on the URI
+                this.Root = origString;
+            }
+            else
+            {
+                this.Root = origString.Substring(0, queryStartPosition);
+                var queryString = origString.Substring(queryStartPosition + 1);
+                foreach (var queryStringParam in queryString.Split('&')
+                    .Select(param =>
+                    {
+                        var kvp = param.Split('=');
+                        return new KeyValuePair<string, string>(kvp[0], kvp[1]);
+                    }))
+                {
+                    try
+                    {
+                        Add(queryStringParam.Key, queryStringParam.Value);
+                    }
+                    catch (ArgumentException aex)
+                    {
+                        throw new ArgumentException("If you wish to use the same key name to add an array of values, try using CollectionFormingDeepLinkParser", aex);
+                    }
+                }
+            }
+        }
+
+        /// <summary>Gets or sets the root path of the Deep link URI</summary>
+        /// <example>
+        /// for "MainPage/Options?option1=value1"
+        /// Root = "MainPage/Options"
+        /// </example>
+        public string Root { get; protected set; }
+    }
+}

--- a/Microsoft.Toolkit.Uwp/Microsoft.Toolkit.Uwp.csproj
+++ b/Microsoft.Toolkit.Uwp/Microsoft.Toolkit.Uwp.csproj
@@ -50,8 +50,10 @@
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Helpers\CollectionFormingDeepLinkParser.cs" />
     <Compile Include="Helpers\ColorHelper.cs" />
     <Compile Include="Helpers\ConnectionHelper.cs" />
+    <Compile Include="Helpers\DeepLinkParser.cs" />
     <Compile Include="Helpers\StorageFileHelper.cs" />
     <Compile Include="Helpers\WeakEventListener.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/UnitTests/DeepLinkParserTests.cs
+++ b/UnitTests/DeepLinkParserTests.cs
@@ -1,0 +1,110 @@
+﻿using Microsoft.Toolkit.Uwp;
+using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
+using System;
+using System.Diagnostics;
+using UnitTests;
+
+namespace Tests
+{
+    [TestClass]
+    public class DeepLinkParserTests
+    {
+        public TestContext TestContext { get; set; }
+
+        private const string SAMPLELINK = @"MainPage/Options?option1=value1&option2=value2&option3=value3";
+        private static readonly DeepLinkParser _parser = new TestDeepLinkParser(SAMPLELINK);
+
+        [TestMethod]
+        public void Test_DeepLink_RootValue()
+        {
+            Assert.AreEqual("MainPage/Options", _parser.Root);
+        }
+
+        [TestMethod]
+        public void Test_DeepLink_PullOptions()
+        {
+            Assert.AreEqual("value1", _parser["option1"]);
+            Assert.AreEqual("value2", _parser["option2"]);
+            Assert.AreEqual("value3", _parser["option3"]);
+        }
+
+        [TestMethod]
+        public void Test_DeepLink_OptionNotFound()
+        {
+            try
+            {
+                var nonexistentvalue = _parser["nonexistentoption"];
+
+                Assert.Fail("Should have thrown KeyNotFoundException");
+            }
+            catch (System.Collections.Generic.KeyNotFoundException)
+            {
+            }
+            catch
+            {
+                Assert.Fail("Should have thrown KeyNotFoundException");
+            }
+        }
+
+        [TestMethod]
+        public void Test_DeepLink_DuplicateKeys()
+        {
+            try
+            {
+                var s = SAMPLELINK + "&option2=value4";
+                var p = new TestDeepLinkParser(s);
+
+                Assert.Fail("Should have thrown ArgumentException");
+            }
+            catch (ArgumentException aex)
+            {
+                Debug.WriteLine(aex.ToString());
+            }
+            catch
+            {
+                Assert.Fail("Should have thrown ArgumentException");
+            }
+        }
+    }
+
+    [TestClass]
+#pragma warning disable SA1402 // File may only contain a single class
+    public class CollectionCapableDeepLinkParserTests
+#pragma warning restore SA1402 // File may only contain a single class
+    {
+        private const string SAMPLELINK = @"MainPage/Options?option1=value1&option2=value2&option3=value3&option2=value4";
+        private static readonly DeepLinkParser _parser = new TestCollectionCapableDeepLinkParser(SAMPLELINK);
+
+        [TestMethod]
+        public void Test_CollectionDeepLink_RootValue()
+        {
+            Assert.AreEqual("MainPage/Options", _parser.Root);
+        }
+
+        [TestMethod]
+        public void Test_CollectionDeepLink_PullOptions()
+        {
+            Assert.AreEqual("value1", _parser["option1"]);
+            Assert.AreEqual("value2,value4", _parser["option2"]);
+            Assert.AreEqual("value3", _parser["option3"]);
+        }
+
+        [TestMethod]
+        public void Test_CollectionDeepLink_OptionNotFound()
+        {
+            try
+            {
+                var nonexistentvalue = _parser["nonexistentoption"];
+
+                Assert.Fail("Should have thrown KeyNotFoundException");
+            }
+            catch (System.Collections.Generic.KeyNotFoundException)
+            {
+            }
+            catch
+            {
+                Assert.Fail("Should have thrown KeyNotFoundException");
+            }
+        }
+    }
+}

--- a/UnitTests/TestParsers.cs
+++ b/UnitTests/TestParsers.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.Toolkit.Uwp;
+
+namespace UnitTests
+{
+#pragma warning disable SA1649 // File name must match first type name
+    internal class TestDeepLinkParser : DeepLinkParser
+#pragma warning restore SA1649 // File name must match first type name
+    {
+        public TestDeepLinkParser(string uri)
+        {
+            ParseUriString(uri);
+        }
+    }
+
+#pragma warning disable SA1402 // File may only contain a single class
+    internal class TestCollectionCapableDeepLinkParser : CollectionFormingDeepLinkParser
+#pragma warning restore SA1402 // File may only contain a single class
+    {
+        public TestCollectionCapableDeepLinkParser(string uri)
+        {
+            ParseUriString(uri);
+        }
+    }
+}

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -113,7 +113,9 @@
     <SDKReference Include="TestPlatform.Universal, Version=$(UnitTestPlatformVersion)" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DeepLinkParserTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TestParsers.cs" />
     <Compile Include="UnitTestApp.xaml.cs">
       <DependentUpon>UnitTestApp.xaml</DependentUpon>
     </Compile>


### PR DESCRIPTION
The purpose of this PR is to provide UWP devs an easy way to deal with Deep link URIs as they become more and more a part of the services we create for devs to consume. Bot Framework, Cortana launches, etc all rely on deep links in to apps to ultimately provide value.

# DeepLinkParser
This class provides a way to create, from `IActivatedEventArgs` a `Dictionary<string,string>`-inheriting object that provides an additional `.Root` property to pull the base path of the URI (eg: in `MainPage/Options?option1=value1`, `.Root` would be `MainPage/Options`.
Once you have an instance, simply saying `instance["optionName"]` will pull the value from the querystring for that option.

# CollectionFormingDeepLinkParser
Some consumers want to be able to do something like `?pref=this&pref=that&pref=theOther` and have a pull of `pref` come back with `this,that,theOther` as its value. This derivative of `DeepLinkParser` provides this functionality.

Both of these are createable using a `.Create(IActivatedEventArgs)` method. Should a user wish to create one in a different manner, the default constructor is `protected` so inheriting from either of these can provide extensibility should they wish to pass in just a `string`, etc. The method that does the heavy lifting of parsing in to the `Dictionary<string,string>` is also `protected` so can be used by any inheriting class.