### PR TITLE
Ensures GitVersion does not attempt to make a "git fetch"

### DIFF
--- a/build/default.ps1
+++ b/build/default.ps1
@@ -50,7 +50,7 @@ task Version -description "Updates the version entries in AssemblyInfo.cs files"
   
   WriteColoredOutput -ForegroundColor Green "Updating AssemblyInfo.cs files...`n"
   
-  Exec { .$tempDir\gitversion.commandline\tools\gitversion.exe $sourceDir /l console /output buildserver /updateassemblyinfo } "Error updating GitVersion"
+  Exec { .$tempDir\gitversion.commandline\tools\gitversion.exe $sourceDir /l console /output buildserver /updateassemblyinfo /nofetch } "Error updating GitVersion"
   
   WriteColoredOutput -ForegroundColor Green "Retrieving version...`n"
 


### PR DESCRIPTION
GitVersion is causing builds to fail, so I'm adding `/nofetch` following @onovotny recomendation.