### PR TITLE
AdaptiveGridView with fixed-aspect items

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/AdaptiveGridView/AdaptiveGridViewCode.bind
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/AdaptiveGridView/AdaptiveGridViewCode.bind
@@ -25,6 +25,7 @@
         <controls:AdaptiveGridView Name="control"
                                      ItemHeight="@[ItemHeight:Slider:200:50-500]"
                                      DesiredWidth="@[DesiredWidth:Slider:300:50-500]"
+                                     ItemAspectRatio="@[ItemAspectRatio:DoubleSlider:0:0-5]"
                                      OneRowModeEnabled="@[OneRowModeEnabled:Bool:False]"
                                      ItemTemplate="{StaticResource PhotosTemplate}"/>
     </Grid>

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/AdaptiveGridView/AdaptiveGridViewCode.bind
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/AdaptiveGridView/AdaptiveGridViewCode.bind
@@ -25,6 +25,7 @@
         <controls:AdaptiveGridView Name="control"
                                      ItemHeight="@[ItemHeight:Slider:200:50-500]"
                                      DesiredWidth="@[DesiredWidth:Slider:300:50-500]"
+                                     OneRowModeEnabled="@[OneRowModeEnabled:Bool:False]"
                                      ItemTemplate="{StaticResource PhotosTemplate}"/>
     </Grid>
 </Page>

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/AdaptiveGridView/AdaptiveGridViewPage.xaml
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/AdaptiveGridView/AdaptiveGridViewPage.xaml
@@ -22,8 +22,9 @@
 	<Grid Background="{StaticResource Brush-Grey-05}">
 		<controls:AdaptiveGridView
           x:Name="AdaptiveGridViewControl"
-          ItemHeight="{Binding ItemHeight.Value}"
+          ItemHeight="{Binding ItemHeight.Value, Mode=TwoWay}"
           DesiredWidth="{Binding DesiredWidth.Value}"
+          ItemAspectRatio="{Binding ItemAspectRatio.Value}"
           OneRowModeEnabled="{Binding OneRowModeEnabled.Value}"
           ItemTemplate="{StaticResource PhotosTemplate}"/>
 	</Grid>

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/AdaptiveGridView/AdaptiveGridViewPage.xaml
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/AdaptiveGridView/AdaptiveGridViewPage.xaml
@@ -24,6 +24,7 @@
           x:Name="AdaptiveGridViewControl"
           ItemHeight="{Binding ItemHeight.Value}"
           DesiredWidth="{Binding DesiredWidth.Value}"
+          OneRowModeEnabled="{Binding OneRowModeEnabled.Value}"
           ItemTemplate="{StaticResource PhotosTemplate}"/>
 	</Grid>
 </Page>

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/AdaptiveGridView/AdaptiveGridViewPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/AdaptiveGridView/AdaptiveGridViewPage.xaml.cs
@@ -9,8 +9,10 @@
 // TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH
 // THE CODE OR THE USE OR OTHER DEALINGS IN THE CODE.
 // ******************************************************************
+using System;
 using Microsoft.Toolkit.Uwp.SampleApp.Models;
-
+using Microsoft.Toolkit.Uwp.UI.Controls;
+using Windows.UI.Xaml;
 using Windows.UI.Xaml.Navigation;
 
 namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
@@ -34,6 +36,16 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
             }
 
             AdaptiveGridViewControl.ItemsSource = await new Data.PhotosDataSource().GetItemsAsync();
+            AdaptiveGridViewControl.RegisterPropertyChangedCallback(AdaptiveGridView.ItemAspectRatioProperty, OnAspectRatioChanged);
+        }
+
+        private void OnAspectRatioChanged(DependencyObject sender, DependencyProperty dp)
+        {
+            // If the user clears the aspect ratio, then let's set the ItemHeight back to its default value.
+            if (AdaptiveGridViewControl.ItemAspectRatio == 0)
+            {
+                AdaptiveGridViewControl.ItemHeight = 200;
+            }
         }
     }
 }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveGridView.Properties.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveGridView.Properties.cs
@@ -79,6 +79,12 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         public static readonly DependencyProperty DesiredWidthProperty =
             DependencyProperty.Register(nameof(DesiredWidth), typeof(double), typeof(AdaptiveGridView), new PropertyMetadata(0D, DesiredWidthChanged));
 
+        /// <summary>
+        /// Identifies the <see cref="ItemAspectRatio"/> dependency property.
+        /// </summary>
+        public static readonly DependencyProperty ItemAspectRatioProperty =
+            DependencyProperty.Register(nameof(ItemAspectRatio), typeof(double), typeof(AdaptiveGridView), new PropertyMetadata(0D, ItemAspectRatioChanged));
+
         private static void OnOneRowModeEnabledChanged(DependencyObject d, object newValue)
         {
             var self = d as AdaptiveGridView;
@@ -125,6 +131,31 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             }
         }
 
+        private static void ItemAspectRatioChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            var self = d as AdaptiveGridView;
+            if (self._isInitialized)
+            {
+                var newRatio = (double)e.NewValue;
+                if (newRatio == 0)
+                {
+                    var b = new Binding()
+                    {
+                        Source = self,
+                        Path = new PropertyPath(nameof(ItemHeight))
+                    };
+
+                    self._templateProxy.SetBinding(FrameworkElement.HeightProperty, b);
+                }
+                else
+                {
+                    self._templateProxy.ClearValue(FrameworkElement.HeightProperty);
+                }
+
+                self.RecalculateLayout(self._listView.ActualWidth);
+            }
+        }
+
         /// <summary>
         /// Gets or sets the desired width of each item
         /// </summary>
@@ -133,6 +164,19 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         {
             get { return (double)GetValue(DesiredWidthProperty); }
             set { SetValue(DesiredWidthProperty, value); }
+        }
+
+        /// <summary>
+        /// Gets or sets the desired aspect ratio of each item
+        /// </summary>
+        /// <value>The ratio of item width divided by item height, or 0 for no fixed aspect ratio.</value>
+        /// <example>Use an aspect ratio of 1.0 to make square items.</example>
+        /// <example>Use the Golden Ratio of 1.618 to make items that are wider than they are tall.</example>
+        /// <example>Use an aspect ratio of 0 to set your own value in <c ref="ItemHeight"/>.</example>
+        public double ItemAspectRatio
+        {
+            get { return (double)GetValue(ItemAspectRatioProperty); }
+            set { SetValue(ItemAspectRatioProperty, value); }
         }
 
         /// <summary>

--- a/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveGridView.Properties.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveGridView.Properties.cs
@@ -83,18 +83,35 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         {
             var self = d as AdaptiveGridView;
 
-            if ((bool)newValue)
+            if (self._isInitialized)
             {
-                if (self._isInitialized)
+                var oneRowMode = (bool)newValue;
+
+                if (oneRowMode)
                 {
                     var b = new Binding()
                     {
                         Source = self,
-                        Path = new PropertyPath("ItemHeight")
+                        Path = new PropertyPath(nameof(ItemHeight))
                     };
 
                     self._listView.SetBinding(GridView.MaxHeightProperty, b);
-                    self.VerticalScrollMode = ScrollMode.Disabled;
+                    ScrollViewer.SetVerticalScrollMode(self._listView, ScrollMode.Disabled);
+
+                    // Scroll to the top of the viewport
+                    var scroller = self._listView.FindDescendant<ScrollViewer>();
+                    scroller?.ChangeView(horizontalOffset: null, verticalOffset: 0, zoomFactor: null, disableAnimation: true);
+                }
+                else
+                {
+                    var b = new Binding
+                    {
+                        Source = self,
+                        Path = new PropertyPath(nameof(VerticalScrollMode))
+                    };
+
+                    self._listView.ClearValue(GridView.MaxHeightProperty);
+                    self._listView.SetBinding(ScrollViewer.VerticalScrollModeProperty, b);
                 }
             }
         }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveGridView.Properties.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveGridView.Properties.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         {
             var self = d as AdaptiveGridView;
 
-            if (self._isInitialized)
+            if (self._isInitialized && self._listView != null)
             {
                 var oneRowMode = (bool)newValue;
 
@@ -125,7 +125,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         private static void DesiredWidthChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             var self = d as AdaptiveGridView;
-            if (self._isInitialized)
+            if (self._isInitialized && self._listView != null)
             {
                 self.RecalculateLayout(self._listView.ActualWidth);
             }
@@ -134,7 +134,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         private static void ItemAspectRatioChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             var self = d as AdaptiveGridView;
-            if (self._isInitialized)
+            if (self._isInitialized && self._listView != null && self._templateProxy != null)
             {
                 var newRatio = (double)e.NewValue;
                 if (newRatio == 0)

--- a/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveGridView.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveGridView.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
             ItemWidth = (containerWidth / _columns) - 5;
 
-            if (ItemAspectRatio > 0)
+            if (ItemAspectRatio > 0 && _templateProxy != null)
             {
                 var safeRatio = Math.Min(100.0, Math.Max(0.01, ItemAspectRatio));
                 _templateProxy.Height = ItemWidth / safeRatio;

--- a/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveGridView.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveGridView.cs
@@ -9,6 +9,7 @@
 // TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH
 // THE CODE OR THE USE OR OTHER DEALINGS IN THE CODE.
 // ******************************************************************
+using System;
 using System.Collections.Generic;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -31,6 +32,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         private int _columns;
         private bool _isInitialized;
         private ListViewBase _listView;
+        private FrameworkElement _templateProxy;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AdaptiveGridView"/> class.
@@ -43,7 +45,12 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
         private void RecalculateLayout(double containerWidth)
         {
-            if (containerWidth == 0 || DesiredWidth == 0)
+            if (containerWidth == 0)
+            {
+                return;
+            }
+
+            if (DesiredWidth <= 0 && ItemAspectRatio <= 0)
             {
                 return;
             }
@@ -58,6 +65,13 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             }
 
             ItemWidth = (containerWidth / _columns) - 5;
+
+            if (ItemAspectRatio > 0)
+            {
+                var safeRatio = Math.Min(100.0, Math.Max(0.01, ItemAspectRatio));
+                _templateProxy.Height = ItemWidth / safeRatio;
+                ItemHeight = _templateProxy.Height;
+            }
         }
 
         /// <summary>
@@ -83,6 +97,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 _listView.ItemClick += ListView_ItemClick;
                 _listView.Items.VectorChanged += ListViewItems_VectorChanged;
             }
+
+            _templateProxy = GetTemplateChild("templateProxy") as FrameworkElement;
 
             _isInitialized = true;
             OnOneRowModeEnabledChanged(this, OneRowModeEnabled);


### PR DESCRIPTION
AdaptiveGridView currently has a variable item width, but fixed item height.  That's fine for some scenarios, but in other cases, you want the items to have the same aspect ratio at all times.

This adds a new property `ItemAspectRatio`.  If set to its default value of zero, you get the pre-existing behavior.  If set to a non-zero value, then `ItemHeight` is calculated dynamically as a function of the item's actual width.

This PR also has an admittedly-unrelated change to make the `OneRowModeEnabled` property able to change on-the-fly.  The pre-existing behavior is that changes to `OneRowModeEnabled` are ignored after the property is toggled.  (BTW, I would suggest changing the name of that property to something like `MaxNumberOfRows`, but it's probably too late to change, huh?)