### PR TITLE
HeaderedTextBlock: if Text is empty, hide its TextBlock

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/HeaderedTextBlock/HeaderedTextBlock.Properties.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/HeaderedTextBlock/HeaderedTextBlock.Properties.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             nameof(Text),
             typeof(string),
             typeof(HeaderedTextBlock),
-            new PropertyMetadata(null, (d, e) => { ((HeaderedTextBlock)d).UpdateText(); }));
+            new PropertyMetadata(null));
 
         /// <summary>
         /// Defines the <see cref="Orientation"/> dependency property.

--- a/Microsoft.Toolkit.Uwp.UI.Controls/HeaderedTextBlock/HeaderedTextBlock.Properties.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/HeaderedTextBlock/HeaderedTextBlock.Properties.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             nameof(Header),
             typeof(string),
             typeof(HeaderedTextBlock),
-            new PropertyMetadata(null, (d, e) => { ((HeaderedTextBlock)d).UpdateHeader(); }));
+            new PropertyMetadata(null, (d, e) => { ((HeaderedTextBlock)d).UpdateVisibility(); }));
 
         /// <summary>
         /// Defines the <see cref="Text"/> dependency property.
@@ -42,7 +42,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             nameof(Text),
             typeof(string),
             typeof(HeaderedTextBlock),
-            new PropertyMetadata(null));
+            new PropertyMetadata(null, (d, e) => { ((HeaderedTextBlock)d).UpdateVisibility(); }));
 
         /// <summary>
         /// Defines the <see cref="Orientation"/> dependency property.

--- a/Microsoft.Toolkit.Uwp.UI.Controls/HeaderedTextBlock/HeaderedTextBlock.Properties.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/HeaderedTextBlock/HeaderedTextBlock.Properties.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             nameof(Text),
             typeof(string),
             typeof(HeaderedTextBlock),
-            new PropertyMetadata(null));
+            new PropertyMetadata(null, (d, e) => { ((HeaderedTextBlock)d).UpdateText(); }));
 
         /// <summary>
         /// Defines the <see cref="Orientation"/> dependency property.

--- a/Microsoft.Toolkit.Uwp.UI.Controls/HeaderedTextBlock/HeaderedTextBlock.Properties.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/HeaderedTextBlock/HeaderedTextBlock.Properties.cs
@@ -54,6 +54,16 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             new PropertyMetadata(Orientation.Vertical, (d, e) => { ((HeaderedTextBlock)d).UpdateForOrientation((Orientation)e.NewValue); }));
 
         /// <summary>
+        /// Defines the <see cref="HideTextIfEmpty"/> dependency property.
+        /// </summary>
+        public static readonly DependencyProperty HideTextIfEmptyProperty = DependencyProperty.Register(
+            nameof(HideTextIfEmpty),
+            typeof(bool),
+            typeof(HeaderedTextBlock),
+            new PropertyMetadata(false, (d, e) => { ((HeaderedTextBlock)d).UpdateVisibility(); }));
+
+
+        /// <summary>
         /// Gets or sets the header style.
         /// </summary>
         public Style HeaderStyle
@@ -132,5 +142,22 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 SetValue(OrientationProperty, value);
             }
         }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the Text TextBlock is hidden if its value is empty
+        /// </summary>
+        public bool HideTextIfEmpty
+        {
+            get
+            {
+                return (bool)GetValue(HideTextIfEmptyProperty);
+            }
+
+            set
+            {
+                SetValue(HideTextIfEmptyProperty, value);
+            }
+        }
+
     }
 }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/HeaderedTextBlock/HeaderedTextBlock.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/HeaderedTextBlock/HeaderedTextBlock.cs
@@ -31,14 +31,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             UpdateVisibility();
         }
 
-        private void UpdateHeader()
-        {
-            if (_headerContent != null)
-            {
-                UpdateVisibility();
-            }
-        }
-
         private void UpdateVisibility()
         {
             if (_headerContent != null)

--- a/Microsoft.Toolkit.Uwp.UI.Controls/HeaderedTextBlock/HeaderedTextBlock.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/HeaderedTextBlock/HeaderedTextBlock.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
             if (_textContent != null)
             {
-                _textContent.Visibility = string.IsNullOrWhiteSpace(_textContent.Text)
+                _textContent.Visibility = string.IsNullOrWhiteSpace(_textContent.Text) && HideTextIfEmpty
                                                     ? Visibility.Collapsed
                                                     : Visibility.Visible;
             }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/HeaderedTextBlock/HeaderedTextBlock.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/HeaderedTextBlock/HeaderedTextBlock.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
     public partial class HeaderedTextBlock : Control
     {
         private TextBlock _headerContent;
+        private TextBlock _textContent;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="HeaderedTextBlock"/> class.
@@ -27,6 +28,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             base.OnApplyTemplate();
 
             _headerContent = GetTemplateChild("HeaderContent") as TextBlock;
+            _textContent = GetTemplateChild("TextContent") as TextBlock;
 
             UpdateVisibility();
         }
@@ -38,6 +40,13 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 _headerContent.Visibility = string.IsNullOrWhiteSpace(_headerContent.Text)
                                                      ? Visibility.Collapsed
                                                      : Visibility.Visible;
+            }
+
+            if (_textContent != null)
+            {
+                _textContent.Visibility = string.IsNullOrWhiteSpace(_textContent.Text)
+                                                    ? Visibility.Collapsed
+                                                    : Visibility.Visible;
             }
         }
 

--- a/Microsoft.Toolkit.Uwp.UI.Controls/HeaderedTextBlock/HeaderedTextBlock.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/HeaderedTextBlock/HeaderedTextBlock.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
     public partial class HeaderedTextBlock : Control
     {
         private TextBlock _headerContent;
+        private TextBlock _textContent;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="HeaderedTextBlock"/> class.
@@ -27,6 +28,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             base.OnApplyTemplate();
 
             _headerContent = GetTemplateChild("HeaderContent") as TextBlock;
+            _textContent = GetTemplateChild("TextContent") as TextBlock;
 
             UpdateVisibility();
         }
@@ -39,6 +41,14 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             }
         }
 
+        private void UpdateText()
+        {
+            if (_textContent != null)
+            {
+                UpdateVisibility();
+            }
+        }
+
         private void UpdateVisibility()
         {
             if (_headerContent != null)
@@ -46,6 +56,13 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 _headerContent.Visibility = string.IsNullOrWhiteSpace(_headerContent.Text)
                                                      ? Visibility.Collapsed
                                                      : Visibility.Visible;
+            }
+
+            if (_textContent != null)
+            {
+                _textContent.Visibility = string.IsNullOrWhiteSpace(_textContent.Text)
+                                                    ? Visibility.Collapsed
+                                                    : Visibility.Visible;
             }
         }
 

--- a/Microsoft.Toolkit.Uwp.UI.Controls/HeaderedTextBlock/HeaderedTextBlock.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/HeaderedTextBlock/HeaderedTextBlock.cs
@@ -10,7 +10,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
     public partial class HeaderedTextBlock : Control
     {
         private TextBlock _headerContent;
-        private TextBlock _textContent;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="HeaderedTextBlock"/> class.
@@ -28,7 +27,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             base.OnApplyTemplate();
 
             _headerContent = GetTemplateChild("HeaderContent") as TextBlock;
-            _textContent = GetTemplateChild("TextContent") as TextBlock;
 
             UpdateVisibility();
         }
@@ -41,14 +39,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             }
         }
 
-        private void UpdateText()
-        {
-            if (_textContent != null)
-            {
-                UpdateVisibility();
-            }
-        }
-
         private void UpdateVisibility()
         {
             if (_headerContent != null)
@@ -56,13 +46,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 _headerContent.Visibility = string.IsNullOrWhiteSpace(_headerContent.Text)
                                                      ? Visibility.Collapsed
                                                      : Visibility.Visible;
-            }
-
-            if (_textContent != null)
-            {
-                _textContent.Visibility = string.IsNullOrWhiteSpace(_textContent.Text)
-                                                    ? Visibility.Collapsed
-                                                    : Visibility.Visible;
             }
         }
 


### PR DESCRIPTION
Rationale: we don't always have the Text property set (I'm thinking of scenarios
involving incomplete translation strings)