### PR TITLE
Cleaning up warnings

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/BladeControl/BladePage.xaml
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/BladeControl/BladePage.xaml
@@ -38,7 +38,7 @@
                 </controls:Blade>
 
                 <controls:Blade Title="Default blade"
-                                BladeID="BladeTest1"
+                                BladeId="BladeTest1"
                                 IsOpen="False">
                     <controls:Blade.Element>
                         <TextBlock HorizontalAlignment="Center"
@@ -49,7 +49,7 @@
                 </controls:Blade>
 
                 <controls:Blade Title="Custom title bar"
-                                BladeID="BladeTest2"
+                                BladeId="BladeTest2"
                                 IsOpen="False"
                                 TitleBarBackground="CornflowerBlue"
                                 TitleBarForeground="White">
@@ -62,7 +62,7 @@
                 </controls:Blade>
 
                 <controls:Blade Title="Custom close button color"
-                                BladeID="BladeTest3"
+                                BladeId="BladeTest3"
                                 CloseButtonBackground="Black"
                                 CloseButtonForeground="White"
                                 IsOpen="False">

--- a/Microsoft.Toolkit.Uwp.UI.Controls/BladeControl/Blade.Properties.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/BladeControl/Blade.Properties.cs
@@ -40,9 +40,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         public static readonly DependencyProperty IsOpenProperty = DependencyProperty.Register(nameof(IsOpen), typeof(bool), typeof(Blade), new PropertyMetadata(default(bool), IsOpenChangedCallback));
 
         /// <summary>
-        /// Identifies the <see cref="BladeID"/> dependency property.
+        /// Identifies the <see cref="BladeId"/> dependency property.
         /// </summary>
-        public static readonly DependencyProperty BladeIDProperty = DependencyProperty.Register(nameof(BladeID), typeof(string), typeof(Blade), new PropertyMetadata(default(string)));
+        public static readonly DependencyProperty BladeIdProperty = DependencyProperty.Register(nameof(BladeId), typeof(string), typeof(Blade), new PropertyMetadata(default(string)));
 
         /// <summary>
         /// Identifies the <see cref="TitleBarForeground"/> dependency property
@@ -59,7 +59,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// </summary>
         public Brush CloseButtonForeground
         {
-            get { return (Brush) GetValue(CloseButtonForegroundProperty); }
+            get { return (Brush)GetValue(CloseButtonForegroundProperty); }
             set { SetValue(CloseButtonForegroundProperty, value); }
         }
 
@@ -68,7 +68,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// </summary>
         public Brush TitleBarForeground
         {
-            get { return (Brush) GetValue(TitleBarForegroundProperty); }
+            get { return (Brush)GetValue(TitleBarForegroundProperty); }
             set { SetValue(TitleBarForegroundProperty, value); }
         }
 
@@ -127,12 +127,12 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         }
 
         /// <summary>
-        /// Gets or sets the Blade ID, this needs to be set in order to use the attached property to toggle a blade
+        /// Gets or sets the Blade Id, this needs to be set in order to use the attached property to toggle a blade
         /// </summary>
-        public string BladeID
+        public string BladeId
         {
-            get { return (string)GetValue(BladeIDProperty); }
-            set { SetValue(BladeIDProperty, value); }
+            get { return (string)GetValue(BladeIdProperty); }
+            set { SetValue(BladeIdProperty, value); }
         }
 
         private static void IsOpenChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)

--- a/Microsoft.Toolkit.Uwp.UI.Controls/BladeControl/BladeControl.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/BladeControl/BladeControl.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             Button pressedButton = sender as Button;
             string bladeName = GetToggleBlade(pressedButton);
             BladeControl container = pressedButton.FindVisualAscendant<BladeControl>();
-            var blade = container.Blades.FirstOrDefault(_ => _.BladeID == bladeName);
+            var blade = container.Blades.FirstOrDefault(_ => _.BladeId == bladeName);
 
             if (blade == null)
             {

--- a/Microsoft.Toolkit.Uwp.UI.Controls/HeaderedTextBlock/HeaderedTextBlock.Properties.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/HeaderedTextBlock/HeaderedTextBlock.Properties.cs
@@ -62,7 +62,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             typeof(HeaderedTextBlock),
             new PropertyMetadata(false, (d, e) => { ((HeaderedTextBlock)d).UpdateVisibility(); }));
 
-
         /// <summary>
         /// Gets or sets the header style.
         /// </summary>
@@ -158,6 +157,5 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 SetValue(HideTextIfEmptyProperty, value);
             }
         }
-
     }
 }


### PR DESCRIPTION
Noticed BladeID naming in the PR (but after merge), while cleaning up I noticed a few more code warnings that got through the PRs