### PR TITLE
Fixed API Hyperlink in documentation

### DIFF
--- a/docs/animations/FadeHeader.md
+++ b/docs/animations/FadeHeader.md
@@ -98,6 +98,6 @@ Explicit usage:
 
 ## API
 
-* [FadeHeader source code](https://github.com/Microsoft/UWPCommunityToolkit/blob/master/Microsoft.Toolkit.Uwp.UI.Animations/Behaviors/FadeHeader.cs)
+* [FadeHeader source code](https://github.com/Microsoft/UWPCommunityToolkit/blob/master/Microsoft.Toolkit.Uwp.UI.Animations/Behaviors/FadeHeaderBehavior.cs)
 
 


### PR DESCRIPTION
The Source Code hyperlink under the API section of the documentation was incorrectly using the animation name instead of the class name. Fixed.

Credit: mad props to @RickHellwege for finding this, thanks!