### PR TITLE
Correctly draw RadialGauge scale when arc < 180°.

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/RadialGauge/RadialGauge.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/RadialGauge/RadialGauge.cs
@@ -537,7 +537,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 pf.StartPoint = radialGauge.ScalePoint(radialGauge.MinAngle, middleOfScale);
                 var seg = new ArcSegment();
                 seg.SweepDirection = SweepDirection.Clockwise;
-                seg.IsLargeArc = true;
+                seg.IsLargeArc = radialGauge.MaxAngle > (radialGauge.MinAngle + 180);
                 seg.Size = new Size(middleOfScale, middleOfScale);
                 seg.Point = radialGauge.ScalePoint(radialGauge.MaxAngle, middleOfScale);
                 pf.Segments.Add(seg);


### PR DESCRIPTION
When drawing the background scale, the RadialGauge assumed it to be a large arc (> 180°). Since MinimumAngle and MaximumAngle are now dependency properties, this assumption became false. So the calculation is adjusted.