### PR TITLE
Allow AdaptiveGrid to be used without setting ItemHeight, ItemWidth, or DesiredWidth properties.

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveGridView.Properties.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveGridView.Properties.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// </summary>
         public static readonly DependencyProperty ItemTemplateProperty =
             DependencyProperty.Register(nameof(ItemTemplate), typeof(DataTemplate), typeof(AdaptiveGridView), new PropertyMetadata(null));
-        
+
         /// <summary>
         /// Identifies the <see cref="ItemHeight"/> dependency property.
         /// </summary>

--- a/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveGridView.Properties.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveGridView.Properties.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// </summary>
         public static readonly DependencyProperty ItemTemplateProperty =
             DependencyProperty.Register(nameof(ItemTemplate), typeof(DataTemplate), typeof(AdaptiveGridView), new PropertyMetadata(null));
-
+        
         /// <summary>
         /// Identifies the <see cref="ItemHeight"/> dependency property.
         /// </summary>

--- a/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveGridView.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveGridView.cs
@@ -45,12 +45,14 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
         private void RecalculateLayout(double containerWidth)
         {
-            if (containerWidth == 0 || DesiredWidth == 0)
+            if (containerWidth == 0)
             {
                 return;
             }
 
-            _columns = CalculateColumns(containerWidth, DesiredWidth);
+            double desiredWidth = double.IsNaN(DesiredWidth) ? containerWidth : DesiredWidth;
+
+            _columns = CalculateColumns(containerWidth, desiredWidth);
 
             // If there's less items than there's columns, reduce the column count;
             if (_listView != null && _listView.Items != null


### PR DESCRIPTION
Addresses issue #479 

Set the `ItemHeight`, `ItemWidth` and `DesiredWidth` default values to double.NaN to allow the control to be used without setting those values. This will cause all the elements to align in a vertical fashion.

This allows the `AdaptiveGrid` control to be used without setting the above properties as such:
```
<controls:AdaptiveGrid ItemsSource="{Binding Items}" ItemTemplate="{StaticResource ItemTemplate}"/>
```