### PR TITLE
Remove useless awaits of BaseObjectStorageHelper

### DIFF
--- a/Microsoft.Toolkit.Uwp/Helpers/ObjectStorage/BaseObjectStorageHelper.cs
+++ b/Microsoft.Toolkit.Uwp/Helpers/ObjectStorage/BaseObjectStorageHelper.cs
@@ -79,9 +79,9 @@ namespace Microsoft.Toolkit.Uwp
         /// </summary>
         /// <param name="filePath">Key of the file (that contains object)</param>
         /// <returns>True if a value exists</returns>
-        public async Task<bool> FileExistsAsync(string filePath)
+        public Task<bool> FileExistsAsync(string filePath)
         {
-            return await Folder.IsFileExistsAsync(filePath);
+            return Folder.IsFileExistsAsync(filePath);
         }
 
         /// <summary>
@@ -105,9 +105,9 @@ namespace Microsoft.Toolkit.Uwp
         /// <param name="filePath">Path to the file that will contain the object</param>
         /// <param name="value">Object to save</param>
         /// <returns>Waiting task until completion</returns>
-        public async Task SaveFileAsync<T>(string filePath, T value)
+        public Task<StorageFile> SaveFileAsync<T>(string filePath, T value)
         {
-            await StorageFileHelper.WriteTextToFileAsync(Folder, JsonConvert.SerializeObject(value), filePath, CreationCollisionOption.ReplaceExisting);
+            return StorageFileHelper.WriteTextToFileAsync(Folder, JsonConvert.SerializeObject(value), filePath, CreationCollisionOption.ReplaceExisting);
         }
     }
 }

--- a/Microsoft.Toolkit.Uwp/Helpers/ObjectStorage/BaseObjectStorageHelper.cs
+++ b/Microsoft.Toolkit.Uwp/Helpers/ObjectStorage/BaseObjectStorageHelper.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Toolkit.Uwp
         /// <typeparam name="T">Type of object saved</typeparam>
         /// <param name="filePath">Path to the file that will contain the object</param>
         /// <param name="value">Object to save</param>
-        /// <returns>Waiting task until completion</returns>
+        /// <returns>When this method completes, it returns the <see cref="StorageFile"/> where the object was saved</returns>
         public Task<StorageFile> SaveFileAsync<T>(string filePath, T value)
         {
             return StorageFileHelper.WriteTextToFileAsync(Folder, JsonConvert.SerializeObject(value), filePath, CreationCollisionOption.ReplaceExisting);

--- a/Microsoft.Toolkit.Uwp/Helpers/ObjectStorage/IObjectStorageHelper.cs
+++ b/Microsoft.Toolkit.Uwp/Helpers/ObjectStorage/IObjectStorageHelper.cs
@@ -11,6 +11,7 @@
 // ******************************************************************
 
 using System.Threading.Tasks;
+using Windows.Storage;
 
 namespace Microsoft.Toolkit.Uwp
 {
@@ -66,6 +67,6 @@ namespace Microsoft.Toolkit.Uwp
         /// <param name="filePath">Path to the file that will contain the object</param>
         /// <param name="value">Object to save</param>
         /// <returns>Waiting task until completion</returns>
-        Task SaveFileAsync<T>(string filePath, T value);
+        Task<StorageFile> SaveFileAsync<T>(string filePath, T value);
     }
 }


### PR DESCRIPTION
To reduce the overhead, we should improve these two async tasks as well. @ScottIsAFool trained my eye to spot such things 👍 