### PR TITLE
Fix blur animation auto start

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Animations/Behaviors/Blur.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Animations/Behaviors/Blur.cs
@@ -43,9 +43,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations.Behaviors
         /// </remarks>
         protected override void OnAttached()
         {
-            base.OnAttached();
-
             _frameworkElement = AssociatedObject as FrameworkElement;
+            base.OnAttached();
         }
 
         /// <summary>

--- a/Microsoft.Toolkit.Uwp.UI.Animations/Behaviors/Blur.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Animations/Behaviors/Blur.cs
@@ -43,8 +43,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations.Behaviors
         /// </remarks>
         protected override void OnAttached()
         {
-            _frameworkElement = AssociatedObject as FrameworkElement;
             base.OnAttached();
+            _frameworkElement = AssociatedObject as FrameworkElement;
         }
 
         /// <summary>

--- a/Microsoft.Toolkit.Uwp.UI.Animations/Behaviors/CompositionBehaviorBase.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Animations/Behaviors/CompositionBehaviorBase.cs
@@ -33,13 +33,32 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations.Behaviors
             var frameworkElement = AssociatedObject as FrameworkElement;
             if (frameworkElement != null)
             {
-                frameworkElement.Loaded += (sender, e) =>
-                {
-                    if (AutomaticallyStart)
-                    {
-                        StartAnimation();
-                    }
-                };
+                frameworkElement.Loaded += OnFrameworkElementLoaded;
+            }
+        }
+
+        /// <summary>
+        /// Called while the behavior is detaching from the <see cref="P:Microsoft.Xaml.Interactivity.Behavior.AssociatedObject" />.
+        /// </summary>
+        /// <remarks>
+        /// Override this to finalize and free everything associated to the <see cref="P:Microsoft.Xaml.Interactivity.Behavior.AssociatedObject" />
+        /// </remarks>
+        protected override void OnDetaching()
+        {
+            base.OnDetaching();
+
+            var frameworkElement = AssociatedObject as FrameworkElement;
+            if (frameworkElement != null)
+            {
+                frameworkElement.Loaded -= OnFrameworkElementLoaded;
+            }
+        }
+
+        private void OnFrameworkElementLoaded(object sender, RoutedEventArgs e)
+        {
+            if (AutomaticallyStart)
+            {
+                StartAnimation();
             }
         }
 

--- a/Microsoft.Toolkit.Uwp.UI.Animations/Behaviors/CompositionBehaviorBase.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Animations/Behaviors/CompositionBehaviorBase.cs
@@ -30,9 +30,16 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations.Behaviors
         {
             base.OnAttached();
 
-            if (AutomaticallyStart)
+            var frameworkElement = AssociatedObject as FrameworkElement;
+            if (frameworkElement != null)
             {
-                StartAnimation();
+                frameworkElement.Loaded += (sender, e) =>
+                {
+                    if (AutomaticallyStart)
+                    {
+                        StartAnimation();
+                    }
+                };
             }
         }
 


### PR DESCRIPTION
In some cases AutomaticallyStart set in the XAML code does not work.

That is because for some reason, the _frameworkElement property is null if StartAnimation() is called too early. 

Repro case here : 
[App1.zip](https://github.com/Microsoft/UWPCommunityToolkit/files/434631/App1.zip)

Or you can just create a new UWP app project in the UWP Toolkit solution, copy the Blur sample in mainpage.
