### PR TITLE
Added IsPointerReleasedOnSwipingHandled Property

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/SlidableListItem/SlidableListItemCode.bind
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/SlidableListItem/SlidableListItemCode.bind
@@ -27,6 +27,7 @@
                     IsLeftSwipeEnabled="@[IsLeftSwipeEnabled:Bool:true]"
                     IsOffsetLimited="@[IsOffsetLimited:Bool:true]"
                     MouseSlidingEnabled="@[MouseSlidingEnabled:Bool:true]"
+                    IsPointerReleasedOnSwipingHandled="@[IsPointerReleasedOnSwipingHandled:Bool:false]"
                     LeftCommand="{x:Bind ToggleFavorite}"
                     RightCommand="{Binding DeleteItem, ElementName=Page, Mode=OneWay}"
                     RightCommandParameter="{Binding}">

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/SlidableListItem/SlidableListItemPage.xaml
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/SlidableListItem/SlidableListItemPage.xaml
@@ -31,6 +31,7 @@
                                        RightCommand="{Binding DeleteItem, ElementName=Page, Mode=OneWay}"
                                        RightCommandParameter="{Binding}"
                                        ActivationWidth="{Binding DataContext.ActivationWidth.Value, ElementName=Root, Mode=OneWay}"
+                                       IsPointerReleasedOnSwipingHandled="{Binding DataContext.IsPointerReleasedOnSwipingHandled.Value, ElementName=Root, Mode=OneWay}"
                                        MinWidth="300"
                                        MaxWidth="800"
                                        >

--- a/Microsoft.Toolkit.Uwp.UI.Controls/SlidableListItem/SlidableListItem.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/SlidableListItem/SlidableListItem.cs
@@ -144,7 +144,13 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// Identifies the <see cref="SwipeStatus"/> property
         /// </summary>
         public static readonly DependencyProperty SwipeStatusProperty =
-            DependencyProperty.Register(nameof(SwipeStatus), typeof(object), typeof(SwipeStatus), new PropertyMetadata(SwipeStatus.Idle));
+            DependencyProperty.Register(nameof(SwipeStatus), typeof(object), typeof(SlidableListItem), new PropertyMetadata(SwipeStatus.Idle));
+
+        /// <summary>
+        /// Identifues the <see cref="IsPointerReleasedOnSwipingHandled"/> property
+        /// </summary>
+        public static readonly DependencyProperty IsPointerReleasedOnSwipingHandledProperty =
+            DependencyProperty.Register("IsPointerReleasedOnSwipingHandled", typeof(bool), typeof(SlidableListItem), new PropertyMetadata(false));
 
         /// <summary>
         /// Occurs when SwipeStatus has changed
@@ -165,7 +171,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         private CompositeTransform _rightCommandTransform;
         private DoubleAnimation _contentAnimation;
         private Storyboard _contentStoryboard;
-        private bool _justFinishedSwiping;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SlidableListItem"/> class.
@@ -196,7 +201,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         {
             if (_contentGrid != null)
             {
-                _contentGrid.PointerPressed -= ContentGrid_PointerPressed;
                 _contentGrid.PointerReleased -= ContentGrid_PointerReleased;
                 _contentGrid.ManipulationStarted -= ContentGrid_ManipulationStarted;
                 _contentGrid.ManipulationDelta -= ContentGrid_ManipulationDelta;
@@ -207,7 +211,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
             if (_contentGrid != null)
             {
-                _contentGrid.PointerPressed += ContentGrid_PointerPressed;
                 _contentGrid.PointerReleased += ContentGrid_PointerReleased;
 
                 _transform = _contentGrid.RenderTransform as CompositeTransform;
@@ -223,24 +226,16 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
                 _contentStoryboard = new Storyboard();
                 _contentStoryboard.Children.Add(_contentAnimation);
-
-                _justFinishedSwiping = false;
             }
 
             base.OnApplyTemplate();
         }
 
-        private void ContentGrid_PointerPressed(object sender, PointerRoutedEventArgs e)
-        {
-            _justFinishedSwiping = false;
-        }
-
         private void ContentGrid_PointerReleased(object sender, PointerRoutedEventArgs e)
         {
-            if (_justFinishedSwiping)
+            if (SwipeStatus != SwipeStatus.Idle && IsPointerReleasedOnSwipingHandled)
             {
                 e.Handled = true;
-                _justFinishedSwiping = false;
             }
         }
 
@@ -310,8 +305,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 LeftCommand?.Execute(LeftCommandParameter);
             }
 
-            SwipeStatus = SwipeStatus.Idle;
-            _justFinishedSwiping = true;
+            Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, () => { SwipeStatus = SwipeStatus.Idle; }).AsTask();
         }
 
         /// <summary>
@@ -687,6 +681,16 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                     SwipeStatusChanged?.Invoke(this, eventArguments);
                 }
             }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the PointerReleased event is handled when swiping.
+        /// Set this to <value>true</value> to prevent ItemClicked or selection to occur when swiping in a <see cref="ListView"/>
+        /// </summary>
+        public bool IsPointerReleasedOnSwipingHandled
+        {
+            get { return (bool)GetValue(IsPointerReleasedOnSwipingHandledProperty); }
+            set { SetValue(IsPointerReleasedOnSwipingHandledProperty, value); }
         }
     }
 }


### PR DESCRIPTION
and added

```csharp
Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, () => { SwipeStatus = SwipeStatus.Idle; }).AsTask();
```
to delay SwipeStatus changing to after PointerPressed firing

ref #316 