### PR TITLE
Fixed stop and completed event on AnimationSet

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Animations/AnimationSet.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Animations/AnimationSet.cs
@@ -164,6 +164,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
             tasks.Add(_storyboard.BeginAsync());
 
             await Task.WhenAll(tasks);
+            Completed?.Invoke(this, new EventArgs());
         }
 
         /// <summary>
@@ -196,7 +197,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
                 effect.EffectBrush.StopAnimation(effect.PropertyName);
             }
 
-            _storyboard.Stop();
+            _storyboard.Pause();
         }
 
         /// <summary>
@@ -505,7 +506,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
         private void Batch_Completed(object sender, CompositionBatchCompletedEventArgs args)
         {
             _manualResetEvent.Set();
-            Completed?.Invoke(this, new EventArgs());
         }
     }
 }


### PR DESCRIPTION
Stop now has the same behavior for composition and storyboards (pauses the animation).

Completed event was not firing when storyboards were used.

ref #392 