### PR TITLE
Use correct InitializeTypeAsync overload in GetFromCacheOrDownloadAsync

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI/Cache/CacheBase.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Cache/CacheBase.cs
@@ -285,10 +285,7 @@ namespace Microsoft.Toolkit.Uwp.UI
 
             if (EqualityComparer<T>.Default.Equals(instance, default(T)) && !preCacheOnly)
             {
-                using (var fileStream = await baseFile.OpenAsync(FileAccessMode.Read).AsTask().ConfigureAwait(MaintainContext))
-                {
-                    instance = await InitializeTypeAsync(fileStream).ConfigureAwait(false);
-                }
+                instance = await InitializeTypeAsync(baseFile).ConfigureAwait(false);
 
                 if (_inMemoryFileStorage.MaxItemCount > 0)
                 {


### PR DESCRIPTION
When a valid file exists in cache, the CacheBase should use the InitializeTypeAsync overload that takes StorageFile. It currently forces the use of Stream version and that does not work when FileCache is used.