### PR TITLE
GitVersion is updating AppVeyor build number so we don't need to do it manually

### DIFF
--- a/build/default.ps1
+++ b/build/default.ps1
@@ -58,10 +58,6 @@ task Version -description "Updates the version entries in AssemblyInfo.cs files"
 
   $script:version = $versionObj.NuGetVersionV2
   
-  if ($isAppVeyor) {
-    Update-AppveyorBuild -Version $script:version
-  }
-  
   WriteColoredOutput -ForegroundColor Green "Build version: $script:version`n"
 }
 


### PR DESCRIPTION
The build script was manually updating AppVeyor build number, but seems this isn't required as GitVersion does the same automatically.