### PR TITLE
Consistent punctuation in md files

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -28,13 +28,13 @@ PR has to be validated by at least two core members (either Microsoft or MVP) be
 * DO ensure that APIs are intuitive and can be successfully used in basic scenarios without referring to the reference documentation.
 * DO communicate incorrect usage of APIs as soon as possible. 
 * DO design an API by writing code samples for the main scenarios. Only then, you define the object model that supports those code samples.
-* DO NOT use regions. DO use partial classes instead
-* DO declare static dependency properties at the top of their file 
-* DO NOT seal controls
-* DO use extension methods over static methods where possible
+* DO NOT use regions. DO use partial classes instead.
+* DO declare static dependency properties at the top of their file.
+* DO NOT seal controls.
+* DO use extension methods over static methods where possible.
 * DO NOT return true or false to give sucess status. Throw exceptions if there was a failure.
 * DO use verbs like GET.
-* DO NOT use verbs that are not already used like fetch
+* DO NOT use verbs that are not already used like fetch.
 
 ## Naming conventions
 * We are following the coding guidelines of [.NET Core Foundational libraries](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/coding-style.md). 
@@ -48,5 +48,5 @@ PR has to be validated by at least two core members (either Microsoft or MVP) be
 * DO use verbose identifier names.
 
 ## Files and folders
-* DO associate no more than one class per file
-* DO use folders to group classes based on features
+* DO associate no more than one class per file.
+* DO use folders to group classes based on features.

--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,7 @@ Want to see the toolkit in action before jumping into the code?  Download and pl
 
 ## Nuget Packages
 
-NuGet is a standard package manager for .Net applications that is built into Visual Studio. From your open solution choose the *Tools* menu, *NuGet Package Manger*, *Mange NuGet packages for solution...* to open the UI.  Enter one of the package names below to search for it online.
+NuGet is a standard package manager for .NET applications that is built into Visual Studio. From your open solution choose the *Tools* menu, *NuGet Package Manager*, *Manage NuGet packages for solution...* to open the UI.  Enter one of the package names below to search for it online.
 
 Once you search you should see a list similar to the one below (versions may be different, but names should be the same).
 
@@ -24,8 +24,8 @@ Once you search you should see a list similar to the one below (versions may be 
 | NuGet Package Name | description |
 | --- | --- |
 | [Microsoft.Toolkit.Uwp](https://developer.microsoft.com/en-us/windows/uwp-community-toolkit/api/Microsoft_Toolkit_Uwp.htm) | Main NuGet package includes code only helpers for Colors, Internet Connection detection, Storage file handling, and a Stream helper class. |
-| [Microsoft.Toolkit.Uwp.Notifications](https://developer.microsoft.com/en-us/windows/uwp-community-toolkit/api/Microsoft_Toolkit_Uwp_Notifications.htm) | Notifications Package - Generate tile, toast, and badge notifications for Windows 10 via code.  Includes intellisense support to avoid having to use the XML syntax. |
-| Microsoft.Toolkit.Uwp.Notifications.Javascript | Notification Packages for JavaScript |
+| [Microsoft.Toolkit.Uwp.Notifications](https://developer.microsoft.com/en-us/windows/uwp-community-toolkit/api/Microsoft_Toolkit_Uwp_Notifications.htm) | Notifications Package - Generate tile, toast, and badge notifications for Windows 10 via code.  Includes IntelliSense support to avoid having to use the XML syntax. |
+| Microsoft.Toolkit.Uwp.Notifications.Javascript | Notification Packages for JavaScript. |
 | [Microsoft.Toolkit.Uwp.Services](https://developer.microsoft.com/en-us/windows/uwp-community-toolkit/api/Microsoft_Toolkit_Uwp_Services.htm) | Services Package - This NuGet package includes the service helpers for Bing, Facebook, and Twitter. |
 | [Microsoft.Toolkit.Uwp.UI](https://developer.microsoft.com/en-us/windows/uwp-community-toolkit/api/Microsoft_Toolkit_Uwp_UI.htm) | UI Packages - XAML converters, Visual tree extensions and helpers for your XAML UI. |
 | [Microsoft.Toolkit.Uwp.UI.Animations](https://developer.microsoft.com/en-us/windows/uwp-community-toolkit/api/Microsoft_Toolkit_Uwp_UI_Animations.htm) | Animations and Composition behaviors such as Blur, Fade, Rotate, etc. |
@@ -76,12 +76,12 @@ Once you search you should see a list similar to the one below (versions may be 
 
 ## Feedback and Requests
 
-Please use [Github issues](https://github.com/Microsoft/UWPCommunityToolkit/issues) for questions or comments.
+Please use [GitHub issues](https://github.com/Microsoft/UWPCommunityToolkit/issues) for questions or comments.
 
 If you have specific feature requests or would like to vote on what others are recommending visit our [UWP Community Toolkit User Voice](https://aka.ms/uwpcommunitytoolkituservoice).
 
 ## Contributing
-Do you want to contribute? Here are our [contribution guidelines](https://github.com/Microsoft/UWPCommunityToolkit/blob/master/contributing.md)
+Do you want to contribute? Here are our [contribution guidelines](https://github.com/Microsoft/UWPCommunityToolkit/blob/master/contributing.md).
 
 ## Principles
 


### PR DESCRIPTION
Consistent punctuation between items in the same list.
Small typo in NuGet Package Manager