### PR TITLE
Consistent naming for const variables

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/PullToRefreshListView/PullToRefreshListView.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/PullToRefreshListView/PullToRefreshListView.cs
@@ -23,13 +23,13 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
     /// <summary>
     /// Extension of ListView that allows "Pull To Refresh" on touch devices
     /// </summary>
-    [TemplatePart(Name = PARTROOT, Type = typeof(Border))]
-    [TemplatePart(Name = PARTSCROLLER, Type = typeof(ScrollViewer))]
-    [TemplatePart(Name = PARTCONTENTTRANSFORM, Type = typeof(CompositeTransform))]
-    [TemplatePart(Name = PARTSCROLLERCONTENT, Type = typeof(Grid))]
-    [TemplatePart(Name = PARTREFRESHINDICATORBORDER, Type = typeof(Border))]
-    [TemplatePart(Name = PARTINDICATORTRANSFORM, Type = typeof(CompositeTransform))]
-    [TemplatePart(Name = PARTDEFAULTINDICATORCONTENT, Type = typeof(TextBlock))]
+    [TemplatePart(Name = PartRoot, Type = typeof(Border))]
+    [TemplatePart(Name = PartScroller, Type = typeof(ScrollViewer))]
+    [TemplatePart(Name = PartContentTransform, Type = typeof(CompositeTransform))]
+    [TemplatePart(Name = PartScrollerContent, Type = typeof(Grid))]
+    [TemplatePart(Name = PartRefreshIndicatorBorder, Type = typeof(Border))]
+    [TemplatePart(Name = PartIndicatorTransform, Type = typeof(CompositeTransform))]
+    [TemplatePart(Name = PartDefaultIndicatorContent, Type = typeof(TextBlock))]
     public class PullToRefreshListView : ListView
     {
         /// <summary>
@@ -56,13 +56,13 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         public static readonly DependencyProperty RefreshIndicatorContentProperty =
             DependencyProperty.Register(nameof(RefreshIndicatorContent), typeof(object), typeof(PullToRefreshListView), new PropertyMetadata(null));
 
-        private const string PARTROOT = "Root";
-        private const string PARTSCROLLER = "ScrollViewer";
-        private const string PARTCONTENTTRANSFORM = "ContentTransform";
-        private const string PARTSCROLLERCONTENT = "ScrollerContent";
-        private const string PARTREFRESHINDICATORBORDER = "RefreshIndicator";
-        private const string PARTINDICATORTRANSFORM = "RefreshIndicatorTransform";
-        private const string PARTDEFAULTINDICATORCONTENT = "DefaultIndicatorContent";
+        private const string PartRoot = "Root";
+        private const string PartScroller = "ScrollViewer";
+        private const string PartContentTransform = "ContentTransform";
+        private const string PartScrollerContent = "ScrollerContent";
+        private const string PartRefreshIndicatorBorder = "RefreshIndicator";
+        private const string PartIndicatorTransform = "RefreshIndicatorTransform";
+        private const string PartDefaultIndicatorContent = "DefaultIndicatorContent";
 
         private Border _root;
         private Border _refreshIndicatorBorder;
@@ -126,13 +126,13 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 _refreshIndicatorBorder.SizeChanged -= RefreshIndicatorBorder_SizeChanged;
             }
 
-            _root = GetTemplateChild(PARTROOT) as Border;
-            _scroller = GetTemplateChild(PARTSCROLLER) as ScrollViewer;
-            _contentTransform = GetTemplateChild(PARTCONTENTTRANSFORM) as CompositeTransform;
-            _scrollerContent = GetTemplateChild(PARTSCROLLERCONTENT) as Grid;
-            _refreshIndicatorBorder = GetTemplateChild(PARTREFRESHINDICATORBORDER) as Border;
-            _refreshIndicatorTransform = GetTemplateChild(PARTINDICATORTRANSFORM) as CompositeTransform;
-            _defaultIndicatorContent = GetTemplateChild(PARTDEFAULTINDICATORCONTENT) as TextBlock;
+            _root = GetTemplateChild(PartRoot) as Border;
+            _scroller = GetTemplateChild(PartScroller) as ScrollViewer;
+            _contentTransform = GetTemplateChild(PartContentTransform) as CompositeTransform;
+            _scrollerContent = GetTemplateChild(PartScrollerContent) as Grid;
+            _refreshIndicatorBorder = GetTemplateChild(PartRefreshIndicatorBorder) as Border;
+            _refreshIndicatorTransform = GetTemplateChild(PartIndicatorTransform) as CompositeTransform;
+            _defaultIndicatorContent = GetTemplateChild(PartDefaultIndicatorContent) as TextBlock;
 
             if (_root != null &&
                 _scroller != null &&

--- a/Microsoft.Toolkit.Uwp.UI.Controls/RotatorTile/RotatorTile.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/RotatorTile/RotatorTile.cs
@@ -24,18 +24,18 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
     /// An items control that presents enumerable content similar to the live tiles on the
     /// start menu.
     /// </summary>
-    [TemplatePart(Name = SCROLLERPARTNAME, Type = typeof(FrameworkElement))]
-    [TemplatePart(Name = CURRENTPARTNAME, Type = typeof(FrameworkElement))]
-    [TemplatePart(Name = NEXTPARTNAME, Type = typeof(FrameworkElement))]
-    [TemplatePart(Name = TRANSLATEPARTNAME, Type = typeof(TranslateTransform))]
-    [TemplatePart(Name = STACKPARTNAME, Type = typeof(StackPanel))]
+    [TemplatePart(Name = ScrollerPartName, Type = typeof(FrameworkElement))]
+    [TemplatePart(Name = CurrentPartName, Type = typeof(FrameworkElement))]
+    [TemplatePart(Name = NextPartName, Type = typeof(FrameworkElement))]
+    [TemplatePart(Name = TranslatePartName, Type = typeof(TranslateTransform))]
+    [TemplatePart(Name = StackPartName, Type = typeof(StackPanel))]
     public sealed class RotatorTile : Control
     {
-        private const string SCROLLERPARTNAME = "Scroller";
-        private const string CURRENTPARTNAME = "Current";
-        private const string NEXTPARTNAME = "Next";
-        private const string TRANSLATEPARTNAME = "Translate";
-        private const string STACKPARTNAME = "Stack";
+        private const string ScrollerPartName = "Scroller";
+        private const string CurrentPartName = "Current";
+        private const string NextPartName = "Next";
+        private const string TranslatePartName = "Translate";
+        private const string StackPartName = "Stack";
 
         private static readonly Random _randomizer = new Random(); // randomizer for randomizing when a tile swaps content
         private int _currentIndex = -1; // current index in the items displayed
@@ -87,11 +87,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// <inheritdoc/>
         protected override void OnApplyTemplate()
         {
-            _scroller = GetTemplateChild(SCROLLERPARTNAME) as FrameworkElement;
-            _currentElement = GetTemplateChild(CURRENTPARTNAME) as FrameworkElement;
-            _nextElement = GetTemplateChild(NEXTPARTNAME) as FrameworkElement;
-            _translate = GetTemplateChild(TRANSLATEPARTNAME) as TranslateTransform;
-            _stackPanel = GetTemplateChild(STACKPARTNAME) as StackPanel;
+            _scroller = GetTemplateChild(ScrollerPartName) as FrameworkElement;
+            _currentElement = GetTemplateChild(CurrentPartName) as FrameworkElement;
+            _nextElement = GetTemplateChild(NextPartName) as FrameworkElement;
+            _translate = GetTemplateChild(TranslatePartName) as TranslateTransform;
+            _stackPanel = GetTemplateChild(StackPartName) as StackPanel;
             if (_stackPanel != null)
             {
                 _stackPanel.Orientation = Direction == RotateDirection.Up ? Orientation.Vertical : Orientation.Horizontal;

--- a/UnitTests.Notifications.Shared/TestMail.cs
+++ b/UnitTests.Notifications.Shared/TestMail.cs
@@ -11,13 +11,13 @@ namespace UnitTests.Notifications
     [TestClass]
     public class TestMail
     {
-        private const string FIRST_FROM = "Jennifer Parker";
-        private const string FIRST_SUBJECT = "Photos from our trip";
-        private const string FIRST_BODY = "Check out these awesome photos I took while in New Zealand!";
+        private const string FirstFrom = "Jennifer Parker";
+        private const string FirstSubject = "Photos from our trip";
+        private const string FirstBody = "Check out these awesome photos I took while in New Zealand!";
 
-        private const string SECOND_FROM = "Steve Bosniak";
-        private const string SECOND_SUBJECT = "Build 2015 Dinner";
-        private const string SECOND_BODY = "Want to go out for dinner after Build tonight?";
+        private const string SecondFrom = "Steve Bosniak";
+        private const string SecondSubject = "Build 2015 Dinner";
+        private const string SecondBody = "Want to go out for dinner after Build tonight?";
 
         [TestCategory("EndToEnd/Mail")]
         [TestMethod]
@@ -107,7 +107,7 @@ namespace UnitTests.Notifications
 
         private static string GenerateXmlGroups(bool makeLarge)
         {
-            return GenerateXmlGroup(FIRST_FROM, FIRST_SUBJECT, FIRST_BODY, makeLarge) + "<text />" + GenerateXmlGroup(SECOND_FROM, SECOND_SUBJECT, SECOND_BODY, makeLarge);
+            return GenerateXmlGroup(FirstFrom, FirstSubject, FirstBody, makeLarge) + "<text />" + GenerateXmlGroup(SecondFrom, SecondSubject, SecondBody, makeLarge);
         }
 
         private static string GenerateXmlGroup(string from, string subject, string body, bool makeLarge)
@@ -131,12 +131,12 @@ namespace UnitTests.Notifications
 
         private static AdaptiveGroup GenerateFirstMessage(bool makeLarge)
         {
-            return GenerateMessage(FIRST_FROM, FIRST_SUBJECT, FIRST_BODY, makeLarge);
+            return GenerateMessage(FirstFrom, FirstSubject, FirstBody, makeLarge);
         }
 
         private static AdaptiveGroup GenerateSecondMessage(bool makeLarge)
         {
-            return GenerateMessage(SECOND_FROM, SECOND_SUBJECT, SECOND_BODY, makeLarge);
+            return GenerateMessage(SecondFrom, SecondSubject, SecondBody, makeLarge);
         }
 
         private static AdaptiveGroup GenerateMessage(string from, string subject, string body, bool makeLarge)

--- a/UnitTests.Notifications.Shared/TestWeather.cs
+++ b/UnitTests.Notifications.Shared/TestWeather.cs
@@ -44,7 +44,6 @@ namespace UnitTests.Notifications
                 }
             };
 
-
             TileBindingContentAdaptive mediumContent = new TileBindingContentAdaptive()
             {
                 BackgroundImage = new TileBackgroundImage() { Source = backgroundImage, HintOverlay = overlay },
@@ -55,14 +54,11 @@ namespace UnitTests.Notifications
                         Children =
                         {
                             GenerateMediumSubgroup("Mon", ImageMostlyCloudy, 63, 42),
-
                             GenerateMediumSubgroup("Tue", ImageCloudy, 57, 38)
                         }
                     }
                 }
             };
-
-
 
             TileBindingContentAdaptive wideContent = new TileBindingContentAdaptive()
             {
@@ -74,21 +70,14 @@ namespace UnitTests.Notifications
                         Children =
                         {
                             GenerateWideSubgroup("Mon", ImageMostlyCloudy, 63, 42),
-
                             GenerateWideSubgroup("Tue", ImageCloudy, 57, 38),
-
                             GenerateWideSubgroup("Wed", ImageSunny, 59, 43),
-
                             GenerateWideSubgroup("Thu", ImageSunny, 62, 42),
-
                             GenerateWideSubgroup("Fri", ImageSunny, 71, 66)
                         }
                     }
                 }
             };
-
-
-
 
             TileBindingContentAdaptive largeContent = new TileBindingContentAdaptive()
             {
@@ -147,19 +136,13 @@ namespace UnitTests.Notifications
                         Children =
                         {
                             GenerateLargeSubgroup("Tue", ImageCloudy, 57, 38),
-
                             GenerateLargeSubgroup("Wed", ImageSunny, 59, 43),
-
                             GenerateLargeSubgroup("Thu", ImageSunny, 62, 42),
-
                             GenerateLargeSubgroup("Fri", ImageSunny, 71, 66)
                         }
                     }
                 }
             };
-
-
-
 
             TileContent content = new TileContent()
             {
@@ -200,7 +183,6 @@ namespace UnitTests.Notifications
 
             expectedPayload += "</group></binding>";
 
-
             // Wide tile
             expectedPayload += @"<binding template=""TileWide"" branding=""nameAndLogo"">";
             expectedPayload += GenerateStringBackgroundImage();
@@ -214,8 +196,6 @@ namespace UnitTests.Notifications
             expectedPayload += GenerateStringWideSubgroup("Fri", ImageSunny, 71, 66);
 
             expectedPayload += "</group></binding>";
-
-
 
             // Large tile
             expectedPayload += @"<binding template=""TileLarge"" branding=""nameAndLogo"">";
@@ -233,7 +213,6 @@ namespace UnitTests.Notifications
 
             expectedPayload += "</group></binding></visual></tile>";
             
-
             AssertHelper.AssertTile(expectedPayload, content);
         }
 

--- a/UnitTests.Notifications.Shared/TestWeather.cs
+++ b/UnitTests.Notifications.Shared/TestWeather.cs
@@ -4,25 +4,22 @@ using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 #endif
 using Microsoft.Toolkit.Uwp.Notifications;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace UnitTests.Notifications
 {
     [TestClass]
     public class TestWeather
     {
-        private const string IMAGE_MOSTLY_CLOUDY = "Assets\\Tiles\\Mostly Cloudy.png";
-        private const string IMAGE_SUNNY = "Assets\\Tiles\\Sunny.png";
-        private const string IMAGE_CLOUDY = "Assets\\Tiles\\Cloudy.png";
+        private const string ImageMostlyCloudy = "Assets\\Tiles\\Mostly Cloudy.png";
+        private const string ImageSunny = "Assets\\Tiles\\Sunny.png";
+        private const string ImageCloudy = "Assets\\Tiles\\Cloudy.png";
 
-        private const string BACKGROUND_IMAGE_MOSTLY_CLOUDY = "Assets\\Tiles\\Mostly Cloudy-Background.jpg";
+        private const string BackgroundImageMostlyCloudy = "Assets\\Tiles\\Mostly Cloudy-Background.jpg";
 
         [TestMethod]
         public void TestWeatherTile()
         {
-            var backgroundImage = BACKGROUND_IMAGE_MOSTLY_CLOUDY;
+            var backgroundImage = BackgroundImageMostlyCloudy;
             int overlay = 30;
 
             TileBindingContentAdaptive smallContent = new TileBindingContentAdaptive()
@@ -57,9 +54,9 @@ namespace UnitTests.Notifications
                     {
                         Children =
                         {
-                            GenerateMediumSubgroup("Mon", IMAGE_MOSTLY_CLOUDY, 63, 42),
+                            GenerateMediumSubgroup("Mon", ImageMostlyCloudy, 63, 42),
 
-                            GenerateMediumSubgroup("Tue", IMAGE_CLOUDY, 57, 38)
+                            GenerateMediumSubgroup("Tue", ImageCloudy, 57, 38)
                         }
                     }
                 }
@@ -76,15 +73,15 @@ namespace UnitTests.Notifications
                     {
                         Children =
                         {
-                            GenerateWideSubgroup("Mon", IMAGE_MOSTLY_CLOUDY, 63, 42),
+                            GenerateWideSubgroup("Mon", ImageMostlyCloudy, 63, 42),
 
-                            GenerateWideSubgroup("Tue", IMAGE_CLOUDY, 57, 38),
+                            GenerateWideSubgroup("Tue", ImageCloudy, 57, 38),
 
-                            GenerateWideSubgroup("Wed", IMAGE_SUNNY, 59, 43),
+                            GenerateWideSubgroup("Wed", ImageSunny, 59, 43),
 
-                            GenerateWideSubgroup("Thu", IMAGE_SUNNY, 62, 42),
+                            GenerateWideSubgroup("Thu", ImageSunny, 62, 42),
 
-                            GenerateWideSubgroup("Fri", IMAGE_SUNNY, 71, 66)
+                            GenerateWideSubgroup("Fri", ImageSunny, 71, 66)
                         }
                     }
                 }
@@ -107,7 +104,7 @@ namespace UnitTests.Notifications
                                 HintWeight = 30,
                                 Children =
                                 {
-                                    new AdaptiveImage() { Source = IMAGE_MOSTLY_CLOUDY }
+                                    new AdaptiveImage() { Source = ImageMostlyCloudy }
                                 }
                             },
 
@@ -149,13 +146,13 @@ namespace UnitTests.Notifications
                     {
                         Children =
                         {
-                            GenerateLargeSubgroup("Tue", IMAGE_CLOUDY, 57, 38),
+                            GenerateLargeSubgroup("Tue", ImageCloudy, 57, 38),
 
-                            GenerateLargeSubgroup("Wed", IMAGE_SUNNY, 59, 43),
+                            GenerateLargeSubgroup("Wed", ImageSunny, 59, 43),
 
-                            GenerateLargeSubgroup("Thu", IMAGE_SUNNY, 62, 42),
+                            GenerateLargeSubgroup("Thu", ImageSunny, 62, 42),
 
-                            GenerateLargeSubgroup("Fri", IMAGE_SUNNY, 71, 66)
+                            GenerateLargeSubgroup("Fri", ImageSunny, 71, 66)
                         }
                     }
                 }
@@ -198,8 +195,8 @@ namespace UnitTests.Notifications
             string expectedPayload = $@"<?xml version=""1.0"" encoding=""utf-8""?><tile><visual displayName=""Seattle""><binding template=""TileSmall"" hint-textStacking=""center"">{GenerateStringBackgroundImage()}<text hint-align=""center"" hint-style=""body"">Mon</text><text hint-align=""center"" hint-style=""base"">63°</text></binding><binding template=""TileMedium"" branding=""name"">{GenerateStringBackgroundImage()}<group>";
 
             // Medium tile subgroups
-            expectedPayload += GenerateStringMediumSubgroup("Mon", IMAGE_MOSTLY_CLOUDY, 63, 42);
-            expectedPayload += GenerateStringMediumSubgroup("Tue", IMAGE_CLOUDY, 57, 38);
+            expectedPayload += GenerateStringMediumSubgroup("Mon", ImageMostlyCloudy, 63, 42);
+            expectedPayload += GenerateStringMediumSubgroup("Tue", ImageCloudy, 57, 38);
 
             expectedPayload += "</group></binding>";
 
@@ -210,11 +207,11 @@ namespace UnitTests.Notifications
             expectedPayload += "<group>";
 
             // Wide tile subgroups
-            expectedPayload += GenerateStringWideSubgroup("Mon", IMAGE_MOSTLY_CLOUDY, 63, 42);
-            expectedPayload += GenerateStringWideSubgroup("Tue", IMAGE_CLOUDY, 57, 38);
-            expectedPayload += GenerateStringWideSubgroup("Wed", IMAGE_SUNNY, 59, 43);
-            expectedPayload += GenerateStringWideSubgroup("Thu", IMAGE_SUNNY, 62, 42);
-            expectedPayload += GenerateStringWideSubgroup("Fri", IMAGE_SUNNY, 71, 66);
+            expectedPayload += GenerateStringWideSubgroup("Mon", ImageMostlyCloudy, 63, 42);
+            expectedPayload += GenerateStringWideSubgroup("Tue", ImageCloudy, 57, 38);
+            expectedPayload += GenerateStringWideSubgroup("Wed", ImageSunny, 59, 43);
+            expectedPayload += GenerateStringWideSubgroup("Thu", ImageSunny, 62, 42);
+            expectedPayload += GenerateStringWideSubgroup("Fri", ImageSunny, 71, 66);
 
             expectedPayload += "</group></binding>";
 
@@ -223,16 +220,16 @@ namespace UnitTests.Notifications
             // Large tile
             expectedPayload += @"<binding template=""TileLarge"" branding=""nameAndLogo"">";
             expectedPayload += GenerateStringBackgroundImage();
-            expectedPayload += $@"<group><subgroup hint-weight=""30""><image src=""{IMAGE_MOSTLY_CLOUDY}"" /></subgroup><subgroup><text hint-style=""base"">Monday</text><text>63° / 42°</text><text hint-style=""captionSubtle"">20% chance of rain</text><text hint-style=""captionSubtle"">Winds 5 mph NE</text></subgroup></group>";
+            expectedPayload += $@"<group><subgroup hint-weight=""30""><image src=""{ImageMostlyCloudy}"" /></subgroup><subgroup><text hint-style=""base"">Monday</text><text>63° / 42°</text><text hint-style=""captionSubtle"">20% chance of rain</text><text hint-style=""captionSubtle"">Winds 5 mph NE</text></subgroup></group>";
 
             expectedPayload += "<text />";
             expectedPayload += "<group>";
 
             // Large tile subgroups
-            expectedPayload += GenerateStringLargeSubgroup("Tue", IMAGE_CLOUDY, 57, 38);
-            expectedPayload += GenerateStringLargeSubgroup("Wed", IMAGE_SUNNY, 59, 43);
-            expectedPayload += GenerateStringLargeSubgroup("Thu", IMAGE_SUNNY, 62, 42);
-            expectedPayload += GenerateStringLargeSubgroup("Fri", IMAGE_SUNNY, 71, 66);
+            expectedPayload += GenerateStringLargeSubgroup("Tue", ImageCloudy, 57, 38);
+            expectedPayload += GenerateStringLargeSubgroup("Wed", ImageSunny, 59, 43);
+            expectedPayload += GenerateStringLargeSubgroup("Thu", ImageSunny, 62, 42);
+            expectedPayload += GenerateStringLargeSubgroup("Fri", ImageSunny, 71, 66);
 
             expectedPayload += "</group></binding></visual></tile>";
             
@@ -242,7 +239,7 @@ namespace UnitTests.Notifications
 
         private static string GenerateStringBackgroundImage()
         {
-            return $@"<image src=""{BACKGROUND_IMAGE_MOSTLY_CLOUDY}"" placement=""background"" hint-overlay=""30""/>";
+            return $@"<image src=""{BackgroundImageMostlyCloudy}"" placement=""background"" hint-overlay=""30""/>";
         }
 
         private static string GenerateStringMediumSubgroup(string day, string image, int high, int low)

--- a/UnitTests/Helpers/Test_ColorHelper.cs
+++ b/UnitTests/Helpers/Test_ColorHelper.cs
@@ -52,16 +52,14 @@ namespace UnitTests.Helpers
         [TestMethod]
         public void Test_ColorHelper_ToHex()
         {
-            const string RED_HEX_VALUE = "#FFFF0000";
-            Assert.AreEqual(Windows.UI.Colors.Red.ToHex(), RED_HEX_VALUE);
+            Assert.AreEqual(Windows.UI.Colors.Red.ToHex(), "#FFFF0000");
         }
 
         [TestCategory("Helpers")]
         [TestMethod]
         public void Test_ColorHelper_ToInt()
         {
-            const int RED_INT_VALUE = -65536;
-            Assert.AreEqual(Windows.UI.Colors.Red.ToInt(), RED_INT_VALUE);
+            Assert.AreEqual(Windows.UI.Colors.Red.ToInt(), -65536);
         }
 
         [TestCategory("Helpers")]

--- a/UnitTests/Helpers/Test_StorageFileHelper.cs
+++ b/UnitTests/Helpers/Test_StorageFileHelper.cs
@@ -10,27 +10,27 @@ namespace UnitTests.Helpers
     [TestClass]
     public class Test_StorageFileHelper
     {
-        private const string SAMPLETEXT = "Lorem ipsum dolor sit amet";
-        private const string FILENAME = "filename.txt";
-        private const string PACKAGEDFILEPATH = @"Assets\Samples\lorem.txt";
+        private const string Sampletext = "Lorem ipsum dolor sit amet";
+        private const string Filename = "filename.txt";
+        private const string PackagedFilePath = @"Assets\Samples\lorem.txt";
 
         [TestCategory("Helpers")]
         [TestMethod]
         public async Task Test_StorageFileHelper_Text_PackagedFile()
         {
-            string loadedText = await StorageFileHelper.ReadTextFromPackagedFileAsync(PACKAGEDFILEPATH);
-            StringAssert.Contains(loadedText, SAMPLETEXT);
+            string loadedText = await StorageFileHelper.ReadTextFromPackagedFileAsync(PackagedFilePath);
+            StringAssert.Contains(loadedText, Sampletext);
         }
 
         [TestCategory("Helpers")]
         [TestMethod]
         public async Task Test_StorageFileHelper_Text_LocalFolder()
         {
-            var storageFile = await StorageFileHelper.WriteTextToLocalFileAsync(SAMPLETEXT, FILENAME);
+            var storageFile = await StorageFileHelper.WriteTextToLocalFileAsync(Sampletext, Filename);
             Assert.IsNotNull(storageFile);
 
-            string loadedText = await StorageFileHelper.ReadTextFromLocalFileAsync(FILENAME);
-            Assert.AreEqual(SAMPLETEXT, loadedText);
+            string loadedText = await StorageFileHelper.ReadTextFromLocalFileAsync(Filename);
+            Assert.AreEqual(Sampletext, loadedText);
 
             await storageFile.DeleteAsync(StorageDeleteOption.Default);
         }
@@ -39,11 +39,11 @@ namespace UnitTests.Helpers
         [TestMethod]
         public async Task Test_StorageFileHelper_Text_LocalCacheFolder()
         {
-            var storageFile = await StorageFileHelper.WriteTextToLocalCacheFileAsync(SAMPLETEXT, FILENAME);
+            var storageFile = await StorageFileHelper.WriteTextToLocalCacheFileAsync(Sampletext, Filename);
             Assert.IsNotNull(storageFile);
 
-            string loadedText = await StorageFileHelper.ReadTextFromLocalCacheFileAsync(FILENAME);
-            Assert.AreEqual(SAMPLETEXT, loadedText);
+            string loadedText = await StorageFileHelper.ReadTextFromLocalCacheFileAsync(Filename);
+            Assert.AreEqual(Sampletext, loadedText);
 
             await storageFile.DeleteAsync(StorageDeleteOption.Default);
         }
@@ -52,11 +52,11 @@ namespace UnitTests.Helpers
         [TestMethod]
         public async Task Test_StorageFileHelper_Text_KnownFolder()
         {
-            var storageFile = await StorageFileHelper.WriteTextToKnownFolderFileAsync(KnownFolderId.PicturesLibrary, SAMPLETEXT, FILENAME);
+            var storageFile = await StorageFileHelper.WriteTextToKnownFolderFileAsync(KnownFolderId.PicturesLibrary, Sampletext, Filename);
             Assert.IsNotNull(storageFile);
 
-            string loadedText = await StorageFileHelper.ReadTextFromKnownFoldersFileAsync(KnownFolderId.PicturesLibrary, FILENAME);
-            Assert.AreEqual(SAMPLETEXT, loadedText);
+            string loadedText = await StorageFileHelper.ReadTextFromKnownFoldersFileAsync(KnownFolderId.PicturesLibrary, Filename);
+            Assert.AreEqual(Sampletext, loadedText);
 
             await storageFile.DeleteAsync(StorageDeleteOption.Default);
         }
@@ -66,11 +66,11 @@ namespace UnitTests.Helpers
         public async Task Test_StorageFileHelper_Text_StorageFolder()
         {
             var folder = ApplicationData.Current.LocalFolder;
-            var storageFile = await StorageFileHelper.WriteTextToFileAsync(folder, SAMPLETEXT, FILENAME);
+            var storageFile = await StorageFileHelper.WriteTextToFileAsync(folder, Sampletext, Filename);
             Assert.IsNotNull(storageFile);
 
-            var loadedText = await StorageFileHelper.ReadTextFromFileAsync(folder, FILENAME);
-            Assert.AreEqual(SAMPLETEXT, loadedText);
+            var loadedText = await StorageFileHelper.ReadTextFromFileAsync(folder, Filename);
+            Assert.AreEqual(Sampletext, loadedText);
 
             await storageFile.DeleteAsync(StorageDeleteOption.Default);
         }
@@ -79,25 +79,25 @@ namespace UnitTests.Helpers
         [TestMethod]
         public async Task Test_StorageFileHelper_Bytes_PackagedFile()
         {
-            byte[] loadedBytes = await StorageFileHelper.ReadBytesFromPackagedFileAsync(PACKAGEDFILEPATH);
+            byte[] loadedBytes = await StorageFileHelper.ReadBytesFromPackagedFileAsync(PackagedFilePath);
 
             string loadedText = Encoding.Unicode.GetString(loadedBytes);
-            StringAssert.Contains(loadedText, SAMPLETEXT);
+            StringAssert.Contains(loadedText, Sampletext);
         }
 
         [TestCategory("Helpers")]
         [TestMethod]
         public async Task Test_StorageFileHelper_Bytes_LocalFolder()
         {
-            byte[] unicodeBytes = Encoding.Unicode.GetBytes(SAMPLETEXT);
+            byte[] unicodeBytes = Encoding.Unicode.GetBytes(Sampletext);
 
-            var storageFile = await StorageFileHelper.WriteBytesToLocalFileAsync(unicodeBytes, FILENAME);
+            var storageFile = await StorageFileHelper.WriteBytesToLocalFileAsync(unicodeBytes, Filename);
             Assert.IsNotNull(storageFile);
 
-            byte[] loadedBytes = await StorageFileHelper.ReadBytesFromLocalFileAsync(FILENAME);
+            byte[] loadedBytes = await StorageFileHelper.ReadBytesFromLocalFileAsync(Filename);
 
             string loadedText = Encoding.Unicode.GetString(loadedBytes);
-            Assert.AreEqual(SAMPLETEXT, loadedText);
+            Assert.AreEqual(Sampletext, loadedText);
 
             await storageFile.DeleteAsync(StorageDeleteOption.Default);
         }
@@ -106,15 +106,15 @@ namespace UnitTests.Helpers
         [TestMethod]
         public async Task Test_StorageFileHelper_Bytes_LocalCacheFolder()
         {
-            byte[] unicodeBytes = Encoding.Unicode.GetBytes(SAMPLETEXT);
+            byte[] unicodeBytes = Encoding.Unicode.GetBytes(Sampletext);
 
-            var storageFile = await StorageFileHelper.WriteBytesToLocalCacheFileAsync(unicodeBytes, FILENAME);
+            var storageFile = await StorageFileHelper.WriteBytesToLocalCacheFileAsync(unicodeBytes, Filename);
             Assert.IsNotNull(storageFile);
 
-            byte[] loadedBytes = await StorageFileHelper.ReadBytesFromLocalCacheFileAsync(FILENAME);
+            byte[] loadedBytes = await StorageFileHelper.ReadBytesFromLocalCacheFileAsync(Filename);
 
             string loadedText = Encoding.Unicode.GetString(loadedBytes);
-            Assert.AreEqual(SAMPLETEXT, loadedText);
+            Assert.AreEqual(Sampletext, loadedText);
 
             await storageFile.DeleteAsync(StorageDeleteOption.Default);
         }
@@ -123,15 +123,15 @@ namespace UnitTests.Helpers
         [TestMethod]
         public async Task Test_StorageFileHelper_Bytes_KnownFolder()
         {
-            byte[] unicodeBytes = Encoding.Unicode.GetBytes(SAMPLETEXT);
+            byte[] unicodeBytes = Encoding.Unicode.GetBytes(Sampletext);
 
-            var storageFile = await StorageFileHelper.WriteBytesToKnownFolderFileAsync(KnownFolderId.PicturesLibrary, unicodeBytes, FILENAME);
+            var storageFile = await StorageFileHelper.WriteBytesToKnownFolderFileAsync(KnownFolderId.PicturesLibrary, unicodeBytes, Filename);
             Assert.IsNotNull(storageFile);
 
-            byte[] loadedBytes = await StorageFileHelper.ReadBytesFromKnownFoldersFileAsync(KnownFolderId.PicturesLibrary, FILENAME);
+            byte[] loadedBytes = await StorageFileHelper.ReadBytesFromKnownFoldersFileAsync(KnownFolderId.PicturesLibrary, Filename);
 
             string loadedText = Encoding.Unicode.GetString(loadedBytes);
-            Assert.AreEqual(SAMPLETEXT, loadedText);
+            Assert.AreEqual(Sampletext, loadedText);
 
             await storageFile.DeleteAsync(StorageDeleteOption.Default);
         }
@@ -140,16 +140,16 @@ namespace UnitTests.Helpers
         [TestMethod]
         public async Task Test_StorageFileHelper_Bytes_StorageFolder()
         {
-            byte[] unicodeBytes = Encoding.Unicode.GetBytes(SAMPLETEXT);
+            byte[] unicodeBytes = Encoding.Unicode.GetBytes(Sampletext);
 
             var folder = ApplicationData.Current.LocalFolder;
-            var storageFile = await StorageFileHelper.WriteBytesToFileAsync(folder, unicodeBytes, FILENAME);
+            var storageFile = await StorageFileHelper.WriteBytesToFileAsync(folder, unicodeBytes, Filename);
             Assert.IsNotNull(storageFile);
 
-            byte[] loadedBytes = await StorageFileHelper.ReadBytesFromFileAsync(folder, FILENAME);
+            byte[] loadedBytes = await StorageFileHelper.ReadBytesFromFileAsync(folder, Filename);
 
             string loadedText = Encoding.Unicode.GetString(loadedBytes);
-            Assert.AreEqual(SAMPLETEXT, loadedText);
+            Assert.AreEqual(Sampletext, loadedText);
 
             await storageFile.DeleteAsync(StorageDeleteOption.Default);
         }

--- a/UnitTests/Helpers/Test_StreamHelper.cs
+++ b/UnitTests/Helpers/Test_StreamHelper.cs
@@ -10,9 +10,9 @@ namespace UnitTests.Helpers
     [TestClass]
     public class Test_StreamHelper
     {
-        private const string SAMPLETEXT = "Lorem ipsum dolor sit amet";
-        private const string FILENAME = "filename.txt";
-        private const string PACKAGEDFILEPATH = @"Assets\Samples\lorem.txt";
+        private const string SampleText = "Lorem ipsum dolor sit amet";
+        private const string Filename = "filename.txt";
+        private const string PackagedFilePath = @"Assets\Samples\lorem.txt";
 
         [TestCategory("Helpers")]
         [TestMethod]
@@ -29,7 +29,7 @@ namespace UnitTests.Helpers
         public async Task Test_StreamHelper_GetHttpStreamToStorageFile()
         {
             StorageFolder folder = ApplicationData.Current.LocalFolder;
-            StorageFile file = await folder.CreateFileAsync(FILENAME, CreationCollisionOption.ReplaceExisting);
+            StorageFile file = await folder.CreateFileAsync(Filename, CreationCollisionOption.ReplaceExisting);
 
             await StreamHelper.GetHttpStreamToStorageFileAsync(new Uri("http://dev.windows.com"), file);
 
@@ -43,12 +43,12 @@ namespace UnitTests.Helpers
         [TestMethod]
         public async Task Test_StreamHelper_PackagedFile()
         {
-            Assert.IsTrue(await StreamHelper.IsPackagedFileExistsAsync(PACKAGEDFILEPATH));
+            Assert.IsTrue(await StreamHelper.IsPackagedFileExistsAsync(PackagedFilePath));
 
-            using (var stream = await StreamHelper.GetPackagedFileStreamAsync(PACKAGEDFILEPATH))
+            using (var stream = await StreamHelper.GetPackagedFileStreamAsync(PackagedFilePath))
             {
                 var loadedText = await stream.ReadTextAsync(Encoding.Unicode);
-                StringAssert.Contains(loadedText, SAMPLETEXT);
+                StringAssert.Contains(loadedText, SampleText);
             }
         }
 
@@ -56,17 +56,17 @@ namespace UnitTests.Helpers
         [TestMethod]
         public async Task Test_StreamHelper_LocalFolder()
         {
-            Assert.IsFalse(await StreamHelper.IsLocalFileExistsAsync(FILENAME));
+            Assert.IsFalse(await StreamHelper.IsLocalFileExistsAsync(Filename));
 
-            var storageFile = await StorageFileHelper.WriteTextToLocalFileAsync(SAMPLETEXT, FILENAME);
+            var storageFile = await StorageFileHelper.WriteTextToLocalFileAsync(SampleText, Filename);
             Assert.IsNotNull(storageFile);
 
-            Assert.IsTrue(await StreamHelper.IsLocalFileExistsAsync(FILENAME));
+            Assert.IsTrue(await StreamHelper.IsLocalFileExistsAsync(Filename));
 
-            using (var stream = await StreamHelper.GetLocalFileStreamAsync(FILENAME))
+            using (var stream = await StreamHelper.GetLocalFileStreamAsync(Filename))
             {
                 var loadedText = await stream.ReadTextAsync(Encoding.UTF8);
-                StringAssert.Contains(loadedText, SAMPLETEXT);
+                StringAssert.Contains(loadedText, SampleText);
             }
 
             await storageFile.DeleteAsync(StorageDeleteOption.Default);
@@ -76,17 +76,17 @@ namespace UnitTests.Helpers
         [TestMethod]
         public async Task Test_StreamHelper_LocalCacheFolder()
         {
-            Assert.IsFalse(await StreamHelper.IsLocalCacheFileExistsAsync(FILENAME));
+            Assert.IsFalse(await StreamHelper.IsLocalCacheFileExistsAsync(Filename));
 
-            var storageFile = await StorageFileHelper.WriteTextToLocalCacheFileAsync(SAMPLETEXT, FILENAME);
+            var storageFile = await StorageFileHelper.WriteTextToLocalCacheFileAsync(SampleText, Filename);
             Assert.IsNotNull(storageFile);
 
-            Assert.IsTrue(await StreamHelper.IsLocalCacheFileExistsAsync(FILENAME));
+            Assert.IsTrue(await StreamHelper.IsLocalCacheFileExistsAsync(Filename));
 
-            using (var stream = await StreamHelper.GetLocalCacheFileStreamAsync(FILENAME))
+            using (var stream = await StreamHelper.GetLocalCacheFileStreamAsync(Filename))
             {
                 var loadedText = await stream.ReadTextAsync(Encoding.UTF8);
-                StringAssert.Contains(loadedText, SAMPLETEXT);
+                StringAssert.Contains(loadedText, SampleText);
             }
 
             await storageFile.DeleteAsync(StorageDeleteOption.Default);
@@ -98,17 +98,17 @@ namespace UnitTests.Helpers
         {
             var folder = KnownFolderId.PicturesLibrary;
 
-            Assert.IsFalse(await StreamHelper.IsKnownFolderFileExistsAsync(folder, FILENAME));
+            Assert.IsFalse(await StreamHelper.IsKnownFolderFileExistsAsync(folder, Filename));
 
-            var storageFile = await StorageFileHelper.WriteTextToKnownFolderFileAsync(folder, SAMPLETEXT, FILENAME);
+            var storageFile = await StorageFileHelper.WriteTextToKnownFolderFileAsync(folder, SampleText, Filename);
             Assert.IsNotNull(storageFile);
 
-            Assert.IsTrue(await StreamHelper.IsKnownFolderFileExistsAsync(folder, FILENAME));
+            Assert.IsTrue(await StreamHelper.IsKnownFolderFileExistsAsync(folder, Filename));
 
-            using (var stream = await StreamHelper.GetKnowFoldersFileStreamAsync(folder, FILENAME))
+            using (var stream = await StreamHelper.GetKnowFoldersFileStreamAsync(folder, Filename))
             {
                 var loadedText = await stream.ReadTextAsync(Encoding.UTF8);
-                StringAssert.Contains(loadedText, SAMPLETEXT);
+                StringAssert.Contains(loadedText, SampleText);
             }
 
             await storageFile.DeleteAsync(StorageDeleteOption.Default);

--- a/UnitTests/Services/Test_BingService.cs
+++ b/UnitTests/Services/Test_BingService.cs
@@ -11,19 +11,19 @@ namespace UnitTests.Services
     [TestClass]
     public class Test_BingService
     {
+        private const string Query = @"Windows 10";
+
         [TestCategory("Services")]
         [TestMethod]
         public async Task Test_BingService_Request()
         {
-            const string QUERY = @"Windows 10";
-
             BingSearchConfig config = new BingSearchConfig();
             config.Country = BingCountry.France;
-            config.Query = QUERY;
+            config.Query = Query;
 
             var results = await BingService.Instance.RequestAsync(config, 50);
 
-            Assert.AreEqual(results.Count(), 50);
+            Assert.AreEqual(results.Count, 50);
         }
     }
 }


### PR DESCRIPTION
Nr 12: We use PascalCasing to name all our constant local variables and fields. The only exception is for interop code where the constant value should exactly match the name and value of the code you are calling via interop.