### PR TITLE
CacheBase tweaks

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI/Cache/CacheBase.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Cache/CacheBase.cs
@@ -332,7 +332,7 @@ namespace Microsoft.Toolkit.Uwp.UI
         {
             if (file == null)
             {
-                return true;
+                return treatNullFileAsOutOfData;
             }
 
             var properties = await file.GetBasicPropertiesAsync().AsTask().ConfigureAwait(false);

--- a/Microsoft.Toolkit.Uwp.UI/Cache/CacheBase.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Cache/CacheBase.cs
@@ -121,7 +121,7 @@ namespace Microsoft.Toolkit.Uwp.UI
         /// </summary>
         /// <param name="duration">Optional timespan to compute whether file has expired or not. If no value is supplied, <see cref="CacheDuration"/> is used.</param>
         /// <returns>awaitable task</returns>
-        public async Task RemoveExpiredAsync(TimeSpan? duration)
+        public async Task RemoveExpiredAsync(TimeSpan? duration = null)
         {
             TimeSpan expiryDuration = duration.HasValue ? duration.Value : CacheDuration;
 

--- a/Microsoft.Toolkit.Uwp.UI/Cache/CacheBase.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Cache/CacheBase.cs
@@ -328,11 +328,11 @@ namespace Microsoft.Toolkit.Uwp.UI
             return instance;
         }
 
-        private async Task<bool> IsFileOutOfDate(StorageFile file, TimeSpan duration, bool treatNullFileAsOutOfData = true)
+        private async Task<bool> IsFileOutOfDate(StorageFile file, TimeSpan duration, bool treatNullFileAsOutOfDate = true)
         {
             if (file == null)
             {
-                return treatNullFileAsOutOfData;
+                return treatNullFileAsOutOfDate;
             }
 
             var properties = await file.GetBasicPropertiesAsync().AsTask().ConfigureAwait(false);


### PR DESCRIPTION
Added RemoveExpiredAsync
Use RemoveExpiredAsync when ClearAsync is called with Duration
Used Timespan rather than converting to DateTime. Pass TimeSpan all the way to IsFileOutOfDate method
Add optional parameter to IsFileOutOfDate method indicating how to treat null files.
Addresses #482