### PR TITLE
Allow VerticalScrollMode and VerticalScrollBarVisibility to be set.

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveGridView.Properties.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveGridView.Properties.cs
@@ -62,12 +62,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             DependencyProperty.Register(nameof(OneRowModeEnabled), typeof(bool), typeof(AdaptiveGridView), new PropertyMetadata(false, (o, e) => { OnOneRowModeEnabledChanged(o, e.NewValue); }));
 
         /// <summary>
-        /// Identifies the <see cref="VerticalScrollMode"/> dependency property.
-        /// </summary>
-        private static readonly DependencyProperty VerticalScrollModeProperty =
-            DependencyProperty.Register(nameof(VerticalScrollMode), typeof(ScrollMode), typeof(AdaptiveGridView), new PropertyMetadata(ScrollMode.Auto));
-
-        /// <summary>
         /// Identifies the <see cref="ItemWidth"/> dependency property.
         /// </summary>
         private static readonly DependencyProperty ItemWidthProperty =
@@ -94,7 +88,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                     };
 
                     self._listView.SetBinding(GridView.MaxHeightProperty, b);
-                    self.VerticalScrollMode = ScrollMode.Disabled;
+                    ScrollViewer.SetVerticalScrollMode(self, ScrollMode.Disabled);
+                    ScrollViewer.SetVerticalScrollBarVisibility(self, ScrollBarVisibility.Hidden);
                 }
             }
         }
@@ -172,12 +167,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// Event raised when an item is clicked
         /// </summary>
         public event ItemClickEventHandler ItemClick;
-
-        private ScrollMode VerticalScrollMode
-        {
-            get { return (ScrollMode)GetValue(VerticalScrollModeProperty); }
-            set { SetValue(VerticalScrollModeProperty, value); }
-        }
 
         private double ItemWidth
         {

--- a/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveGridView.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveGridView.xaml
@@ -9,7 +9,7 @@
                     <Grid>
 						<ContentPresenter x:Name="templateProxy" Width="{TemplateBinding ItemWidth}" Height="{TemplateBinding ItemHeight}" ContentTemplate="{TemplateBinding ItemTemplate}" Visibility="Collapsed" />
 						<GridView HorizontalAlignment="Stretch" x:Name="ListView" IsItemClickEnabled="True" SelectionMode="None" IsSwipeEnabled="False" IsTabStop="False"
-                          ScrollViewer.VerticalScrollMode="{TemplateBinding VerticalScrollMode}" ScrollViewer.VerticalScrollBarVisibility="Hidden"
+                          ScrollViewer.VerticalScrollMode="{TemplateBinding ScrollViewer.VerticalScrollMode}" ScrollViewer.VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}"
                           ItemsSource="{TemplateBinding ItemsSource}">
                             <GridView.ItemTemplate>
                                 <DataTemplate>


### PR DESCRIPTION
Vertical scroll mode was being managed by a private dependency property and vertical scroll mode was hardcoded to hidden. For desktop uses, it's often useful to have the scroll bar shown, which is not currently possible. I've removed the private dependency property since it didn't look like we needed it and made the control use `ScrollViewer.VerticalScrollMode` and `ScrollViewer.VerticalScrollBarVisibility` instead. Using `ScrollViewer.Set*` for the behaviour that the private `VerticalScrollMode` was providing.