### PR TITLE
Use C#6 nameof() instead of hard-coded strings

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp/Controls/CodeRenderer/CodeRenderer.Properties.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/Controls/CodeRenderer/CodeRenderer.Properties.cs
@@ -15,11 +15,11 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.Controls
 {
     public partial class CodeRenderer
     {
-        public static readonly DependencyProperty HtmlSourceProperty = DependencyProperty.Register("HtmlSource", typeof(string), typeof(CodeRenderer), new PropertyMetadata(null, HtmlSourceChanged));
-        public static readonly DependencyProperty CSharpSourceProperty = DependencyProperty.Register("CSharpSource", typeof(string), typeof(CodeRenderer), new PropertyMetadata(null, CSharpSourceChanged));
-        public static readonly DependencyProperty JsonSourceProperty = DependencyProperty.Register("JsonSource", typeof(string), typeof(CodeRenderer), new PropertyMetadata(null, JsonSourceChanged));
-        public static readonly DependencyProperty XamlSourceProperty = DependencyProperty.Register("XamlSource", typeof(string), typeof(CodeRenderer), new PropertyMetadata(null, XamlSourceChanged));
-        public static readonly DependencyProperty XmlSourceProperty = DependencyProperty.Register("XmlSource", typeof(string), typeof(CodeRenderer), new PropertyMetadata(null, XmlSourceChanged));
+        public static readonly DependencyProperty HtmlSourceProperty = DependencyProperty.Register(nameof(HtmlSource), typeof(string), typeof(CodeRenderer), new PropertyMetadata(null, HtmlSourceChanged));
+        public static readonly DependencyProperty CSharpSourceProperty = DependencyProperty.Register(nameof(CSharpSource), typeof(string), typeof(CodeRenderer), new PropertyMetadata(null, CSharpSourceChanged));
+        public static readonly DependencyProperty JsonSourceProperty = DependencyProperty.Register(nameof(JsonSource), typeof(string), typeof(CodeRenderer), new PropertyMetadata(null, JsonSourceChanged));
+        public static readonly DependencyProperty XamlSourceProperty = DependencyProperty.Register(nameof(XamlSource), typeof(string), typeof(CodeRenderer), new PropertyMetadata(null, XamlSourceChanged));
+        public static readonly DependencyProperty XmlSourceProperty = DependencyProperty.Register(nameof(XmlSource), typeof(string), typeof(CodeRenderer), new PropertyMetadata(null, XmlSourceChanged));
 
         public string HtmlSource
         {

--- a/Microsoft.Toolkit.Uwp.UI.Animations/Behaviors/Blur.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Animations/Behaviors/Blur.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations.Behaviors
         /// <summary>
         /// The Blur value of the associated object
         /// </summary>
-        public static readonly DependencyProperty ValueProperty = DependencyProperty.Register("Value", typeof(double), typeof(Blur), new PropertyMetadata(1d, PropertyChangedCallback));
+        public static readonly DependencyProperty ValueProperty = DependencyProperty.Register(nameof(Value), typeof(double), typeof(Blur), new PropertyMetadata(1d, PropertyChangedCallback));
 
         /// <summary>
         /// Gets or sets the Blur.

--- a/Microsoft.Toolkit.Uwp.UI.Animations/Behaviors/CompositionBehaviorBase.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Animations/Behaviors/CompositionBehaviorBase.cs
@@ -39,17 +39,17 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations.Behaviors
         /// <summary>
         /// The duration of the animation.
         /// </summary>
-        public static readonly DependencyProperty DurationProperty = DependencyProperty.Register("Duration", typeof(double), typeof(CompositionBehaviorBase), new PropertyMetadata(1d, PropertyChangedCallback));
+        public static readonly DependencyProperty DurationProperty = DependencyProperty.Register(nameof(Duration), typeof(double), typeof(CompositionBehaviorBase), new PropertyMetadata(1d, PropertyChangedCallback));
 
         /// <summary>
         /// The delay of the animation.
         /// </summary>
-        public static readonly DependencyProperty DelayProperty = DependencyProperty.Register("Delay", typeof(double), typeof(CompositionBehaviorBase), new PropertyMetadata(0d, PropertyChangedCallback));
+        public static readonly DependencyProperty DelayProperty = DependencyProperty.Register(nameof(Delay), typeof(double), typeof(CompositionBehaviorBase), new PropertyMetadata(0d, PropertyChangedCallback));
 
         /// <summary>
         /// The property sets if the animation should automatically start.
         /// </summary>
-        public static readonly DependencyProperty AutomaticallyStartProperty = DependencyProperty.Register("AutomaticallyStart", typeof(bool), typeof(CompositionBehaviorBase), new PropertyMetadata(true, PropertyChangedCallback));
+        public static readonly DependencyProperty AutomaticallyStartProperty = DependencyProperty.Register(nameof(AutomaticallyStart), typeof(bool), typeof(CompositionBehaviorBase), new PropertyMetadata(true, PropertyChangedCallback));
 
         /// <summary>
         /// Gets or sets a value indicating whether [automatically start] on the animation is set.

--- a/Microsoft.Toolkit.Uwp.UI.Animations/Behaviors/Fade.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Animations/Behaviors/Fade.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations.Behaviors
         /// <summary>
         /// The Opacity value of the associated object
         /// </summary>
-        public static readonly DependencyProperty ValueProperty = DependencyProperty.Register("Value", typeof(double), typeof(Fade), new PropertyMetadata(1d, PropertyChangedCallback));
+        public static readonly DependencyProperty ValueProperty = DependencyProperty.Register(nameof(Value), typeof(double), typeof(Fade), new PropertyMetadata(1d, PropertyChangedCallback));
 
         /// <summary>
         /// Gets or sets the Opacity.

--- a/Microsoft.Toolkit.Uwp.UI.Animations/Behaviors/Offset.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Animations/Behaviors/Offset.cs
@@ -26,12 +26,12 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations.Behaviors
         /// <summary>
         /// The Offset on the x axis of the associated object
         /// </summary>
-        public static readonly DependencyProperty OffsetXProperty = DependencyProperty.Register("OffsetX", typeof(double), typeof(Offset), new PropertyMetadata(1d, PropertyChangedCallback));
+        public static readonly DependencyProperty OffsetXProperty = DependencyProperty.Register(nameof(OffsetX), typeof(double), typeof(Offset), new PropertyMetadata(1d, PropertyChangedCallback));
 
         /// <summary>
         /// The Offset on the y axis of the associated object
         /// </summary>
-        public static readonly DependencyProperty OffsetYProperty = DependencyProperty.Register("OffsetY", typeof(double), typeof(Offset), new PropertyMetadata(1d, PropertyChangedCallback));
+        public static readonly DependencyProperty OffsetYProperty = DependencyProperty.Register(nameof(OffsetY), typeof(double), typeof(Offset), new PropertyMetadata(1d, PropertyChangedCallback));
 
         /// <summary>
         /// Gets or sets the Offset x.

--- a/Microsoft.Toolkit.Uwp.UI.Animations/Behaviors/Rotate.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Animations/Behaviors/Rotate.cs
@@ -22,17 +22,17 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations.Behaviors
         /// <summary>
         /// The rotation of the associated object in degrees
         /// </summary>
-        public static readonly DependencyProperty ValueProperty = DependencyProperty.Register("Value", typeof(double), typeof(Rotate), new PropertyMetadata(1d, PropertyChangedCallback));
+        public static readonly DependencyProperty ValueProperty = DependencyProperty.Register(nameof(Value), typeof(double), typeof(Rotate), new PropertyMetadata(1d, PropertyChangedCallback));
 
         /// <summary>
         /// The center (x axis) of rotation for associated object
         /// </summary>
-        public static readonly DependencyProperty CenterXProperty = DependencyProperty.Register("CenterX", typeof(double), typeof(Rotate), new PropertyMetadata(0d, PropertyChangedCallback));
+        public static readonly DependencyProperty CenterXProperty = DependencyProperty.Register(nameof(CenterX), typeof(double), typeof(Rotate), new PropertyMetadata(0d, PropertyChangedCallback));
 
         /// <summary>
         /// The center (y axis) of rotation for associated object
         /// </summary>
-        public static readonly DependencyProperty CenterYProperty = DependencyProperty.Register("CenterY", typeof(double), typeof(Rotate), new PropertyMetadata(0d, PropertyChangedCallback));
+        public static readonly DependencyProperty CenterYProperty = DependencyProperty.Register(nameof(CenterY), typeof(double), typeof(Rotate), new PropertyMetadata(0d, PropertyChangedCallback));
 
         /// <summary>
         /// Gets or sets the center point (x axis) of the associated object.

--- a/Microsoft.Toolkit.Uwp.UI.Animations/Behaviors/Scale.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Animations/Behaviors/Scale.cs
@@ -22,22 +22,22 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations.Behaviors
         /// <summary>
         /// The scale (x axis) of the associated object
         /// </summary>
-        public static readonly DependencyProperty ScaleXProperty = DependencyProperty.Register("ScaleX", typeof(double), typeof(Scale), new PropertyMetadata(1d, PropertyChangedCallback));
+        public static readonly DependencyProperty ScaleXProperty = DependencyProperty.Register(nameof(ScaleX), typeof(double), typeof(Scale), new PropertyMetadata(1d, PropertyChangedCallback));
 
         /// <summary>
         /// The scale (y axis) of the associated object
         /// </summary>
-        public static readonly DependencyProperty ScaleYProperty = DependencyProperty.Register("ScaleY", typeof(double), typeof(Scale), new PropertyMetadata(1d, PropertyChangedCallback));
+        public static readonly DependencyProperty ScaleYProperty = DependencyProperty.Register(nameof(ScaleY), typeof(double), typeof(Scale), new PropertyMetadata(1d, PropertyChangedCallback));
 
         /// <summary>
         /// The center (x axis) of scale for associated object
         /// </summary>
-        public static readonly DependencyProperty CenterXProperty = DependencyProperty.Register("CenterX", typeof(double), typeof(Scale), new PropertyMetadata(0d, PropertyChangedCallback));
+        public static readonly DependencyProperty CenterXProperty = DependencyProperty.Register(nameof(CenterX), typeof(double), typeof(Scale), new PropertyMetadata(0d, PropertyChangedCallback));
 
         /// <summary>
         /// The center (y axis) of scale for associated object
         /// </summary>
-        public static readonly DependencyProperty CenterYProperty = DependencyProperty.Register("CenterY", typeof(double), typeof(Scale), new PropertyMetadata(0d, PropertyChangedCallback));
+        public static readonly DependencyProperty CenterYProperty = DependencyProperty.Register(nameof(CenterY), typeof(double), typeof(Scale), new PropertyMetadata(0d, PropertyChangedCallback));
 
         /// <summary>
         /// Gets or sets the scale on the x axis.

--- a/Microsoft.Toolkit.Uwp.UI.Controls/HamburgerMenu/HamburgerMenu.Options.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/HamburgerMenu/HamburgerMenu.Options.cs
@@ -21,17 +21,17 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// <summary>
         /// Identifies the <see cref="OptionsItemsSource"/> dependency property.
         /// </summary>
-        public static readonly DependencyProperty OptionsItemsSourceProperty = DependencyProperty.Register("OptionsItemsSource", typeof(object), typeof(HamburgerMenu), new PropertyMetadata(null));
+        public static readonly DependencyProperty OptionsItemsSourceProperty = DependencyProperty.Register(nameof(OptionsItemsSource), typeof(object), typeof(HamburgerMenu), new PropertyMetadata(null));
 
         /// <summary>
         /// Identifies the <see cref="OptionsItemTemplate"/> dependency property.
         /// </summary>
-        public static readonly DependencyProperty OptionsItemTemplateProperty = DependencyProperty.Register("OptionsItemTemplate", typeof(DataTemplate), typeof(HamburgerMenu), new PropertyMetadata(null));
+        public static readonly DependencyProperty OptionsItemTemplateProperty = DependencyProperty.Register(nameof(OptionsItemTemplate), typeof(DataTemplate), typeof(HamburgerMenu), new PropertyMetadata(null));
 
         /// <summary>
         /// Identifies the <see cref="OptionsVisibility"/> dependency property.
         /// </summary>
-        public static readonly DependencyProperty OptionsVisibilityProperty = DependencyProperty.Register("OptionsVisibility", typeof(Visibility), typeof(HamburgerMenu), new PropertyMetadata(Visibility.Visible));
+        public static readonly DependencyProperty OptionsVisibilityProperty = DependencyProperty.Register(nameof(OptionsVisibility), typeof(Visibility), typeof(HamburgerMenu), new PropertyMetadata(Visibility.Visible));
 
         /// <summary>
         ///     Gets or sets an object source used to generate the content of the options.

--- a/Microsoft.Toolkit.Uwp.UI.Controls/HamburgerMenu/HamburgerMenu.Properties.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/HamburgerMenu/HamburgerMenu.Properties.cs
@@ -12,42 +12,42 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// <summary>
         /// Identifies the <see cref="OpenPaneLength"/> dependency property.
         /// </summary>
-        public static readonly DependencyProperty OpenPaneLengthProperty = DependencyProperty.Register("OpenPaneLength", typeof(double), typeof(HamburgerMenu), new PropertyMetadata(240.0));
+        public static readonly DependencyProperty OpenPaneLengthProperty = DependencyProperty.Register(nameof(OpenPaneLength), typeof(double), typeof(HamburgerMenu), new PropertyMetadata(240.0));
 
         /// <summary>
         /// Identifies the <see cref="PanePlacement"/> dependency property.
         /// </summary>
-        public static readonly DependencyProperty PanePlacementProperty = DependencyProperty.Register("PanePlacement", typeof(SplitViewPanePlacement), typeof(HamburgerMenu), new PropertyMetadata(SplitViewPanePlacement.Left));
+        public static readonly DependencyProperty PanePlacementProperty = DependencyProperty.Register(nameof(PanePlacement), typeof(SplitViewPanePlacement), typeof(HamburgerMenu), new PropertyMetadata(SplitViewPanePlacement.Left));
 
         /// <summary>
         /// Identifies the <see cref="DisplayMode"/> dependency property.
         /// </summary>
-        public static readonly DependencyProperty DisplayModeProperty = DependencyProperty.Register("DisplayMode", typeof(SplitViewDisplayMode), typeof(HamburgerMenu), new PropertyMetadata(SplitViewDisplayMode.CompactInline));
+        public static readonly DependencyProperty DisplayModeProperty = DependencyProperty.Register(nameof(DisplayMode), typeof(SplitViewDisplayMode), typeof(HamburgerMenu), new PropertyMetadata(SplitViewDisplayMode.CompactInline));
 
         /// <summary>
         /// Identifies the <see cref="CompactPaneLength"/> dependency property.
         /// </summary>
-        public static readonly DependencyProperty CompactPaneLengthProperty = DependencyProperty.Register("CompactPaneLength", typeof(double), typeof(HamburgerMenu), new PropertyMetadata(48.0));
+        public static readonly DependencyProperty CompactPaneLengthProperty = DependencyProperty.Register(nameof(CompactPaneLength), typeof(double), typeof(HamburgerMenu), new PropertyMetadata(48.0));
 
         /// <summary>
         /// Identifies the <see cref="PaneBackground"/> dependency property.
         /// </summary>
-        public static readonly DependencyProperty PaneBackgroundProperty = DependencyProperty.Register("PaneBackground", typeof(Brush), typeof(HamburgerMenu), new PropertyMetadata(null));
+        public static readonly DependencyProperty PaneBackgroundProperty = DependencyProperty.Register(nameof(PaneBackground), typeof(Brush), typeof(HamburgerMenu), new PropertyMetadata(null));
 
         /// <summary>
         /// Identifies the <see cref="IsPaneOpen"/> dependency property.
         /// </summary>
-        public static readonly DependencyProperty IsPaneOpenProperty = DependencyProperty.Register("IsPaneOpen", typeof(bool), typeof(HamburgerMenu), new PropertyMetadata(false));
+        public static readonly DependencyProperty IsPaneOpenProperty = DependencyProperty.Register(nameof(IsPaneOpen), typeof(bool), typeof(HamburgerMenu), new PropertyMetadata(false));
 
         /// <summary>
         /// Identifies the <see cref="ItemsSource"/> dependency property.
         /// </summary>
-        public static readonly DependencyProperty ItemsSourceProperty = DependencyProperty.Register("ItemsSource", typeof(object), typeof(HamburgerMenu), new PropertyMetadata(null));
+        public static readonly DependencyProperty ItemsSourceProperty = DependencyProperty.Register(nameof(ItemsSource), typeof(object), typeof(HamburgerMenu), new PropertyMetadata(null));
 
         /// <summary>
         /// Identifies the <see cref="ItemTemplate"/> dependency property.
         /// </summary>
-        public static readonly DependencyProperty ItemTemplateProperty = DependencyProperty.Register("ItemTemplate", typeof(DataTemplate), typeof(HamburgerMenu), new PropertyMetadata(null));
+        public static readonly DependencyProperty ItemTemplateProperty = DependencyProperty.Register(nameof(ItemTemplate), typeof(DataTemplate), typeof(HamburgerMenu), new PropertyMetadata(null));
 
         /// <summary>
         /// Gets or sets the width of the pane when it's fully expanded.

--- a/Microsoft.Toolkit.Uwp.UI.Controls/ImageEx/ImageEx.Members.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/ImageEx/ImageEx.Members.cs
@@ -25,12 +25,12 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// <summary>
         /// Identifies the <see cref="NineGrid"/> dependency property.
         /// </summary>
-        public static readonly DependencyProperty NineGridProperty = DependencyProperty.Register("NineGrid", typeof(Thickness), typeof(ImageEx), new PropertyMetadata(default(Thickness)));
+        public static readonly DependencyProperty NineGridProperty = DependencyProperty.Register(nameof(NineGrid), typeof(Thickness), typeof(ImageEx), new PropertyMetadata(default(Thickness)));
 
         /// <summary>
         /// Identifies the <see cref="Stretch"/> dependency property.
         /// </summary>
-        public static readonly DependencyProperty StretchProperty = DependencyProperty.Register("Stretch", typeof(Stretch), typeof(ImageEx), new PropertyMetadata(Stretch.Uniform));
+        public static readonly DependencyProperty StretchProperty = DependencyProperty.Register(nameof(Stretch), typeof(Stretch), typeof(ImageEx), new PropertyMetadata(Stretch.Uniform));
 
         /// <summary>
         /// Event raised if the image failed loading.

--- a/Microsoft.Toolkit.Uwp.UI.Controls/ImageEx/ImageEx.Placeholder.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/ImageEx/ImageEx.Placeholder.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// Identifies the <see cref="PlaceholderSource"/> dependency property.
         /// </summary>
         public static readonly DependencyProperty PlaceholderSourceProperty = DependencyProperty.Register(
-            "PlaceholderSource",
+            nameof(PlaceholderSource),
             typeof(ImageSource),
             typeof(ImageEx),
             new PropertyMetadata(default(ImageSource)));
@@ -38,7 +38,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// Identifies the <see cref="PlaceholderStretch"/> dependency property.
         /// </summary>
         public static readonly DependencyProperty PlaceholderStretchProperty = DependencyProperty.Register(
-            "PlaceholderStretch",
+            nameof(PlaceholderStretch),
             typeof(Stretch),
             typeof(ImageEx),
             new PropertyMetadata(default(Stretch)));
@@ -48,7 +48,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// </summary>
         public static readonly DependencyProperty PlaceholderAnimationDurationProperty =
             DependencyProperty.Register(
-                "PlaceholderAnimationDuration",
+                nameof(PlaceholderAnimationDuration),
                 typeof(Duration),
                 typeof(ImageEx),
                 new PropertyMetadata(TimeSpan.Zero));

--- a/Microsoft.Toolkit.Uwp.UI.Controls/PullToRefreshListView/PullToRefreshListView.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/PullToRefreshListView/PullToRefreshListView.cs
@@ -36,25 +36,25 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// Identifies the <see cref="OverscrollLimit"/> property.
         /// </summary>
         public static readonly DependencyProperty OverscrollLimitProperty =
-            DependencyProperty.Register("OverscrollLimit", typeof(double), typeof(PullToRefreshListView), new PropertyMetadata(0.4, OverscrollLimitPropertyChanged));
+            DependencyProperty.Register(nameof(OverscrollLimit), typeof(double), typeof(PullToRefreshListView), new PropertyMetadata(0.4, OverscrollLimitPropertyChanged));
 
         /// <summary>
         /// Identifies the <see cref="PullThreshold"/> property.
         /// </summary>
         public static readonly DependencyProperty PullThresholdProperty =
-            DependencyProperty.Register("PullThreshold", typeof(double), typeof(PullToRefreshListView), new PropertyMetadata(100.0));
+            DependencyProperty.Register(nameof(PullThreshold), typeof(double), typeof(PullToRefreshListView), new PropertyMetadata(100.0));
 
         /// <summary>
         /// Identifies the <see cref="RefreshCommand"/> property.
         /// </summary>
         public static readonly DependencyProperty RefreshCommandProperty =
-            DependencyProperty.Register("RefreshCommand", typeof(ICommand), typeof(PullToRefreshListView), new PropertyMetadata(null));
+            DependencyProperty.Register(nameof(RefreshCommand), typeof(ICommand), typeof(PullToRefreshListView), new PropertyMetadata(null));
 
         /// <summary>
         /// Identifies the <see cref="RefreshIndicatorContent"/> property.
         /// </summary>
         public static readonly DependencyProperty RefreshIndicatorContentProperty =
-            DependencyProperty.Register("RefreshIndicatorContent", typeof(object), typeof(PullToRefreshListView), new PropertyMetadata(null));
+            DependencyProperty.Register(nameof(RefreshIndicatorContent), typeof(object), typeof(PullToRefreshListView), new PropertyMetadata(null));
 
         private const string PARTROOT = "Root";
         private const string PARTSCROLLER = "ScrollViewer";

--- a/Microsoft.Toolkit.Uwp.UI.Controls/RangeSelector/RangeSelector.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/RangeSelector/RangeSelector.cs
@@ -35,22 +35,22 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// <summary>
         /// Identifies the Minimum dependency property.
         /// </summary>
-        public static readonly DependencyProperty MinimumProperty = DependencyProperty.Register("Minimum", typeof(double), typeof(RangeSelector), new PropertyMetadata(0.0, MinimumChangedCallback));
+        public static readonly DependencyProperty MinimumProperty = DependencyProperty.Register(nameof(Minimum), typeof(double), typeof(RangeSelector), new PropertyMetadata(0.0, MinimumChangedCallback));
 
         /// <summary>
         /// Identifies the Maximum dependency property.
         /// </summary>
-        public static readonly DependencyProperty MaximumProperty = DependencyProperty.Register("Maximum", typeof(double), typeof(RangeSelector), new PropertyMetadata(1.0, MaximumChangedCallback));
+        public static readonly DependencyProperty MaximumProperty = DependencyProperty.Register(nameof(Maximum), typeof(double), typeof(RangeSelector), new PropertyMetadata(1.0, MaximumChangedCallback));
 
         /// <summary>
         /// Identifies the RangeMin dependency property.
         /// </summary>
-        public static readonly DependencyProperty RangeMinProperty = DependencyProperty.Register("RangeMin", typeof(double), typeof(RangeSelector), new PropertyMetadata(0.0, RangeMinChangedCallback));
+        public static readonly DependencyProperty RangeMinProperty = DependencyProperty.Register(nameof(RangeMin), typeof(double), typeof(RangeSelector), new PropertyMetadata(0.0, RangeMinChangedCallback));
 
         /// <summary>
         /// Identifies the RangeMax dependency property.
         /// </summary>
-        public static readonly DependencyProperty RangeMaxProperty = DependencyProperty.Register("RangeMax", typeof(double), typeof(RangeSelector), new PropertyMetadata(1.0, RangeMaxChangedCallback));
+        public static readonly DependencyProperty RangeMaxProperty = DependencyProperty.Register(nameof(RangeMax), typeof(double), typeof(RangeSelector), new PropertyMetadata(1.0, RangeMaxChangedCallback));
 
         private const double Epsilon = 0.01;
 

--- a/Microsoft.Toolkit.Uwp.UI.Controls/SlidableListItem/SlidableListItem.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/SlidableListItem/SlidableListItem.cs
@@ -34,73 +34,73 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// Indetifies the <see cref="ActivationWidth"/> property
         /// </summary>
         public static readonly DependencyProperty ActivationWidthProperty =
-            DependencyProperty.Register("ActivationWidth", typeof(double), typeof(SlidableListItem), new PropertyMetadata(80));
+            DependencyProperty.Register(nameof(ActivationWidth), typeof(double), typeof(SlidableListItem), new PropertyMetadata(80));
 
         /// <summary>
         /// Indeifies the <see cref="LeftIcon"/> property
         /// </summary>
         public static readonly DependencyProperty LeftIconProperty =
-            DependencyProperty.Register("LeftIcon", typeof(Symbol), typeof(SlidableListItem), new PropertyMetadata(Symbol.Favorite));
+            DependencyProperty.Register(nameof(LeftIcon), typeof(Symbol), typeof(SlidableListItem), new PropertyMetadata(Symbol.Favorite));
 
         /// <summary>
         /// Indetifies the <see cref="RightIcon"/> property
         /// </summary>
         public static readonly DependencyProperty RightIconProperty =
-            DependencyProperty.Register("RightIcon", typeof(Symbol), typeof(SlidableListItem), new PropertyMetadata(Symbol.Delete));
+            DependencyProperty.Register(nameof(RightIcon), typeof(Symbol), typeof(SlidableListItem), new PropertyMetadata(Symbol.Delete));
 
         /// <summary>
         /// Indetifies the <see cref="LeftLabel"/> property
         /// </summary>
         public static readonly DependencyProperty LeftLabelProperty =
-            DependencyProperty.Register("LeftLabel", typeof(string), typeof(SlidableListItem), new PropertyMetadata(string.Empty));
+            DependencyProperty.Register(nameof(LeftLabel), typeof(string), typeof(SlidableListItem), new PropertyMetadata(string.Empty));
 
         /// <summary>
         /// Indetifies the <see cref="RightLabel"/> property
         /// </summary>
         public static readonly DependencyProperty RightLabelProperty =
-            DependencyProperty.Register("RightLabel", typeof(string), typeof(SlidableListItem), new PropertyMetadata(string.Empty));
+            DependencyProperty.Register(nameof(RightLabel), typeof(string), typeof(SlidableListItem), new PropertyMetadata(string.Empty));
 
         /// <summary>
         /// Indetifies the <see cref="LeftForeground"/> property
         /// </summary>
         public static readonly DependencyProperty LeftForegroundProperty =
-            DependencyProperty.Register("LeftForeground", typeof(Brush), typeof(SlidableListItem), new PropertyMetadata(new SolidColorBrush(Colors.White)));
+            DependencyProperty.Register(nameof(LeftForeground), typeof(Brush), typeof(SlidableListItem), new PropertyMetadata(new SolidColorBrush(Colors.White)));
 
         /// <summary>
         /// Indetifies the <see cref="RightForeground"/> property
         /// </summary>
         public static readonly DependencyProperty RightForegroundProperty =
-            DependencyProperty.Register("RightForeground", typeof(Brush), typeof(SlidableListItem), new PropertyMetadata(new SolidColorBrush(Colors.White)));
+            DependencyProperty.Register(nameof(RightForeground), typeof(Brush), typeof(SlidableListItem), new PropertyMetadata(new SolidColorBrush(Colors.White)));
 
         /// <summary>
         /// Indetifies the <see cref="LeftBackground"/> property
         /// </summary>
         public static readonly DependencyProperty LeftBackgroundProperty =
-            DependencyProperty.Register("LeftBackground", typeof(Brush), typeof(SlidableListItem), new PropertyMetadata(new SolidColorBrush(Colors.LightGray)));
+            DependencyProperty.Register(nameof(LeftBackground), typeof(Brush), typeof(SlidableListItem), new PropertyMetadata(new SolidColorBrush(Colors.LightGray)));
 
         /// <summary>
         /// Identifies the <see cref="RightBackground"/> property
         /// </summary>
         public static readonly DependencyProperty RightBackgroundProperty =
-            DependencyProperty.Register("RightBackground", typeof(Brush), typeof(SlidableListItem), new PropertyMetadata(new SolidColorBrush(Colors.DarkGray)));
+            DependencyProperty.Register(nameof(RightBackground), typeof(Brush), typeof(SlidableListItem), new PropertyMetadata(new SolidColorBrush(Colors.DarkGray)));
 
         /// <summary>
         /// Identifies the <see cref="MouseSlidingEnabled"/> property
         /// </summary>
         public static readonly DependencyProperty MouseSlidingEnabledProperty =
-            DependencyProperty.Register("MouseSlidingEnabled", typeof(bool), typeof(SlidableListItem), new PropertyMetadata(false));
+            DependencyProperty.Register(nameof(MouseSlidingEnabled), typeof(bool), typeof(SlidableListItem), new PropertyMetadata(false));
 
         /// <summary>
         /// Identifies the <see cref="LeftCommand"/> property
         /// </summary>
         public static readonly DependencyProperty LeftCommandProperty =
-            DependencyProperty.Register("LeftCommand", typeof(ICommand), typeof(SlidableListItem), new PropertyMetadata(null));
+            DependencyProperty.Register(nameof(LeftCommand), typeof(ICommand), typeof(SlidableListItem), new PropertyMetadata(null));
 
         /// <summary>
         /// Identifies the <see cref="RightCommand"/> property
         /// </summary>
         public static readonly DependencyProperty RightCommandProperty =
-            DependencyProperty.Register("RightCommand", typeof(ICommand), typeof(SlidableListItem), new PropertyMetadata(null));
+            DependencyProperty.Register(nameof(RightCommand), typeof(ICommand), typeof(SlidableListItem), new PropertyMetadata(null));
 
         private const string PartContentGrid = "ContentGrid";
         private const string PartCommandContainer = "CommandContainer";


### PR DESCRIPTION
Since C#6 has this amazing feature that prevent future hidden bugs, let's use it. This commit replaces hard-coded property strings by compile-time strings.