### PR TITLE
Addressing #388 NullReference if ProgressRing isn't part of template

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/ImageEx/ImageEx.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/ImageEx/ImageEx.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         {
             var newSquareSize = Math.Min(finalSize.Width, finalSize.Height) / 8.0;
 
-            if (_progress.Width == newSquareSize)
+            if (_progress?.Width == newSquareSize)
             {
                 _progress.Height = newSquareSize;
             }


### PR DESCRIPTION
Adding a check to ensure progress ring is not null before checking the width