### PR TITLE
Issue329 and343

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/Microsoft.Toolkit.Uwp.UI.Controls.csproj
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/Microsoft.Toolkit.Uwp.UI.Controls.csproj
@@ -62,6 +62,7 @@
     <Compile Include="HeaderedTextBlock\HeaderedTextBlock.cs" />
     <Compile Include="HeaderedTextBlock\HeaderedTextBlock.Properties.cs" />
     <Compile Include="BladeControl\Blade.Events.cs" />
+    <Compile Include="SlidableListItem\SwipeStatus.cs" />
     <None Include="Microsoft.Toolkit.Uwp.UI.Controls.ruleset" />
     <None Include="project.json" />
   </ItemGroup>

--- a/Microsoft.Toolkit.Uwp.UI.Controls/SlidableListItem/SlidableListItem.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/SlidableListItem/SlidableListItem.cs
@@ -21,6 +21,8 @@ using Windows.UI.Xaml.Media.Animation;
 
 namespace Microsoft.Toolkit.Uwp.UI.Controls
 {
+    using Animations;
+
     /// <summary>
     /// ContentControl providing functionality for sliding left or right to expose functions
     /// </summary>
@@ -142,7 +144,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// Identifies the <see cref="SwipeStatus"/> property
         /// </summary>
         public static readonly DependencyProperty SwipeStatusProperty =
-            DependencyProperty.Register(nameof(SwipeStatus), typeof(object), typeof(SwipeStatus), new PropertyMetadata(SwipeStatus.NotRunning));
+            DependencyProperty.Register(nameof(SwipeStatus), typeof(object), typeof(SwipeStatus), new PropertyMetadata(SwipeStatus.Idle));
 
         private const string PartContentGrid = "ContentGrid";
         private const string PartCommandContainer = "CommandContainer";
@@ -268,9 +270,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             _contentAnimation.From = x;
             _contentStoryboard.Begin();
 
-            _leftCommandTransform.TranslateX = 0;
-            _rightCommandTransform.TranslateX = 0;
-            _commandContainer.Opacity = 0; // How to animate this?
+            _commandContainer.Fade(0, 100).Start();
 
             if (SwipeStatus == SwipeStatus.SwipingPassedLeftThreshold)
             {
@@ -283,7 +283,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 LeftCommand?.Execute(LeftCommandParameter);
             }
 
-            SwipeStatus = SwipeStatus.NotRunning;
+            SwipeStatus = SwipeStatus.Idle;
         }
 
         /// <summary>
@@ -291,14 +291,14 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// </summary>
         private void ContentGrid_ManipulationDelta(object sender, ManipulationDeltaRoutedEventArgs e)
         {
-            if (SwipeStatus == SwipeStatus.NotRunning)
+            if (SwipeStatus == SwipeStatus.Idle)
             {
                 return;
             }
 
             var newTranslationX = _transform.TranslateX + e.Delta.Translation.X;
             bool swipingInDisabledArea = false;
-            SwipeStatus newSwipeStatus = SwipeStatus.NotRunning;
+            SwipeStatus newSwipeStatus = SwipeStatus.Idle;
 
             if (newTranslationX > 0)
             {
@@ -647,51 +647,5 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 SetValue(SwipeStatusProperty, value);
             }
         }
-    }
-
-    /// <summary>
-    /// Types of swipe status.
-    /// </summary>
-    public enum SwipeStatus
-    {
-        /// <summary>
-        /// Swiping is not occuring.
-        /// </summary>
-        NotRunning,
-
-        /// <summary>
-        /// Swiping is going to start.
-        /// </summary>
-        Starting,
-
-        /// <summary>
-        /// Swiping to the left, but the command is disabled.
-        /// </summary>
-        DisabledSwipingToLeft,
-
-        /// <summary>
-        /// Swiping to the left below the threshold.
-        /// </summary>
-        SwipingToLeftThreshold,
-
-        /// <summary>
-        /// Swiping to the left above the threshold.
-        /// </summary>
-        SwipingPassedLeftThreshold,
-
-        /// <summary>
-        /// Swiping to the right, but the command is disabled.
-        /// </summary>
-        DisabledSwipingToRight,
-
-        /// <summary>
-        /// Swiping to the right below the threshold.
-        /// </summary>
-        SwipingToRightThreshold,
-
-        /// <summary>
-        /// Swiping to the right above the threshold.
-        /// </summary>
-        SwipingPassedRightThreshold
     }
 }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/SlidableListItem/SlidableListItem.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/SlidableListItem/SlidableListItem.cs
@@ -406,13 +406,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 if (newTranslationX < ActivationWidth)
                 {
                     _leftCommandTransform.TranslateX = newTranslationX / 2;
-                    _leftCommandPanel.Clip.Rect = new Windows.Foundation.Rect(0, 0, newTranslationX / 2, 40);
                     newSwipeStatus = SwipeStatus.SwipingToRightThreshold;
                 }
                 else
                 {
                     _leftCommandTransform.TranslateX = 20;
-                    _leftCommandPanel.Clip.Rect = new Windows.Foundation.Rect(0, 0, newTranslationX - 20, 40);
                     newSwipeStatus = SwipeStatus.SwipingPassedRightThreshold;
                 }
             }
@@ -430,14 +428,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 if (-newTranslationX < ActivationWidth)
                 {
                     _rightCommandTransform.TranslateX = newTranslationX / 2;
-                    _rightCommandPanel.Clip.Rect = new Windows.Foundation.Rect(_rightCommandPanel.ActualWidth + (newTranslationX / 2), 0, -newTranslationX / 2, _rightCommandPanel.ActualHeight);
                     newSwipeStatus = SwipeStatus.SwipingToLeftThreshold;
                 }
                 else
                 {
                     _rightCommandTransform.TranslateX = -20;
-                    var drawingWidth = -newTranslationX - 20;
-                    _rightCommandPanel.Clip.Rect = new Windows.Foundation.Rect(_rightCommandPanel.ActualWidth - drawingWidth, 0, drawingWidth, _rightCommandPanel.ActualHeight);
                     newSwipeStatus = SwipeStatus.SwipingPassedLeftThreshold;
                 }
             }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/SlidableListItem/SlidableListItem.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/SlidableListItem/SlidableListItem.cs
@@ -11,6 +11,7 @@
 // ******************************************************************
 using System;
 using System.Windows.Input;
+using Microsoft.Toolkit.Uwp.UI.Animations;
 using Windows.Devices.Input;
 using Windows.UI;
 using Windows.UI.Xaml;
@@ -21,8 +22,6 @@ using Windows.UI.Xaml.Media.Animation;
 
 namespace Microsoft.Toolkit.Uwp.UI.Controls
 {
-    using Animations;
-
     /// <summary>
     /// ContentControl providing functionality for sliding left or right to expose functions
     /// </summary>

--- a/Microsoft.Toolkit.Uwp.UI.Controls/SlidableListItem/SlidableListItem.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/SlidableListItem/SlidableListItem.cs
@@ -303,7 +303,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                     var sub = _transform.TranslateX + e.Delta.Translation.X;
                     if (sub > swipeThreshold)
                     {
-                        _transform.TranslateX += swipeThreshold - _transform.TranslateX;
+                        _transform.TranslateX = swipeThreshold;
                         return;
                     }
 
@@ -346,7 +346,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                     var sub = Math.Abs(_transform.TranslateX + e.Delta.Translation.X);
                     if (sub > swipeThreshold)
                     {
-                        _transform.TranslateX += -(swipeThreshold - (_transform.TranslateX * -1));
+                        _transform.TranslateX = -swipeThreshold;
                         return;
                     }
 

--- a/Microsoft.Toolkit.Uwp.UI.Controls/SlidableListItem/SlidableListItem.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/SlidableListItem/SlidableListItem.cs
@@ -167,8 +167,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 if (value != _swipeStatus)
                 {
                     _swipeStatus = value;
-
-                    System.Diagnostics.Debug.WriteLine("New swipe status: " + _swipeStatus);
                 }
             }
         }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/SlidableListItem/SlidableListItem.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/SlidableListItem/SlidableListItem.cs
@@ -138,6 +138,12 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         public static readonly DependencyProperty RightCommandParameterProperty =
             DependencyProperty.Register(nameof(RightCommandParameter), typeof(object), typeof(SlidableListItem), new PropertyMetadata(null));
 
+        /// <summary>
+        /// Identifies the <see cref="SwipeStatus"/> property
+        /// </summary>
+        public static readonly DependencyProperty SwipeStatusProperty =
+            DependencyProperty.Register(nameof(SwipeStatus), typeof(object), typeof(SwipeStatus), new PropertyMetadata(SwipeStatus.NotRunning));
+
         private const string PartContentGrid = "ContentGrid";
         private const string PartCommandContainer = "CommandContainer";
         private const string PartLeftCommandPanel = "LeftCommandPanel";
@@ -152,24 +158,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         private CompositeTransform _rightCommandTransform;
         private DoubleAnimation _contentAnimation;
         private Storyboard _contentStoryboard;
-
-        private SwipeStatus _swipeStatus = SwipeStatus.NotRunning;
-
-        public SwipeStatus SwipeStatus
-        {
-            get
-            {
-                return _swipeStatus;
-            }
-
-            private set
-            {
-                if (value != _swipeStatus)
-                {
-                    _swipeStatus = value;
-                }
-            }
-        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SlidableListItem"/> class.
@@ -309,6 +297,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
             var newTranslationX = _transform.TranslateX + e.Delta.Translation.X;
             bool swipingInDisabledArea = false;
+            SwipeStatus newSwipeStatus = SwipeStatus.NotRunning;
 
             if (newTranslationX > 0)
             {
@@ -319,7 +308,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                     if (newTranslationX > 0)
                     {
                         swipingInDisabledArea = true;
-                        SwipeStatus = SwipeStatus.DisabledSwipingToRight;
+                        newSwipeStatus = SwipeStatus.DisabledSwipingToRight;
                     }
 
                     if (newTranslationX > 16)
@@ -360,7 +349,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                     if (newTranslationX < 0)
                     {
                         swipingInDisabledArea = true;
-                        SwipeStatus = SwipeStatus.DisabledSwipingToLeft;
+                        newSwipeStatus = SwipeStatus.DisabledSwipingToLeft;
                     }
 
                     if (newTranslationX < -16)
@@ -423,13 +412,13 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 {
                     _leftCommandTransform.TranslateX = newTranslationX / 2;
                     _leftCommandPanel.Clip.Rect = new Windows.Foundation.Rect(0, 0, newTranslationX / 2, 40);
-                    SwipeStatus = SwipeStatus.SwipingToRightThreshold;
+                    newSwipeStatus = SwipeStatus.SwipingToRightThreshold;
                 }
                 else
                 {
                     _leftCommandTransform.TranslateX = 20;
                     _leftCommandPanel.Clip.Rect = new Windows.Foundation.Rect(0, 0, newTranslationX - 20, 40);
-                    SwipeStatus = SwipeStatus.SwipingPassedRightThreshold;
+                    newSwipeStatus = SwipeStatus.SwipingPassedRightThreshold;
                 }
             }
             else
@@ -453,18 +442,19 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 {
                     _rightCommandTransform.TranslateX = newTranslationX / 2;
                     _rightCommandPanel.Clip.Rect = new Windows.Foundation.Rect(_rightCommandPanel.ActualWidth + (newTranslationX / 2), 0, -newTranslationX / 2, _rightCommandPanel.ActualHeight);
-                    SwipeStatus = SwipeStatus.SwipingToLeftThreshold;
+                    newSwipeStatus = SwipeStatus.SwipingToLeftThreshold;
                 }
                 else
                 {
                     _rightCommandTransform.TranslateX = -20;
                     var drawingWidth = -newTranslationX - 20;
                     _rightCommandPanel.Clip.Rect = new Windows.Foundation.Rect(_rightCommandPanel.ActualWidth - drawingWidth, 0, drawingWidth, _rightCommandPanel.ActualHeight);
-                    SwipeStatus = SwipeStatus.SwipingPassedLeftThreshold;
+                    newSwipeStatus = SwipeStatus.SwipingPassedLeftThreshold;
                 }
             }
 
             _transform.TranslateX = newTranslationX;
+            SwipeStatus = newSwipeStatus;
         }
 
         /// <summary>
@@ -655,6 +645,22 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             set
             {
                 SetValue(RightCommandParameterProperty, value);
+            }
+        }
+
+        /// <summary>
+        /// Gets the SwipeStatus for current swipe status
+        /// </summary>
+        public SwipeStatus SwipeStatus
+        {
+            get
+            {
+                return (SwipeStatus)GetValue(SwipeStatusProperty);
+            }
+
+            private set
+            {
+                SetValue(SwipeStatusProperty, value);
             }
         }
     }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/SlidableListItem/SlidableListItem.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/SlidableListItem/SlidableListItem.xaml
@@ -7,7 +7,7 @@
         <Setter Property="LeftForeground" Value="White"></Setter>
         <Setter Property="RightForeground" Value="White"></Setter>
         <Setter Property="VerticalAlignment" Value="Stretch"></Setter>
-        <Setter Property="Background" Value="White"></Setter>
+        <Setter Property="Background" Value="Transparent"></Setter>
         <Setter Property="ActivationWidth" Value="80"></Setter>
         <Setter Property="IsOffsetLimited" Value="True"></Setter>
         <Setter Property="ExtraSwipeThreshold" Value="24"></Setter>

--- a/Microsoft.Toolkit.Uwp.UI.Controls/SlidableListItem/SwipeStatus.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/SlidableListItem/SwipeStatus.cs
@@ -1,0 +1,48 @@
+﻿namespace Microsoft.Toolkit.Uwp.UI.Controls
+{
+    /// <summary>
+    /// Types of swipe status.
+    /// </summary>
+    public enum SwipeStatus
+    {
+        /// <summary>
+        /// Swiping is not occuring.
+        /// </summary>
+        Idle,
+
+        /// <summary>
+        /// Swiping is going to start.
+        /// </summary>
+        Starting,
+
+        /// <summary>
+        /// Swiping to the left, but the command is disabled.
+        /// </summary>
+        DisabledSwipingToLeft,
+
+        /// <summary>
+        /// Swiping to the left below the threshold.
+        /// </summary>
+        SwipingToLeftThreshold,
+
+        /// <summary>
+        /// Swiping to the left above the threshold.
+        /// </summary>
+        SwipingPassedLeftThreshold,
+
+        /// <summary>
+        /// Swiping to the right, but the command is disabled.
+        /// </summary>
+        DisabledSwipingToRight,
+
+        /// <summary>
+        /// Swiping to the right below the threshold.
+        /// </summary>
+        SwipingToRightThreshold,
+
+        /// <summary>
+        /// Swiping to the right above the threshold.
+        /// </summary>
+        SwipingPassedRightThreshold
+    }
+}


### PR DESCRIPTION
This PR solves #329 (SlidableListItem is not transparent). Almost all changes are in ContentGrid_ManipulationDelta that was rewritten from scratch. When testing this on a mobile I haven’t seen any major performance impact.

One thing I haven’t figure out to do is animate the opacity of _commandContainer to 0 when swiping is completed (**update**: clipping on should be animated, not opacity). Now it just immediately disappears, which is not that bad, but I assume an animation would be better. I tried to do something similar like _contentAnimation but it didn’t work :-/. Some guidance here would be great because I’m sure it’s trivial :-)

If swiping is disabled in one direction the user will still be able to swipe but just a tiny bit. Very similar to pulling down on a list that is scrolled to the top. Quite neat I think :). Issue #343 (It’s not possible to swipe back if IsLeftSwipeEnabled/IsRightSwipeEnabled) is also solved by this PR.

The property SwipeStatus has also been added. It would be nice to have an event that is triggered when this value is changed (like discussed in #316 and #330).

