### PR TITLE
enabled paging support for fb service requests

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Facebook Service/FacebookCode.bind
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Facebook Service/FacebookCode.bind
@@ -23,7 +23,7 @@ await FacebookService.Instance.PostToFeedWithDialogAsync(TitleText.Text, Descrip
 await FacebookService.Instance.PostPictureToFeedAsync(TitleText.Text, picture.Name, stream);
 
 // Get current user's photo albums
-await FacebookService.Instance.GetUserAlbumsAsync();
+await FacebookService.Instance.GetUserAlbumsAsync(20, FacebookAlbum.Fields);
 
 // Get current user's photos by album Id
-await FacebookService.Instance.GetUserPhotosByAlbumIdAsync(album.Id);
+await FacebookService.Instance.GetUserPhotosByAlbumIdAsync(addedItem.Id, 20, FacebookPhoto.Fields);

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Facebook Service/FacebookCode.bind
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Facebook Service/FacebookCode.bind
@@ -23,7 +23,7 @@ await FacebookService.Instance.PostToFeedWithDialogAsync(TitleText.Text, Descrip
 await FacebookService.Instance.PostPictureToFeedAsync(TitleText.Text, picture.Name, stream);
 
 // Get current user's photo albums
-await FacebookService.Instance.GetUserAlbumsAsync(20, FacebookAlbum.Fields);
+await FacebookService.Instance.GetUserAlbumsAsync();
 
 // Get current user's photos by album Id
-await FacebookService.Instance.GetUserPhotosByAlbumIdAsync(addedItem.Id, 20, FacebookPhoto.Fields);
+await FacebookService.Instance.GetUserPhotosByAlbumIdAsync(addedItem.Id);

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Facebook Service/FacebookPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Facebook Service/FacebookPage.xaml.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
 
             if (QueryType.SelectedIndex == 3)
             {
-                PhotoGridView.ItemsSource = await FacebookService.Instance.GetUserAlbumsAsync(20, FacebookAlbum.Fields);
+                PhotoGridView.ItemsSource = await FacebookService.Instance.GetUserAlbumsAsync();
                 ShareBox.Visibility = Visibility.Collapsed;
                 PhotoBox.Visibility = Visibility.Visible;
                 HidePostPanel();
@@ -215,7 +215,7 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
 
             if (addedItem != null)
             {
-                PhotoGridView.ItemsSource = await FacebookService.Instance.GetUserPhotosByAlbumIdAsync(addedItem.Id, 20, FacebookPhoto.Fields);
+                PhotoGridView.ItemsSource = await FacebookService.Instance.GetUserPhotosByAlbumIdAsync(addedItem.Id);
             }
 
             Shell.Current.DisplayWaitRing = false;

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Facebook Service/FacebookPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Facebook Service/FacebookPage.xaml.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
 
             if (QueryType.SelectedIndex == 3)
             {
-                PhotoGridView.ItemsSource = await FacebookService.Instance.GetUserAlbumsAsync();
+                PhotoGridView.ItemsSource = await FacebookService.Instance.GetUserAlbumsAsync(20, FacebookAlbum.Fields);
                 ShareBox.Visibility = Visibility.Collapsed;
                 PhotoBox.Visibility = Visibility.Visible;
                 HidePostPanel();
@@ -215,7 +215,7 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
 
             if (addedItem != null)
             {
-                PhotoGridView.ItemsSource = await FacebookService.Instance.GetUserPhotosByAlbumIdAsync(addedItem.Id);
+                PhotoGridView.ItemsSource = await FacebookService.Instance.GetUserPhotosByAlbumIdAsync(addedItem.Id, 20, FacebookPhoto.Fields);
             }
 
             Shell.Current.DisplayWaitRing = false;

--- a/Microsoft.Toolkit.Uwp.Services/Microsoft.Toolkit.Uwp.Services.csproj
+++ b/Microsoft.Toolkit.Uwp.Services/Microsoft.Toolkit.Uwp.Services.csproj
@@ -61,6 +61,7 @@
     <Compile Include="Services\Bing\BingService.cs" />
     <Compile Include="Services\Facebook\FacebookAlbum.cs" />
     <Compile Include="Services\Facebook\FacebookOAuthTokens.cs" />
+    <Compile Include="Services\Facebook\FacebookRequestSource.cs" />
     <Compile Include="Services\LinkedIn\LinkedInConstants.cs" />
     <Compile Include="Services\LinkedIn\LinkedInContent.cs" />
     <Compile Include="Services\LinkedIn\LinkedInDataConfig.cs" />

--- a/Microsoft.Toolkit.Uwp.Services/Services/Facebook/FacebookPost.cs
+++ b/Microsoft.Toolkit.Uwp.Services/Services/Facebook/FacebookPost.cs
@@ -20,6 +20,11 @@ namespace Microsoft.Toolkit.Uwp.Services.Facebook
     public class FacebookPost
     {
         /// <summary>
+        /// Gets a string description of the strongly typed properties in this model.
+        /// </summary>
+        public static string Fields => "id, message, created_time, link, full_picture";
+
+        /// <summary>
         /// Gets or sets id property.
         /// </summary>
         public string Id { get; set; }

--- a/Microsoft.Toolkit.Uwp.Services/Services/Facebook/FacebookRequestSource.cs
+++ b/Microsoft.Toolkit.Uwp.Services/Services/Facebook/FacebookRequestSource.cs
@@ -1,4 +1,16 @@
-﻿using System;
+﻿// ******************************************************************
+// Copyright (c) Microsoft. All rights reserved.
+// This code is licensed under the MIT License (MIT).
+// THE CODE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH
+// THE CODE OR THE USE OR OTHER DEALINGS IN THE CODE.
+// ******************************************************************
+
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;

--- a/Microsoft.Toolkit.Uwp.Services/Services/Facebook/FacebookRequestSource.cs
+++ b/Microsoft.Toolkit.Uwp.Services/Services/Facebook/FacebookRequestSource.cs
@@ -1,0 +1,117 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Windows.Foundation.Collections;
+using winsdkfb;
+using winsdkfb.Graph;
+
+namespace Microsoft.Toolkit.Uwp.Services.Facebook
+{
+    /// <summary>
+    /// Type to handle paged requests to Facebook Graph.
+    /// </summary>
+    /// <typeparam name="T">Strong type to return.</typeparam>
+    public class FacebookRequestSource<T> : IIncrementalSource<T>
+    {
+        private bool _isFirstCall = true;
+
+        private FBPaginatedArray _paginatedArray;
+
+        private FacebookDataConfig _config;
+
+        private string _fields;
+
+        private PropertySet _propertySet;
+
+        private FBJsonClassFactory _factory;
+
+        private string _limit;
+
+        private int _maxPages;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FacebookRequestSource{T}"/> class.
+        /// </summary>
+        public FacebookRequestSource()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FacebookRequestSource{T}"/> class.
+        /// </summary>
+        /// <param name="config">Config containing query information.</param>
+        /// <param name="fields">Comma-separated list of properties expected in the JSON response.  Accompanying properties must be found on the strong-typed T.</param>
+        /// <param name="limit">A string representation of the number of records for page - i.e. pageSize.</param>
+        /// <param name="maxPages">Upper limit of pages to return.</param>
+        public FacebookRequestSource(FacebookDataConfig config, string fields, string limit, int maxPages)
+        {
+            _config = config;
+            _fields = fields;
+            _limit = limit;
+            _maxPages = maxPages;
+
+            _propertySet = new PropertySet { { "fields", _fields }, { "limit", _limit } };
+
+            _factory = new FBJsonClassFactory(s => JsonConvert.DeserializeObject(s, typeof(T)));
+
+            // FBPaginatedArray does not allow us to set page size per request so we must go with first supplied - see https://github.com/Microsoft/winsdkfb/issues/221
+            _paginatedArray = new FBPaginatedArray(_config.Query, _propertySet, _factory);
+        }
+
+        /// <summary>
+        /// Returns strong typed page of data.
+        /// </summary>
+        /// <param name="pageIndex">Page number.</param>
+        /// <param name="pageSize">Size of page.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Strong typed page of data.</returns>
+        public async Task<IEnumerable<T>> GetPagedItemsAsync(int pageIndex, int pageSize, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (_isFirstCall)
+            {
+                var result = await _paginatedArray.FirstAsync();
+
+                return ProcessResult(result);
+            }
+            else
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return null;
+                }
+
+                if (_paginatedArray.HasNext && (pageIndex < _maxPages))
+                {
+                    var result = await _paginatedArray.NextAsync();
+                    return ProcessResult(result);
+                }
+                else
+                {
+                    return null;
+                }
+            }
+        }
+
+        private IEnumerable<T> ProcessResult(FBResult result)
+        {
+            List<T> items = new List<T>();
+
+            if (result.Succeeded)
+            {
+                IReadOnlyList<object> processedResults = (IReadOnlyList<object>)result.Object;
+
+                foreach (T processedResult in processedResults)
+                {
+                    items.Add(processedResult);
+                }
+
+                _isFirstCall = false;
+                return items;
+            }
+
+            throw new Exception(result.ErrorInfo?.Message);
+        }
+    }
+}

--- a/Microsoft.Toolkit.Uwp.Services/Services/Facebook/FacebookService.cs
+++ b/Microsoft.Toolkit.Uwp.Services/Services/Facebook/FacebookService.cs
@@ -36,11 +36,6 @@ namespace Microsoft.Toolkit.Uwp.Services.Facebook
         private bool isInitialized;
 
         /// <summary>
-        /// Reference to paginated array object for handling multiple pages of returned service list data.
-        /// </summary>
-        private FBPaginatedArray paginatedArray;
-
-        /// <summary>
         /// List of permissions required by the app.
         /// </summary>
         private FBPermissions permissions;
@@ -204,11 +199,12 @@ namespace Microsoft.Toolkit.Uwp.Services.Facebook
         /// Request list data from service provider based upon a given config / query.
         /// </summary>
         /// <param name="config">FacebookDataConfig instance.</param>
-        /// <param name="maxRecords">Upper limit of records to return.</param>
+        /// <param name="pageSize">Upper limit of records to return.</param>
+        /// <param name="maxPages">Upper limit of pages to return.</param>
         /// <returns>Strongly typed list of data returned from the service.</returns>
-        public Task<List<FacebookPost>> RequestAsync(FacebookDataConfig config, int maxRecords = 20)
+        public Task<IncrementalLoadingCollection<FacebookRequestSource<FacebookPost>, FacebookPost>> RequestAsync(FacebookDataConfig config, int pageSize = 20, int maxPages = 5)
         {
-            return RequestAsync<FacebookPost>(config, maxRecords);
+            return RequestAsync<FacebookPost>(config, pageSize, FacebookPost.Fields, maxPages);
         }
 
         /// <summary>
@@ -216,39 +212,23 @@ namespace Microsoft.Toolkit.Uwp.Services.Facebook
         /// </summary>
         /// <typeparam name="T">Strong type of model.</typeparam>
         /// <param name="config">FacebookDataConfig instance.</param>
-        /// <param name="maxRecords">Upper limit of records to return.</param>
+        /// <param name="pageSize">Upper limit of records to return.</param>
         /// <param name="fields">A comma seperated string of required fields, which will have strongly typed representation in the model passed in.</param>
+        /// <param name="maxPages">Upper limit of pages to return.</param>
         /// <returns>Strongly typed list of data returned from the service.</returns>
-        public async Task<List<T>> RequestAsync<T>(FacebookDataConfig config, int maxRecords = 20, string fields = "id,message,from,created_time,link,full_picture")
+        public async Task<IncrementalLoadingCollection<FacebookRequestSource<T>, T>> RequestAsync<T>(FacebookDataConfig config, int pageSize = 20, string fields = "id,message,from,created_time,link,full_picture", int maxPages = 5)
         {
             if (Provider.LoggedIn)
             {
-                var processedResults = new List<T>();
+                var requestSource = new FacebookRequestSource<T>(config, fields, pageSize.ToString(), maxPages);
 
-                PropertySet propertySet = new PropertySet { { "fields", fields } };
-
-                var factory = new FBJsonClassFactory(s => JsonConvert.DeserializeObject(s, typeof(T)));
-
-                paginatedArray = new FBPaginatedArray(config.Query, propertySet, factory);
-
-                var result = await paginatedArray.FirstAsync();
-
-                if (result.Succeeded)
-                {
-                    IReadOnlyList<object> results = (IReadOnlyList<object>)result.Object;
-
-                    await ProcessResultsAsync(results, maxRecords, processedResults);
-
-                    return processedResults;
-                }
-
-                throw new Exception(result.ErrorInfo?.Message);
+                return new IncrementalLoadingCollection<FacebookRequestSource<T>, T>(requestSource);
             }
 
             var isLoggedIn = await LoginAsync();
             if (isLoggedIn)
             {
-                return await RequestAsync<T>(config, maxRecords, fields);
+                return await RequestAsync<T>(config, pageSize, fields);
             }
 
             return null;
@@ -289,30 +269,32 @@ namespace Microsoft.Toolkit.Uwp.Services.Facebook
         /// <summary>
         /// Retrieves list of user photo albums.
         /// </summary>
-        /// <param name="maxRecords">Maximum number of records to retrieve.</param>
+        /// <param name="pageSize">Number of records to retrieve per page.</param>
         /// <param name="fields">Custom list of Album fields to retrieve.</param>
+        /// <param name="maxPages">Upper limit of pages to return.</param>
         /// <returns>List of User Photo Albums.</returns>
-        public Task<List<FacebookAlbum>> GetUserAlbumsAsync(int maxRecords = 20, string fields = null)
+        public async Task<IncrementalLoadingCollection<FacebookRequestSource<FacebookAlbum>, FacebookAlbum>> GetUserAlbumsAsync(int pageSize = 20, string fields = null, int maxPages = 5)
         {
             fields = fields ?? FacebookAlbum.Fields;
             var config = new FacebookDataConfig { Query = "/me/albums" };
 
-            return RequestAsync<FacebookAlbum>(config, maxRecords, fields);
+            return await RequestAsync<FacebookAlbum>(config, pageSize, fields, maxPages);
         }
 
         /// <summary>
         /// Retrieves list of user photos by album id.
         /// </summary>
         /// <param name="albumId">Albums Id for photos.</param>
-        /// <param name="maxRecords">Maximum number of photos.</param>
+        /// <param name="pageSize">Number of records to retrieve per page.</param>
         /// <param name="fields">Custom list of Photo fields to retrieve.</param>
+        /// <param name="maxPages">Upper limit of pages to return.</param>
         /// <returns>List of User Photos.</returns>
-        public Task<List<FacebookPhoto>> GetUserPhotosByAlbumIdAsync(string albumId, int maxRecords = 20, string fields = null)
+        public async Task<IncrementalLoadingCollection<FacebookRequestSource<FacebookPhoto>, FacebookPhoto>> GetUserPhotosByAlbumIdAsync(string albumId, int pageSize = 20, string fields = null, int maxPages = 5)
         {
             fields = fields ?? FacebookPhoto.Fields;
             var config = new FacebookDataConfig { Query = $"/{albumId}/photos" };
 
-            return RequestAsync<FacebookPhoto>(config, maxRecords, fields);
+            return await RequestAsync<FacebookPhoto>(config, pageSize, fields, maxPages);
         }
 
         /// <summary>
@@ -481,35 +463,6 @@ namespace Microsoft.Toolkit.Uwp.Services.Facebook
             }
 
             return null;
-        }
-
-        /// <summary>
-        /// Helper method to process pages of results from underlying service instance.
-        /// </summary>
-        /// <typeparam name="T">Strong type of model.</typeparam>
-        /// <param name="results">List of results to process.</param>
-        /// <param name="maxRecords">Total upper limit of records to process.</param>
-        /// <param name="processedResults">Stores the processed results constrained by maxRecords.</param>
-        /// <returns>Task to support await of async call.</returns>
-        private async Task ProcessResultsAsync<T>(IReadOnlyList<object> results, int maxRecords, List<T> processedResults)
-        {
-            foreach (T result in results)
-            {
-                if (processedResults.Count < maxRecords)
-                {
-                    processedResults.Add(result);
-                }
-            }
-
-            if (paginatedArray.HasNext && processedResults.Count < maxRecords)
-            {
-                var nextResult = await paginatedArray.NextAsync();
-                if (nextResult.Succeeded)
-                {
-                    IReadOnlyList<object> nextResults = (IReadOnlyList<object>)nextResult.Object;
-                    await ProcessResultsAsync<T>(nextResults, maxRecords, processedResults);
-                }
-            }
         }
     }
 }

--- a/Microsoft.Toolkit.Uwp.Services/Services/Facebook/FacebookService.cs
+++ b/Microsoft.Toolkit.Uwp.Services/Services/Facebook/FacebookService.cs
@@ -201,9 +201,9 @@ namespace Microsoft.Toolkit.Uwp.Services.Facebook
         /// <param name="config">FacebookDataConfig instance.</param>
         /// <param name="maxRecords">Upper limit of records to return.</param>
         /// <returns>Strongly typed list of data returned from the service.</returns>
-        public async Task<List<FacebookPost>> RequestAsync(FacebookDataConfig config, int maxRecords = 20)
+        public Task<List<FacebookPost>> RequestAsync(FacebookDataConfig config, int maxRecords = 20)
         {
-            return await RequestAsync<FacebookPost>(config, maxRecords, FacebookPost.Fields);
+            return RequestAsync<FacebookPost>(config, maxRecords, FacebookPost.Fields);
         }
 
         /// <summary>
@@ -241,9 +241,9 @@ namespace Microsoft.Toolkit.Uwp.Services.Facebook
         /// <param name="pageSize">Upper limit of records to return.</param>
         /// <param name="maxPages">Upper limit of pages to return.</param>
         /// <returns>Strongly typed list of data returned from the service.</returns>
-        public Task<IncrementalLoadingCollection<FacebookRequestSource<FacebookPost>, FacebookPost>> RequestAsync(FacebookDataConfig config, int pageSize = 20, int maxPages = 5)
+        public Task<IncrementalLoadingCollection<FacebookRequestSource<FacebookPost>, FacebookPost>> RequestAsync(FacebookDataConfig config, int pageSize, int maxPages)
         {
-            return RequestAsync<FacebookPost>(config, pageSize, FacebookPost.Fields, maxPages);
+            return RequestAsync<FacebookPost>(config, pageSize, maxPages, FacebookPost.Fields);
         }
 
         /// <summary>
@@ -252,10 +252,10 @@ namespace Microsoft.Toolkit.Uwp.Services.Facebook
         /// <typeparam name="T">Strong type of model.</typeparam>
         /// <param name="config">FacebookDataConfig instance.</param>
         /// <param name="pageSize">Upper limit of records to return.</param>
-        /// <param name="fields">A comma seperated string of required fields, which will have strongly typed representation in the model passed in.</param>
         /// <param name="maxPages">Upper limit of pages to return.</param>
+        /// <param name="fields">A comma seperated string of required fields, which will have strongly typed representation in the model passed in.</param>
         /// <returns>Strongly typed list of data returned from the service.</returns>
-        public async Task<IncrementalLoadingCollection<FacebookRequestSource<T>, T>> RequestAsync<T>(FacebookDataConfig config, int pageSize = 20, string fields = "id,message,from,created_time,link,full_picture", int maxPages = 5)
+        public async Task<IncrementalLoadingCollection<FacebookRequestSource<T>, T>> RequestAsync<T>(FacebookDataConfig config, int pageSize, int maxPages, string fields = "id,message,from,created_time,link,full_picture")
         {
             if (Provider.LoggedIn)
             {
@@ -267,7 +267,7 @@ namespace Microsoft.Toolkit.Uwp.Services.Facebook
             var isLoggedIn = await LoginAsync();
             if (isLoggedIn)
             {
-                return await RequestAsync<T>(config, pageSize, fields, maxPages);
+                return await RequestAsync<T>(config, pageSize, maxPages, fields);
             }
 
             return null;
@@ -323,15 +323,15 @@ namespace Microsoft.Toolkit.Uwp.Services.Facebook
         /// Retrieves list of user photo albums.
         /// </summary>
         /// <param name="pageSize">Number of records to retrieve per page.</param>
-        /// <param name="fields">Custom list of Album fields to retrieve.</param>
         /// <param name="maxPages">Upper limit of pages to return.</param>
+        /// <param name="fields">Custom list of Album fields to retrieve.</param>
         /// <returns>List of User Photo Albums.</returns>
-        public async Task<IncrementalLoadingCollection<FacebookRequestSource<FacebookAlbum>, FacebookAlbum>> GetUserAlbumsAsync(int pageSize = 20, string fields = null, int maxPages = 5)
+        public async Task<IncrementalLoadingCollection<FacebookRequestSource<FacebookAlbum>, FacebookAlbum>> GetUserAlbumsAsync(int pageSize, int maxPages, string fields = null)
         {
             fields = fields ?? FacebookAlbum.Fields;
             var config = new FacebookDataConfig { Query = "/me/albums" };
 
-            return await RequestAsync<FacebookAlbum>(config, pageSize, fields, maxPages);
+            return await RequestAsync<FacebookAlbum>(config, pageSize, maxPages, fields);
         }
 
         /// <summary>
@@ -354,15 +354,15 @@ namespace Microsoft.Toolkit.Uwp.Services.Facebook
         /// </summary>
         /// <param name="albumId">Albums Id for photos.</param>
         /// <param name="pageSize">Number of records to retrieve per page.</param>
-        /// <param name="fields">Custom list of Photo fields to retrieve.</param>
         /// <param name="maxPages">Upper limit of pages to return.</param>
+        /// <param name="fields">Custom list of Photo fields to retrieve.</param>
         /// <returns>List of User Photos.</returns>
-        public async Task<IncrementalLoadingCollection<FacebookRequestSource<FacebookPhoto>, FacebookPhoto>> GetUserPhotosByAlbumIdAsync(string albumId, int pageSize = 20, string fields = null, int maxPages = 5)
+        public async Task<IncrementalLoadingCollection<FacebookRequestSource<FacebookPhoto>, FacebookPhoto>> GetUserPhotosByAlbumIdAsync(string albumId, int pageSize, int maxPages, string fields = null)
         {
             fields = fields ?? FacebookPhoto.Fields;
             var config = new FacebookDataConfig { Query = $"/{albumId}/photos" };
 
-            return await RequestAsync<FacebookPhoto>(config, pageSize, fields, maxPages);
+            return await RequestAsync<FacebookPhoto>(config, pageSize, maxPages, fields);
         }
 
         /// <summary>

--- a/Microsoft.Toolkit.Uwp.Services/project.json
+++ b/Microsoft.Toolkit.Uwp.Services/project.json
@@ -4,7 +4,7 @@
     "Microsoft.IdentityModel.Clients.ActiveDirectory": "2.19.208020213",
     "Microsoft.NETCore.UniversalWindowsPlatform": "5.1.0",
     "StyleCop.Analyzers": "1.0.0",
-    "winsdkfb": "0.11.20160720.1"
+    "winsdkfb": "0.12.20161020.4"
   },
   "frameworks": {
     "uap10.0": {}

--- a/build/Microsoft.Toolkit.Uwp.Services.nuspec
+++ b/build/Microsoft.Toolkit.Uwp.Services.nuspec
@@ -19,7 +19,7 @@
     </references>
     <dependencies>
       <dependency id="Microsoft.Toolkit.Uwp" version="$version$" />
-      <dependency id="winsdkfb" version="0.11.20160720.1" />
+      <dependency id="winsdkfb" version="0.12.20161020.4" />
       <dependency id="Newtonsoft.Json" version="9.0.1" />
       <dependency id="Microsoft.Graph" version="1.0.1"/>
       <dependency id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="2.19.208020213"/>

--- a/docs/services/Facebook.md
+++ b/docs/services/Facebook.md
@@ -83,10 +83,10 @@ await FacebookService.Instance.PostToFeedWithDialogAsync(TitleText.Text, Descrip
 await FacebookService.Instance.PostToFeedAsync(TitleText.Text, MessageText.Text, DescriptionText.Text, picture.Name, stream);
 
 // Get current user's photo albums
-await FacebookService.Instance.GetUserAlbumsAsync();
+await FacebookService.Instance.GetUserAlbumsAsync(20, FacebookAlbum.Fields);
 
 // Get current user's photos by album Id
-await FacebookService.Instance.GetUserPhotosByAlbumIdAsync(album.Id);
+await FacebookService.Instance.GetUserPhotosByAlbumIdAsync(addedItem.Id, 20, FacebookPhoto.Fields);
 
 ```
  

--- a/docs/services/Facebook.md
+++ b/docs/services/Facebook.md
@@ -83,10 +83,10 @@ await FacebookService.Instance.PostToFeedWithDialogAsync(TitleText.Text, Descrip
 await FacebookService.Instance.PostToFeedAsync(TitleText.Text, MessageText.Text, DescriptionText.Text, picture.Name, stream);
 
 // Get current user's photo albums
-await FacebookService.Instance.GetUserAlbumsAsync(20, FacebookAlbum.Fields);
+await FacebookService.Instance.GetUserAlbumsAsync();
 
 // Get current user's photos by album Id
-await FacebookService.Instance.GetUserPhotosByAlbumIdAsync(addedItem.Id, 20, FacebookPhoto.Fields);
+await FacebookService.Instance.GetUserPhotosByAlbumIdAsync(addedItem.Id);
 
 ```
  


### PR DESCRIPTION
https://github.com/Microsoft/UWPCommunityToolkit/issues/366

The service calls to Facebook are now paged - defaulting to a page size 20 and a maximum of 5 pages, which can be easily overridden.

Key changes - 

```
▪ Update to winsdkfb nuget with paging fix

▪ (Potential) breaking changes

FacebookService.Instance.GetUserAlbumsAsync(); now returns 

    Task<IncrementalLoadingCollection<FacebookAlbumSource, FacebookAlbum>>

    Not

    Task<List<FacebookAlbum>>

FacebookService.Instance.GetUserPhotosByAlbumIdAsync(); now returns 

    Task<IncrementalLoadingCollection<FacebookPhotoSource, FacebookPhoto>> 

    Not

    Task<List<FacebookPhoto>> 

FacebookService.Instance.RequestAsync(); now returns

    Task<IncrementalLoadingCollection<FacebookRequestSource<T>, T>>

    Not

    Task<List<T>>
```

These generally will not require changes if you are assigning directly to an ItemsSource, or letting the compiler figure the type out with a 'var'.  The SampleApp for example did not require any changes.
