### PR TITLE
Downgrade NETStandard.Library to 1.5.0

### DIFF
--- a/Microsoft.Toolkit.Uwp.Notifications.NETStandard/project.json
+++ b/Microsoft.Toolkit.Uwp.Notifications.NETStandard/project.json
@@ -1,7 +1,7 @@
 ﻿{
   "supports": {},
   "dependencies": {
-    "NETStandard.Library": "1.6.0"
+    "NETStandard.Library": "1.5.0"
   },
   "frameworks": {
     "netstandard1.0": {}


### PR DESCRIPTION
NETStandard 1.6.0 is not currently supported by .NET Framework as outlined [here](https://docs.microsoft.com/en-us/dotnet/articles/standard/library).

This cause the build to fail when using MSBuild.
It works correctly when building with Visual Studio, because VS seem to be overriding this to use 1.0 (not really sure about that).

Changing the dependency to 1.5 to fix this issue.

More info on this issue:
https://github.com/dotnet/corefx/issues/10213
https://github.com/dotnet/roslyn/issues/12918