### PR TITLE
Set default values for ItemHeight, ItemWidth, and DesiredWidth

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveGridView.Properties.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveGridView.Properties.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// Identifies the <see cref="ItemHeight"/> dependency property.
         /// </summary>
         public static readonly DependencyProperty ItemHeightProperty =
-            DependencyProperty.Register(nameof(ItemHeight), typeof(double), typeof(AdaptiveGridView), new PropertyMetadata(0D));
+            DependencyProperty.Register(nameof(ItemHeight), typeof(double), typeof(AdaptiveGridView), new PropertyMetadata(double.NaN));
 
         /// <summary>
         /// Identifies the <see cref="OneRowModeEnabled"/> dependency property.
@@ -94,13 +94,13 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// Identifies the <see cref="ItemWidth"/> dependency property.
         /// </summary>
         private static readonly DependencyProperty ItemWidthProperty =
-            DependencyProperty.Register(nameof(ItemWidth), typeof(double), typeof(AdaptiveGridView), new PropertyMetadata(0D));
+            DependencyProperty.Register(nameof(ItemWidth), typeof(double), typeof(AdaptiveGridView), new PropertyMetadata(double.NaN));
 
         /// <summary>
         /// Identifies the <see cref="DesiredWidth"/> dependency property.
         /// </summary>
         public static readonly DependencyProperty DesiredWidthProperty =
-            DependencyProperty.Register(nameof(DesiredWidth), typeof(double), typeof(AdaptiveGridView), new PropertyMetadata(0D, DesiredWidthChanged));
+            DependencyProperty.Register(nameof(DesiredWidth), typeof(double), typeof(AdaptiveGridView), new PropertyMetadata(double.NaN, DesiredWidthChanged));
 
         private static void OnOneRowModeEnabledChanged(DependencyObject d, object newValue)
         {


### PR DESCRIPTION
Set default values for ItemHeight, ItemWidth, and DesiredWidth to double.NaN which allows the control to be used without setting these.

Final fixes for #479