### PR TITLE
Added a way to modify the Easing Function used in animations (issue #500)

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Animations/EasingType.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Animations/EasingType.cs
@@ -13,10 +13,15 @@
 namespace Microsoft.Toolkit.Uwp.UI.Animations
 {
     /// <summary>
-    /// InterpolationType is used to describe how the animation interpolates between keyframes.
+    /// EasingType is used to describe how the animation interpolates between keyframes.
     /// </summary>
-    public enum InterpolationType
+    public enum EasingType
     {
+        /// <summary>
+        /// Creates an animation that accelerates with the default EasingType which is specified in AnimationExtensions.DefaultEasingType which is by default Cubic.
+        /// </summary>
+        Default,
+
         /// <summary>
         /// Creates an animation that accelerates or decelerates linear.
         /// </summary>

--- a/Microsoft.Toolkit.Uwp.UI.Animations/Extensions/AnimationExtensions.Fade.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Animations/Extensions/AnimationExtensions.Fade.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
         /// <param name="value">The fade value, between 0 and 1.</param>
         /// <param name="duration">The duration in milliseconds.</param>
         /// <param name="delay">The delay. (ignored if duration == 0)</param>
+        /// <param name="interpolationType">Used to describe how the animation interpolates between keyframes.</param>
         /// <returns>
         /// An AnimationSet.
         /// </returns>
@@ -35,7 +36,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
             this UIElement associatedObject,
             float value = 0f,
             double duration = 500d,
-            double delay = 0d)
+            double delay = 0d,
+            InterpolationType interpolationType = InterpolationType.Cubic)
         {
             if (associatedObject == null)
             {
@@ -43,7 +45,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
             }
 
             var animationSet = new AnimationSet(associatedObject);
-            return animationSet.Fade(value, duration, delay);
+            return animationSet.Fade(value, duration, delay, interpolationType);
         }
 
         /// <summary>
@@ -53,6 +55,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
         /// <param name="value">The fade value, between 0 and 1.</param>
         /// <param name="duration">The duration in milliseconds.</param>
         /// <param name="delay">The delay. (ignored if duration == 0)</param>
+        /// <param name="interpolationType">Used to describe how the animation interpolates between keyframes.</param>
         /// <returns>
         /// An AnimationSet.
         /// </returns>
@@ -60,7 +63,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
             this AnimationSet animationSet,
             float value = 0f,
             double duration = 500d,
-            double delay = 0d)
+            double delay = 0d,
+            InterpolationType interpolationType = InterpolationType.Cubic)
         {
             if (animationSet == null)
             {
@@ -74,7 +78,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
                     To = value,
                     Duration = TimeSpan.FromMilliseconds(duration),
                     BeginTime = TimeSpan.FromMilliseconds(delay),
-                    EasingFunction = _defaultStoryboardEasingFunction
+                    EasingFunction = GetEasingFunction(interpolationType)
                 };
 
                 animationSet.AddStoryboardAnimation("Opacity", animation);

--- a/Microsoft.Toolkit.Uwp.UI.Animations/Extensions/AnimationExtensions.Fade.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Animations/Extensions/AnimationExtensions.Fade.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
         /// <param name="value">The fade value, between 0 and 1.</param>
         /// <param name="duration">The duration in milliseconds.</param>
         /// <param name="delay">The delay. (ignored if duration == 0)</param>
-        /// <param name="interpolationType">Used to describe how the animation interpolates between keyframes.</param>
+        /// <param name="easingType">Used to describe how the animation interpolates between keyframes.</param>
         /// <returns>
         /// An AnimationSet.
         /// </returns>
@@ -37,7 +37,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
             float value = 0f,
             double duration = 500d,
             double delay = 0d,
-            InterpolationType interpolationType = InterpolationType.Cubic)
+            EasingType easingType = EasingType.Default)
         {
             if (associatedObject == null)
             {
@@ -45,7 +45,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
             }
 
             var animationSet = new AnimationSet(associatedObject);
-            return animationSet.Fade(value, duration, delay, interpolationType);
+            return animationSet.Fade(value, duration, delay, easingType);
         }
 
         /// <summary>
@@ -55,7 +55,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
         /// <param name="value">The fade value, between 0 and 1.</param>
         /// <param name="duration">The duration in milliseconds.</param>
         /// <param name="delay">The delay. (ignored if duration == 0)</param>
-        /// <param name="interpolationType">Used to describe how the animation interpolates between keyframes.</param>
+        /// <param name="easingType">Used to describe how the animation interpolates between keyframes.</param>
         /// <returns>
         /// An AnimationSet.
         /// </returns>
@@ -64,7 +64,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
             float value = 0f,
             double duration = 500d,
             double delay = 0d,
-            InterpolationType interpolationType = InterpolationType.Cubic)
+            EasingType easingType = EasingType.Default)
         {
             if (animationSet == null)
             {
@@ -78,7 +78,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
                     To = value,
                     Duration = TimeSpan.FromMilliseconds(duration),
                     BeginTime = TimeSpan.FromMilliseconds(delay),
-                    EasingFunction = GetEasingFunction(interpolationType)
+                    EasingFunction = GetEasingFunction(easingType)
                 };
 
                 animationSet.AddStoryboardAnimation("Opacity", animation);

--- a/Microsoft.Toolkit.Uwp.UI.Animations/Extensions/AnimationExtensions.Offset.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Animations/Extensions/AnimationExtensions.Offset.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
         /// <param name="offsetY">The offset on the y axis.</param>
         /// <param name="duration">The duration in milliseconds.</param>
         /// <param name="delay">The delay in milliseconds. (ignored if duration == 0)</param>
+        /// <param name="interpolationType">Used to describe how the animation interpolates between keyframes.</param>
         /// <returns>
         /// An AnimationSet.
         /// </returns>
@@ -38,7 +39,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
             float offsetX = 0f,
             float offsetY = 0f,
             double duration = 500d,
-            double delay = 0d)
+            double delay = 0d,
+            InterpolationType interpolationType = InterpolationType.Cubic)
         {
             if (associatedObject == null)
             {
@@ -46,7 +48,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
             }
 
             var animationSet = new AnimationSet(associatedObject);
-            return animationSet.Offset(offsetX, offsetY, duration, delay);
+            return animationSet.Offset(offsetX, offsetY, duration, delay, interpolationType);
         }
 
         /// <summary>
@@ -57,6 +59,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
         /// <param name="offsetY">The offset on the y axis.</param>
         /// <param name="duration">The duration in milliseconds.</param>
         /// <param name="delay">The delay in milliseconds. (ignored if duration == 0)</param>
+        /// <param name="interpolationType">Used to describe how the animation interpolates between keyframes.</param>
         /// <returns>
         /// An AnimationSet.
         /// </returns>
@@ -65,7 +68,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
             float offsetX = 0f,
             float offsetY = 0f,
             double duration = 500d,
-            double delay = 0d)
+            double delay = 0d,
+            InterpolationType interpolationType = InterpolationType.Cubic)
         {
             if (animationSet == null)
             {
@@ -85,7 +89,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
 
                 animationX.Duration = animationY.Duration = TimeSpan.FromMilliseconds(duration);
                 animationX.BeginTime = animationY.BeginTime = TimeSpan.FromMilliseconds(delay);
-                animationX.EasingFunction = animationY.EasingFunction = _defaultStoryboardEasingFunction;
+                animationX.EasingFunction = animationY.EasingFunction = GetEasingFunction(interpolationType);
 
                 animationSet.AddStoryboardAnimation(GetAnimationPath(transform, element, "TranslateX"), animationX);
                 animationSet.AddStoryboardAnimation(GetAnimationPath(transform, element, "TranslateY"), animationY);

--- a/Microsoft.Toolkit.Uwp.UI.Animations/Extensions/AnimationExtensions.Offset.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Animations/Extensions/AnimationExtensions.Offset.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
         /// <param name="offsetY">The offset on the y axis.</param>
         /// <param name="duration">The duration in milliseconds.</param>
         /// <param name="delay">The delay in milliseconds. (ignored if duration == 0)</param>
-        /// <param name="interpolationType">Used to describe how the animation interpolates between keyframes.</param>
+        /// <param name="easingType">Used to describe how the animation interpolates between keyframes.</param>
         /// <returns>
         /// An AnimationSet.
         /// </returns>
@@ -40,7 +40,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
             float offsetY = 0f,
             double duration = 500d,
             double delay = 0d,
-            InterpolationType interpolationType = InterpolationType.Cubic)
+            EasingType easingType = EasingType.Default)
         {
             if (associatedObject == null)
             {
@@ -48,7 +48,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
             }
 
             var animationSet = new AnimationSet(associatedObject);
-            return animationSet.Offset(offsetX, offsetY, duration, delay, interpolationType);
+            return animationSet.Offset(offsetX, offsetY, duration, delay, easingType);
         }
 
         /// <summary>
@@ -59,7 +59,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
         /// <param name="offsetY">The offset on the y axis.</param>
         /// <param name="duration">The duration in milliseconds.</param>
         /// <param name="delay">The delay in milliseconds. (ignored if duration == 0)</param>
-        /// <param name="interpolationType">Used to describe how the animation interpolates between keyframes.</param>
+        /// <param name="easingType">Used to describe how the animation interpolates between keyframes.</param>
         /// <returns>
         /// An AnimationSet.
         /// </returns>
@@ -69,7 +69,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
             float offsetY = 0f,
             double duration = 500d,
             double delay = 0d,
-            InterpolationType interpolationType = InterpolationType.Cubic)
+            EasingType easingType = EasingType.Default)
         {
             if (animationSet == null)
             {
@@ -89,7 +89,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
 
                 animationX.Duration = animationY.Duration = TimeSpan.FromMilliseconds(duration);
                 animationX.BeginTime = animationY.BeginTime = TimeSpan.FromMilliseconds(delay);
-                animationX.EasingFunction = animationY.EasingFunction = GetEasingFunction(interpolationType);
+                animationX.EasingFunction = animationY.EasingFunction = GetEasingFunction(easingType);
 
                 animationSet.AddStoryboardAnimation(GetAnimationPath(transform, element, "TranslateX"), animationX);
                 animationSet.AddStoryboardAnimation(GetAnimationPath(transform, element, "TranslateY"), animationY);

--- a/Microsoft.Toolkit.Uwp.UI.Animations/Extensions/AnimationExtensions.Rotate.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Animations/Extensions/AnimationExtensions.Rotate.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
         /// <param name="centerY">The center y in pixels.</param>
         /// <param name="duration">The duration in milliseconds.</param>
         /// <param name="delay">The delay in milliseconds. (ignored if duration == 0)</param>
+        /// <param name="interpolationType">Used to describe how the animation interpolates between keyframes.</param>
         /// <returns>
         /// An AnimationSet.
         /// </returns>
@@ -40,7 +41,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
             float centerX = 0f,
             float centerY = 0f,
             double duration = 500d,
-            double delay = 0d)
+            double delay = 0d,
+            InterpolationType interpolationType = InterpolationType.Cubic)
         {
             if (associatedObject == null)
             {
@@ -48,7 +50,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
             }
 
             var animationSet = new AnimationSet(associatedObject);
-            return animationSet.Rotate(value, centerX, centerY, duration, delay);
+            return animationSet.Rotate(value, centerX, centerY, duration, delay, interpolationType);
         }
 
         /// <summary>
@@ -60,6 +62,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
         /// <param name="centerY">The center y in pixels.</param>
         /// <param name="duration">The duration in milliseconds.</param>
         /// <param name="delay">The delay in milliseconds. (ignored if duration == 0)</param>
+        /// <param name="interpolationType">Used to describe how the animation interpolates between keyframes.</param>
         /// <returns>
         /// An AnimationSet.
         /// </returns>
@@ -69,7 +72,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
             float centerX = 0f,
             float centerY = 0f,
             double duration = 500d,
-            double delay = 0d)
+            double delay = 0d,
+            InterpolationType interpolationType = InterpolationType.Cubic)
         {
             if (animationSet == null)
             {
@@ -89,7 +93,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
                     To = value,
                     Duration = TimeSpan.FromMilliseconds(duration),
                     BeginTime = TimeSpan.FromMilliseconds(delay),
-                    EasingFunction = _defaultStoryboardEasingFunction
+                    EasingFunction = GetEasingFunction(interpolationType)
                 };
 
                 animationSet.AddStoryboardAnimation(GetAnimationPath(transform, element, "Rotation"), animation);

--- a/Microsoft.Toolkit.Uwp.UI.Animations/Extensions/AnimationExtensions.Rotate.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Animations/Extensions/AnimationExtensions.Rotate.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
         /// <param name="centerY">The center y in pixels.</param>
         /// <param name="duration">The duration in milliseconds.</param>
         /// <param name="delay">The delay in milliseconds. (ignored if duration == 0)</param>
-        /// <param name="interpolationType">Used to describe how the animation interpolates between keyframes.</param>
+        /// <param name="easingType">Used to describe how the animation interpolates between keyframes.</param>
         /// <returns>
         /// An AnimationSet.
         /// </returns>
@@ -42,7 +42,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
             float centerY = 0f,
             double duration = 500d,
             double delay = 0d,
-            InterpolationType interpolationType = InterpolationType.Cubic)
+            EasingType easingType = EasingType.Default)
         {
             if (associatedObject == null)
             {
@@ -50,7 +50,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
             }
 
             var animationSet = new AnimationSet(associatedObject);
-            return animationSet.Rotate(value, centerX, centerY, duration, delay, interpolationType);
+            return animationSet.Rotate(value, centerX, centerY, duration, delay, easingType);
         }
 
         /// <summary>
@@ -62,7 +62,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
         /// <param name="centerY">The center y in pixels.</param>
         /// <param name="duration">The duration in milliseconds.</param>
         /// <param name="delay">The delay in milliseconds. (ignored if duration == 0)</param>
-        /// <param name="interpolationType">Used to describe how the animation interpolates between keyframes.</param>
+        /// <param name="easingType">Used to describe how the animation interpolates between keyframes.</param>
         /// <returns>
         /// An AnimationSet.
         /// </returns>
@@ -73,7 +73,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
             float centerY = 0f,
             double duration = 500d,
             double delay = 0d,
-            InterpolationType interpolationType = InterpolationType.Cubic)
+            EasingType easingType = EasingType.Default)
         {
             if (animationSet == null)
             {
@@ -93,7 +93,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
                     To = value,
                     Duration = TimeSpan.FromMilliseconds(duration),
                     BeginTime = TimeSpan.FromMilliseconds(delay),
-                    EasingFunction = GetEasingFunction(interpolationType)
+                    EasingFunction = GetEasingFunction(easingType)
                 };
 
                 animationSet.AddStoryboardAnimation(GetAnimationPath(transform, element, "Rotation"), animation);

--- a/Microsoft.Toolkit.Uwp.UI.Animations/Extensions/AnimationExtensions.Scale.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Animations/Extensions/AnimationExtensions.Scale.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
         /// <param name="centerY">The center y in pixels.</param>
         /// <param name="duration">The duration in millisecond.</param>
         /// <param name="delay">The delay in milliseconds. (ignored if duration == 0)</param>
-        /// <param name="interpolationType">Used to describe how the animation interpolates between keyframes.</param>
+        /// <param name="easingType">Used to describe how the animation interpolates between keyframes.</param>
         /// <returns>
         /// An AnimationSet.
         /// </returns>
@@ -44,7 +44,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
             float centerY = 0f,
             double duration = 500d,
             double delay = 0d,
-            InterpolationType interpolationType = InterpolationType.Cubic)
+            EasingType easingType = EasingType.Default)
         {
             if (associatedObject == null)
             {
@@ -52,7 +52,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
             }
 
             var animationSet = new AnimationSet(associatedObject);
-            return animationSet.Scale(scaleX, scaleY, centerX, centerY, duration, delay, interpolationType);
+            return animationSet.Scale(scaleX, scaleY, centerX, centerY, duration, delay, easingType);
         }
 
         /// <summary>
@@ -65,7 +65,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
         /// <param name="centerY">The center y in pixels.</param>
         /// <param name="duration">The duration in milliseconds.</param>
         /// <param name="delay">The delay in milliseconds. (ignored if duration == 0)</param>
-        /// <param name="interpolationType">Used to describe how the animation interpolates between keyframes.</param>
+        /// <param name="easingType">Used to describe how the animation interpolates between keyframes.</param>
         /// <returns>
         /// An AnimationSet.
         /// </returns>
@@ -77,7 +77,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
             float centerY = 0f,
             double duration = 500d,
             double delay = 0d,
-            InterpolationType interpolationType = InterpolationType.Cubic)
+            EasingType easingType = EasingType.Default)
         {
             if (animationSet == null)
             {
@@ -100,7 +100,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
 
                 animationX.Duration = animationY.Duration = TimeSpan.FromMilliseconds(duration);
                 animationX.BeginTime = animationY.BeginTime = TimeSpan.FromMilliseconds(delay);
-                animationX.EasingFunction = animationY.EasingFunction = GetEasingFunction(interpolationType);
+                animationX.EasingFunction = animationY.EasingFunction = GetEasingFunction(easingType);
 
                 animationSet.AddStoryboardAnimation(GetAnimationPath(transform, element, "ScaleX"), animationX);
                 animationSet.AddStoryboardAnimation(GetAnimationPath(transform, element, "ScaleY"), animationY);

--- a/Microsoft.Toolkit.Uwp.UI.Animations/Extensions/AnimationExtensions.Scale.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Animations/Extensions/AnimationExtensions.Scale.cs
@@ -32,6 +32,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
         /// <param name="centerY">The center y in pixels.</param>
         /// <param name="duration">The duration in millisecond.</param>
         /// <param name="delay">The delay in milliseconds. (ignored if duration == 0)</param>
+        /// <param name="interpolationType">Used to describe how the animation interpolates between keyframes.</param>
         /// <returns>
         /// An AnimationSet.
         /// </returns>
@@ -42,7 +43,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
             float centerX = 0f,
             float centerY = 0f,
             double duration = 500d,
-            double delay = 0d)
+            double delay = 0d,
+            InterpolationType interpolationType = InterpolationType.Cubic)
         {
             if (associatedObject == null)
             {
@@ -50,7 +52,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
             }
 
             var animationSet = new AnimationSet(associatedObject);
-            return animationSet.Scale(scaleX, scaleY, centerX, centerY, duration, delay);
+            return animationSet.Scale(scaleX, scaleY, centerX, centerY, duration, delay, interpolationType);
         }
 
         /// <summary>
@@ -63,6 +65,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
         /// <param name="centerY">The center y in pixels.</param>
         /// <param name="duration">The duration in milliseconds.</param>
         /// <param name="delay">The delay in milliseconds. (ignored if duration == 0)</param>
+        /// <param name="interpolationType">Used to describe how the animation interpolates between keyframes.</param>
         /// <returns>
         /// An AnimationSet.
         /// </returns>
@@ -73,7 +76,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
             float centerX = 0f,
             float centerY = 0f,
             double duration = 500d,
-            double delay = 0d)
+            double delay = 0d,
+            InterpolationType interpolationType = InterpolationType.Cubic)
         {
             if (animationSet == null)
             {
@@ -96,7 +100,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
 
                 animationX.Duration = animationY.Duration = TimeSpan.FromMilliseconds(duration);
                 animationX.BeginTime = animationY.BeginTime = TimeSpan.FromMilliseconds(delay);
-                animationX.EasingFunction = animationY.EasingFunction = _defaultStoryboardEasingFunction;
+                animationX.EasingFunction = animationY.EasingFunction = GetEasingFunction(interpolationType);
 
                 animationSet.AddStoryboardAnimation(GetAnimationPath(transform, element, "ScaleX"), animationX);
                 animationSet.AddStoryboardAnimation(GetAnimationPath(transform, element, "ScaleY"), animationY);

--- a/Microsoft.Toolkit.Uwp.UI.Animations/Extensions/AnimationExtensions.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Animations/Extensions/AnimationExtensions.cs
@@ -23,7 +23,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
     /// </summary>
     public static partial class AnimationExtensions
     {
-        private static readonly EasingFunctionBase _defaultStoryboardEasingFunction = new CubicEase();
 
         /// <summary>
         /// Begins a Storyboard animation and returns a task that completes when the
@@ -132,6 +131,35 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
             }
 
             return result;
+        }
+
+        private static EasingFunctionBase GetEasingFunction(InterpolationType interpolationType)
+        {
+            switch (interpolationType)
+            {
+                case InterpolationType.Linear:
+                    return null;
+                case InterpolationType.Cubic:
+                    return new CubicEase();
+                case InterpolationType.Back:
+                    return new BackEase();
+                case InterpolationType.Bounce:
+                    return new BounceEase();
+                case InterpolationType.Elastic:
+                    return new ElasticEase();
+                case InterpolationType.Circle:
+                    return new CircleEase();
+                case InterpolationType.Quadratic:
+                    return new QuadraticEase();
+                case InterpolationType.Quartic:
+                    return new QuarticEase();
+                case InterpolationType.Quintic:
+                    return new QuinticEase();
+                case InterpolationType.Sine:
+                    return new SineEase();
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(interpolationType), interpolationType, null);
+            }
         }
     }
 }

--- a/Microsoft.Toolkit.Uwp.UI.Animations/Extensions/AnimationExtensions.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Animations/Extensions/AnimationExtensions.cs
@@ -23,6 +23,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
     /// </summary>
     public static partial class AnimationExtensions
     {
+        /// <summary>
+        /// Gets or sets the default EasingType used for storyboard animations
+        /// </summary>
+        public static EasingType DefaultEasingType { get; set; } = EasingType.Cubic;
 
         /// <summary>
         /// Begins a Storyboard animation and returns a task that completes when the
@@ -44,6 +48,45 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
             storyboard.Begin();
 
             return taskSource.Task;
+        }
+
+        /// <summary>
+        /// Gets the EasingFunction from EasingType
+        /// </summary>
+        /// <param name="easingType">The EasingType used to determine the EasingFunction</param>
+        /// <returns>Return the appropriate EasingFuntion or null if the EasingType is Linear</returns>
+        public static EasingFunctionBase GetEasingFunction(EasingType easingType)
+        {
+            if (easingType == EasingType.Default)
+            {
+                easingType = DefaultEasingType;
+            }
+
+            switch (easingType)
+            {
+                case EasingType.Linear:
+                    return null;
+                case EasingType.Cubic:
+                    return new CubicEase();
+                case EasingType.Back:
+                    return new BackEase();
+                case EasingType.Bounce:
+                    return new BounceEase();
+                case EasingType.Elastic:
+                    return new ElasticEase();
+                case EasingType.Circle:
+                    return new CircleEase();
+                case EasingType.Quadratic:
+                    return new QuadraticEase();
+                case EasingType.Quartic:
+                    return new QuarticEase();
+                case EasingType.Quintic:
+                    return new QuinticEase();
+                case EasingType.Sine:
+                    return new SineEase();
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(easingType),easingType,null);
+            }
         }
 
         private static string GetAnimationPath(CompositeTransform transform, UIElement element, string property)
@@ -131,35 +174,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
             }
 
             return result;
-        }
-
-        private static EasingFunctionBase GetEasingFunction(InterpolationType interpolationType)
-        {
-            switch (interpolationType)
-            {
-                case InterpolationType.Linear:
-                    return null;
-                case InterpolationType.Cubic:
-                    return new CubicEase();
-                case InterpolationType.Back:
-                    return new BackEase();
-                case InterpolationType.Bounce:
-                    return new BounceEase();
-                case InterpolationType.Elastic:
-                    return new ElasticEase();
-                case InterpolationType.Circle:
-                    return new CircleEase();
-                case InterpolationType.Quadratic:
-                    return new QuadraticEase();
-                case InterpolationType.Quartic:
-                    return new QuarticEase();
-                case InterpolationType.Quintic:
-                    return new QuinticEase();
-                case InterpolationType.Sine:
-                    return new SineEase();
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(interpolationType), interpolationType, null);
-            }
         }
     }
 }

--- a/Microsoft.Toolkit.Uwp.UI.Animations/InterpolationType.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Animations/InterpolationType.cs
@@ -1,0 +1,58 @@
+﻿namespace Microsoft.Toolkit.Uwp.UI.Animations
+{
+    /// <summary>
+    /// InterpolationType is used to describe how the animation interpolates between keyframes.
+    /// </summary>
+    public enum InterpolationType
+    {
+        /// <summary>
+        /// Creates an animation that accelerates or decelerates linear.
+        /// </summary>
+        Linear,
+
+        /// <summary>
+        /// Creates an animation that accelerates or decelerates using the formula f(t) = t3.
+        /// </summary>
+        Cubic,
+
+        /// <summary>
+        /// Retracts the motion of an animation slightly before it begins to animate in the path indicated.
+        /// </summary>
+        Back,
+
+        /// <summary>
+        /// Creates a bouncing effect.
+        /// </summary>
+        Bounce,
+
+        /// <summary>
+        /// Creates an animation that resembles a spring oscillating back and forth until it comes to rest.
+        /// </summary>
+        Elastic,
+
+        /// <summary>
+        ///  Creates an animation that accelerates or decelerates using a circular function.
+        /// </summary>
+        Circle,
+
+        /// <summary>
+        /// Creates an animation that accelerates or decelerates using the formula f(t) = t2.
+        /// </summary>
+        Quadratic,
+
+        /// <summary>
+        /// Creates an animation that accelerates or decelerates using the formula f(t) = t4.
+        /// </summary>
+        Quartic,
+
+        /// <summary>
+        /// Create an animation that accelerates or decelerates using the formula f(t) = t5.
+        /// </summary>
+        Quintic,
+
+        /// <summary>
+        ///  Creates an animation that accelerates or decelerates using a sine formula.
+        /// </summary>
+        Sine
+    }
+}

--- a/Microsoft.Toolkit.Uwp.UI.Animations/InterpolationType.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Animations/InterpolationType.cs
@@ -1,4 +1,16 @@
-﻿namespace Microsoft.Toolkit.Uwp.UI.Animations
+﻿// ******************************************************************
+// Copyright (c) Microsoft. All rights reserved.
+// This code is licensed under the MIT License (MIT).
+// THE CODE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH
+// THE CODE OR THE USE OR OTHER DEALINGS IN THE CODE.
+// ******************************************************************
+
+namespace Microsoft.Toolkit.Uwp.UI.Animations
 {
     /// <summary>
     /// InterpolationType is used to describe how the animation interpolates between keyframes.

--- a/Microsoft.Toolkit.Uwp.UI.Animations/Microsoft.Toolkit.Uwp.UI.Animations.csproj
+++ b/Microsoft.Toolkit.Uwp.UI.Animations/Microsoft.Toolkit.Uwp.UI.Animations.csproj
@@ -58,6 +58,7 @@
     <Compile Include="AnimationSet.cs" />
     <Compile Include="EffectAnimationDefinition.cs" />
     <Compile Include="EffectDirectPropertyChangeDefinition.cs" />
+    <Compile Include="InterpolationType.cs" />
     <Compile Include="Extensions\AnimationExtensions.Blur.cs" />
     <Compile Include="Extensions\AnimationExtensions.cs" />
     <Compile Include="Extensions\AnimationExtensions.Fade.cs" />

--- a/Microsoft.Toolkit.Uwp.UI.Animations/Microsoft.Toolkit.Uwp.UI.Animations.csproj
+++ b/Microsoft.Toolkit.Uwp.UI.Animations/Microsoft.Toolkit.Uwp.UI.Animations.csproj
@@ -58,7 +58,7 @@
     <Compile Include="AnimationSet.cs" />
     <Compile Include="EffectAnimationDefinition.cs" />
     <Compile Include="EffectDirectPropertyChangeDefinition.cs" />
-    <Compile Include="InterpolationType.cs" />
+    <Compile Include="EasingType.cs" />
     <Compile Include="Extensions\AnimationExtensions.Blur.cs" />
     <Compile Include="Extensions\AnimationExtensions.cs" />
     <Compile Include="Extensions\AnimationExtensions.Fade.cs" />

--- a/docs/animations/Fade.md
+++ b/docs/animations/Fade.md
@@ -42,12 +42,13 @@ Behavior animations can also be chained and awaited.
 
 [Fade Behavior Sample Page Source](https://github.com/Microsoft/UWPCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Fade)
 
-## InterpolationType
+## EasingType
 
-You can change the way how the animation interpolates between keyframes by defining the InterpolationType using an optional parameter. The default is **Cubic**.
+You can change the way how the animation interpolates between keyframes by defining the EasingType using an optional parameter.
 
-| InterpolationType | Explanation|
+| EasingType | Explanation|
 | --- | --- |
+| Default | Creates an animation that accelerates with the default EasingType which is specified in AnimationExtensions.DefaultEasingType which is by default Cubic. |
 | Linear | Creates an animation that accelerates or decelerates linear. |
 | Cubic | Creates an animation that accelerates or decelerates using the formula f(t) = t3. |
 | Back | Retracts the motion of an animation slightly before it begins to animate in the path indicated. |
@@ -61,7 +62,7 @@ You can change the way how the animation interpolates between keyframes by defin
 
 **Example Usage:**
 ```csharp
-MyRectangle.Fade(value: 10, duration: 10, delay: 0, interpolationType: InterpolationType.Bounce);       
+MyRectangle.Fade(value: 10, duration: 10, delay: 0, easingType: EasingType.Bounce);       
 ```
 
 ## Example Image

--- a/docs/animations/Fade.md
+++ b/docs/animations/Fade.md
@@ -42,6 +42,28 @@ Behavior animations can also be chained and awaited.
 
 [Fade Behavior Sample Page Source](https://github.com/Microsoft/UWPCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Fade)
 
+## InterpolationType
+
+You can change the way how the animation interpolates between keyframes by defining the InterpolationType using an optional parameter. The default is **Cubic**.
+
+| InterpolationType | Explanation|
+| --- | --- |
+| Linear | Creates an animation that accelerates or decelerates linear. |
+| Cubic | Creates an animation that accelerates or decelerates using the formula f(t) = t3. |
+| Back | Retracts the motion of an animation slightly before it begins to animate in the path indicated. |
+| Bounce | Creates a bouncing effect. |
+| Elastic | Creates an animation that resembles a spring oscillating back and forth until it comes to rest.|
+| Circle | Creates an animation that accelerates or decelerates using a circular function. |
+| Quadratic | Creates an animation that accelerates or decelerates using the formula f(t) = t2. |
+| Quartic | Creates an animation that accelerates or decelerates using the formula f(t) = t4. |
+| Quintic | Create an animation that accelerates or decelerates using the formula f(t) = t5. |
+| Sine | Creates an animation that accelerates or decelerates using a sine formula. |
+
+**Example Usage:**
+```csharp
+MyRectangle.Fade(value: 10, duration: 10, delay: 0, interpolationType: InterpolationType.Bounce);       
+```
+
 ## Example Image
 
 ![Fade Behavior animation](../resources/images/Animations-Fade.gif "Fade Behavior")

--- a/docs/animations/Offset.md
+++ b/docs/animations/Offset.md
@@ -47,12 +47,13 @@ Behavior animations can also be chained and awaited.
 
 [Offset Behavior Sample Page Source](https://github.com/Microsoft/UWPCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Offset)
 
-## InterpolationType
+## EasingType
 
-You can change the way how the animation interpolates between keyframes by defining the InterpolationType using an optional parameter. The default is **Cubic**.
+You can change the way how the animation interpolates between keyframes by defining the EasingType using an optional parameter.
 
-| InterpolationType | Explanation|
+| EasingType | Explanation|
 | --- | --- |
+| Default | Creates an animation that accelerates with the default EasingType which is specified in AnimationExtensions.DefaultEasingType which is by default Cubic. |
 | Linear | Creates an animation that accelerates or decelerates linear. |
 | Cubic | Creates an animation that accelerates or decelerates using the formula f(t) = t3. |
 | Back | Retracts the motion of an animation slightly before it begins to animate in the path indicated. |
@@ -66,7 +67,7 @@ You can change the way how the animation interpolates between keyframes by defin
 
 **Example Usage:**
 ```csharp
-MyRectangle.Offset(offsetX: 10, offsetY: 10, duration: 10, delay: 0, interpolationType: InterpolationType.Bounce);       
+MyRectangle.Offset(offsetX: 10, offsetY: 10, duration: 10, delay: 0, easingType: EasingType.Bounce);       
 ```
 
 ## Example Image

--- a/docs/animations/Offset.md
+++ b/docs/animations/Offset.md
@@ -47,6 +47,28 @@ Behavior animations can also be chained and awaited.
 
 [Offset Behavior Sample Page Source](https://github.com/Microsoft/UWPCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Offset)
 
+## InterpolationType
+
+You can change the way how the animation interpolates between keyframes by defining the InterpolationType using an optional parameter. The default is **Cubic**.
+
+| InterpolationType | Explanation|
+| --- | --- |
+| Linear | Creates an animation that accelerates or decelerates linear. |
+| Cubic | Creates an animation that accelerates or decelerates using the formula f(t) = t3. |
+| Back | Retracts the motion of an animation slightly before it begins to animate in the path indicated. |
+| Bounce | Creates a bouncing effect. |
+| Elastic | Creates an animation that resembles a spring oscillating back and forth until it comes to rest.|
+| Circle | Creates an animation that accelerates or decelerates using a circular function. |
+| Quadratic | Creates an animation that accelerates or decelerates using the formula f(t) = t2. |
+| Quartic | Creates an animation that accelerates or decelerates using the formula f(t) = t4. |
+| Quintic | Create an animation that accelerates or decelerates using the formula f(t) = t5. |
+| Sine | Creates an animation that accelerates or decelerates using a sine formula. |
+
+**Example Usage:**
+```csharp
+MyRectangle.Offset(offsetX: 10, offsetY: 10, duration: 10, delay: 0, interpolationType: InterpolationType.Bounce);       
+```
+
 ## Example Image
 
 ![Offset Behavior animation](../resources/images/Animations-Offset.gif "Offset Behavior")

--- a/docs/animations/Rotate.md
+++ b/docs/animations/Rotate.md
@@ -49,6 +49,28 @@ Behavior animations can also be chained and awaited.
 
 [Rotate Behavior Sample Page Source](https://github.com/Microsoft/UWPCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Rotate)
 
+## InterpolationType
+
+You can change the way how the animation interpolates between keyframes by defining the InterpolationType using an optional parameter. The default is **Cubic**.
+
+| InterpolationType | Explanation|
+| --- | --- |
+| Linear | Creates an animation that accelerates or decelerates linear. |
+| Cubic | Creates an animation that accelerates or decelerates using the formula f(t) = t3. |
+| Back | Retracts the motion of an animation slightly before it begins to animate in the path indicated. |
+| Bounce | Creates a bouncing effect. |
+| Elastic | Creates an animation that resembles a spring oscillating back and forth until it comes to rest.|
+| Circle | Creates an animation that accelerates or decelerates using a circular function. |
+| Quadratic | Creates an animation that accelerates or decelerates using the formula f(t) = t2. |
+| Quartic | Creates an animation that accelerates or decelerates using the formula f(t) = t4. |
+| Quintic | Create an animation that accelerates or decelerates using the formula f(t) = t5. |
+| Sine | Creates an animation that accelerates or decelerates using a sine formula. |
+
+**Example Usage:**
+```csharp
+MyRectangle.Offset(value: 10, duration: 10, delay: 0, interpolationType: InterpolationType.Bounce);       
+```
+
 ## Example Image
 
 ![Rotate Behavior animation](../resources/images/Animations-Rotate.gif "Rotate Behavior")

--- a/docs/animations/Rotate.md
+++ b/docs/animations/Rotate.md
@@ -49,12 +49,13 @@ Behavior animations can also be chained and awaited.
 
 [Rotate Behavior Sample Page Source](https://github.com/Microsoft/UWPCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Rotate)
 
-## InterpolationType
+## EasingType
 
-You can change the way how the animation interpolates between keyframes by defining the InterpolationType using an optional parameter. The default is **Cubic**.
+You can change the way how the animation interpolates between keyframes by defining the EasingType using an optional parameter.
 
-| InterpolationType | Explanation|
+| EasingType | Explanation|
 | --- | --- |
+| Default | Creates an animation that accelerates with the default EasingType which is specified in AnimationExtensions.DefaultEasingType which is by default Cubic. |
 | Linear | Creates an animation that accelerates or decelerates linear. |
 | Cubic | Creates an animation that accelerates or decelerates using the formula f(t) = t3. |
 | Back | Retracts the motion of an animation slightly before it begins to animate in the path indicated. |
@@ -68,7 +69,7 @@ You can change the way how the animation interpolates between keyframes by defin
 
 **Example Usage:**
 ```csharp
-MyRectangle.Offset(value: 10, duration: 10, delay: 0, interpolationType: InterpolationType.Bounce);       
+MyRectangle.Offset(value: 10, duration: 10, delay: 0, easingType: EasingType.Bounce);       
 ```
 
 ## Example Image

--- a/docs/animations/Scale.md
+++ b/docs/animations/Scale.md
@@ -52,12 +52,13 @@ Behaviors can also be chained and awaited.
 
 [Scale Behavior Sample Page Source](https://github.com/Microsoft/UWPCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Scale)
 
-## InterpolationType
+## EasingType
 
-You can change the way how the animation interpolates between keyframes by defining the InterpolationType using an optional parameter. The default is **Cubic**.
+You can change the way how the animation interpolates between keyframes by defining the EasingType using an optional parameter.
 
-| InterpolationType | Explanation|
+| EasingType | Explanation|
 | --- | --- |
+| Default | Creates an animation that accelerates with the default EasingType which is specified in AnimationExtensions.DefaultEasingType which is by default Cubic. |
 | Linear | Creates an animation that accelerates or decelerates linear. |
 | Cubic | Creates an animation that accelerates or decelerates using the formula f(t) = t3. |
 | Back | Retracts the motion of an animation slightly before it begins to animate in the path indicated. |
@@ -71,7 +72,7 @@ You can change the way how the animation interpolates between keyframes by defin
 
 **Example Usage:**
 ```csharp
-MyRectangle.Offset(value: 10, duration: 10, delay: 0, interpolationType: InterpolationType.Bounce);       
+MyRectangle.Offset(value: 10, duration: 10, delay: 0, easingType: EasingType.Bounce);       
 ```
 
 ## Example Image

--- a/docs/animations/Scale.md
+++ b/docs/animations/Scale.md
@@ -52,6 +52,28 @@ Behaviors can also be chained and awaited.
 
 [Scale Behavior Sample Page Source](https://github.com/Microsoft/UWPCommunityToolkit/tree/master/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Scale)
 
+## InterpolationType
+
+You can change the way how the animation interpolates between keyframes by defining the InterpolationType using an optional parameter. The default is **Cubic**.
+
+| InterpolationType | Explanation|
+| --- | --- |
+| Linear | Creates an animation that accelerates or decelerates linear. |
+| Cubic | Creates an animation that accelerates or decelerates using the formula f(t) = t3. |
+| Back | Retracts the motion of an animation slightly before it begins to animate in the path indicated. |
+| Bounce | Creates a bouncing effect. |
+| Elastic | Creates an animation that resembles a spring oscillating back and forth until it comes to rest.|
+| Circle | Creates an animation that accelerates or decelerates using a circular function. |
+| Quadratic | Creates an animation that accelerates or decelerates using the formula f(t) = t2. |
+| Quartic | Creates an animation that accelerates or decelerates using the formula f(t) = t4. |
+| Quintic | Create an animation that accelerates or decelerates using the formula f(t) = t5. |
+| Sine | Creates an animation that accelerates or decelerates using a sine formula. |
+
+**Example Usage:**
+```csharp
+MyRectangle.Offset(value: 10, duration: 10, delay: 0, interpolationType: InterpolationType.Bounce);       
+```
+
 ## Example Image
 
 ![Scale Behavior animation](../resources/images/Animations-Scale.gif "Scale Behavior")


### PR DESCRIPTION
This commit adds a way to modify the easing function used in animations using an optional enum type which is named "InterpolationType" (See issue #500). I tried to document the things right but I don't have much experience in documenting. So please be considerate. I only documented in code with the xml-tags. I hope that someone else can make the proper documentation in (https://github.com/Microsoft/UWPCommunityToolkit/tree/dev/docs) and modify the UWP Toolkit Samples app to show off the different easing functions.

Info: https://msdn.microsoft.com/en-us/windows/uwp/graphics/composition-animation#easing-functions
