### PR TITLE
PullToRefreshListView: Allow object content as pull/release-ToRefreshLabel

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/PullToRefreshListView/PullToRefreshListViewPage.xaml
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/PullToRefreshListView/PullToRefreshListViewPage.xaml
@@ -2,7 +2,6 @@
     x:Class="Microsoft.Toolkit.Uwp.SampleApp.SamplePages.PullToRefreshListViewPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:Microsoft.Toolkit.Uwp.SampleApp.SamplePages"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:controls="using:Microsoft.Toolkit.Uwp.UI.Controls"
@@ -15,7 +14,6 @@
                                         OverscrollLimit="{Binding OverscrollLimit.Value, Mode=OneWay}"
 										PullThreshold="{Binding PullThreshold.Value, Mode=OneWay}"
                                         RefreshRequested="ListView_RefreshCommand"
-                                        PullProgressChanged="ListView_PullProgressChanged"
                                         HorizontalAlignment="Center"
                                         MinWidth="200"
                                         Margin="24"
@@ -25,9 +23,7 @@
                     <TextBlock Text="{x:Bind Title}" Style="{StaticResource CaptionTextBlockStyle}" TextWrapping="WrapWholeWords"/>
                 </DataTemplate>
             </controls:PullToRefreshListView.ItemTemplate>
-            <controls:PullToRefreshListView.RefreshIndicatorContent>
-                <Border HorizontalAlignment="Center" x:Name="refreshindicator" CornerRadius="30" Height="20" Width="20" ></Border>
-            </controls:PullToRefreshListView.RefreshIndicatorContent>
+           
         </controls:PullToRefreshListView>
     </Grid>
 </Page>

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/PullToRefreshListView/PullToRefreshListViewPage.xaml
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/PullToRefreshListView/PullToRefreshListViewPage.xaml
@@ -2,28 +2,31 @@
     x:Class="Microsoft.Toolkit.Uwp.SampleApp.SamplePages.PullToRefreshListViewPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:controls="using:Microsoft.Toolkit.Uwp.UI.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:data="using:Microsoft.Toolkit.Uwp.SampleApp.Models"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
     <Grid Background="{StaticResource Brush-Grey-05}">
-        <controls:PullToRefreshListView x:Name="ListView"
-                                        ItemsSource="{x:Bind _items}"
-                                        OverscrollLimit="{Binding OverscrollLimit.Value, Mode=OneWay}"
-										PullThreshold="{Binding PullThreshold.Value, Mode=OneWay}"
-                                        RefreshRequested="ListView_RefreshCommand"
-                                        HorizontalAlignment="Center"
-                                        MinWidth="200"
-                                        Margin="24"
-                                        Background="White">
+        <controls:PullToRefreshListView
+            x:Name="ListView"
+            MinWidth="200"
+            Margin="24"
+            HorizontalAlignment="Center"
+            Background="White"
+            ItemsSource="{x:Bind _items}"
+            OverscrollLimit="{Binding OverscrollLimit.Value, Mode=OneWay}"
+            PullThreshold="{Binding PullThreshold.Value, Mode=OneWay}"
+            RefreshRequested="ListView_RefreshCommand">
             <controls:PullToRefreshListView.ItemTemplate>
                 <DataTemplate x:DataType="data:Item">
-                    <TextBlock Text="{x:Bind Title}" Style="{StaticResource CaptionTextBlockStyle}" TextWrapping="WrapWholeWords"/>
+                    <TextBlock
+                        Style="{StaticResource CaptionTextBlockStyle}"
+                        Text="{x:Bind Title}"
+                        TextWrapping="WrapWholeWords" />
                 </DataTemplate>
             </controls:PullToRefreshListView.ItemTemplate>
-           
         </controls:PullToRefreshListView>
     </Grid>
 </Page>

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/PullToRefreshListView/PullToRefreshListViewPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/PullToRefreshListView/PullToRefreshListViewPage.xaml.cs
@@ -13,9 +13,6 @@
 using System;
 using System.Collections.ObjectModel;
 using Microsoft.Toolkit.Uwp.SampleApp.Models;
-using Microsoft.Toolkit.Uwp.UI.Controls;
-using Windows.UI;
-using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
 
 namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
@@ -54,13 +51,6 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
         private void ListView_RefreshCommand(object sender, EventArgs e)
         {
             AddItems();
-        }
-
-        private void ListView_PullProgressChanged(object sender, RefreshProgressEventArgs e)
-        {
-            refreshindicator.Opacity = e.PullProgress;
-
-            refreshindicator.Background = e.PullProgress < 1.0 ? new SolidColorBrush(Colors.Red) : new SolidColorBrush(Colors.Blue);
         }
     }
 }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/PullToRefreshListView/PullToRefreshListView.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/PullToRefreshListView/PullToRefreshListView.cs
@@ -425,10 +425,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             set { SetValue(PullToRefreshLabelProperty, value); }
         }
 
-        // <summary>
-        // Gets or sets the label that will be shown when the user needs to release to refresh.
-        // Note: This label will only show up if <see cref="RefreshIndicatorContent" /> is null/>
-        // </summary>
+        /// <summary>
+        /// Gets or sets the label that will be shown when the user needs to release to refresh.
+        /// Note: This label will only show up if <see cref="RefreshIndicatorContent" /> is null/>
+        /// </summary>
         [Obsolete("Use " + nameof(ReleaseToRefreshContent))]
         public string ReleaseToRefreshLabel
         {
@@ -436,12 +436,24 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             set { SetValue(ReleaseToRefreshLabelProperty, value); }
         }
 
+        /// <summary>
+        /// Gets or sets the content that will be shown when the user pulls down to refresh.
+        /// </summary>
+        /// <remarks>
+        /// This content will only show up if <see cref="RefreshIndicatorContent" /> is null
+        /// </remarks>
         public object PullToRefreshContent
         {
             get { return (string)GetValue(PullToRefreshContentProperty); }
             set { SetValue(PullToRefreshContentProperty, value); }
         }
 
+        /// <summary>
+        /// Gets or sets the content that will be shown when the user needs to release to refresh.
+        /// </summary>
+        /// <remarks>
+        /// This content will only show up if <see cref="RefreshIndicatorContent" /> is null
+        /// </remarks>
         public object ReleaseToRefreshContent
         {
             get { return (string)GetValue(ReleaseToRefreshContentProperty); }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/PullToRefreshListView/PullToRefreshListView.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/PullToRefreshListView/PullToRefreshListView.cs
@@ -297,7 +297,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                     if(_defaultIndicatorContent != null)
                     _defaultIndicatorContent.Text = ReleaseToRefreshLabel;
                     if(_pullAndReleaseIndicatorContent != null)
-                    _pullAndReleaseIndicatorContent.Content = ReleaseToRefreshLabel;
+                    _pullAndReleaseIndicatorContent.Content = ReleaseToRefreshContent;
                 }
             }
             else if (_lastRefreshActivation != DateTime.MinValue)
@@ -315,7 +315,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                         if(_defaultIndicatorContent != null)
                         _defaultIndicatorContent.Text = PullToRefreshLabel;
                         if(_pullAndReleaseIndicatorContent != null)
-                        _pullAndReleaseIndicatorContent.Content = PullToRefreshLabel;
+                        _pullAndReleaseIndicatorContent.Content = PullToRefreshContent;
                     }
                 }
                 else

--- a/Microsoft.Toolkit.Uwp.UI.Controls/PullToRefreshListView/PullToRefreshListView.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/PullToRefreshListView/PullToRefreshListView.cs
@@ -95,6 +95,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         private ScrollViewer _scroller;
         private CompositeTransform _contentTransform;
         private ItemsPresenter _scrollerContent;
+        [Obsolete]
         private TextBlock _defaultIndicatorContent;
         private ContentPresenter _pullAndReleaseIndicatorContent;
         private double _lastOffset = 0.0;
@@ -165,7 +166,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 _scrollerContent != null &&
                 _refreshIndicatorBorder != null &&
                 _refreshIndicatorTransform != null &&
-                (_defaultIndicatorContent != null || _pullAndReleaseIndicatorContent != null)) //after removing defaultIndicatorContent 
+                (_defaultIndicatorContent != null || _pullAndReleaseIndicatorContent != null)) // if _defaultIndicatorContent is removed check for _pullAndReleaseIndicatorContent only)
             {
                 _scroller.DirectManipulationCompleted += Scroller_DirectManipulationCompleted;
                 _scroller.DirectManipulationStarted += Scroller_DirectManipulationStarted;
@@ -200,10 +201,15 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             {
                 if (RefreshIndicatorContent == null)
                 {
-                    if(_defaultIndicatorContent != null)
-                    _defaultIndicatorContent.Text = PullToRefreshLabel;
-                    if(_pullAndReleaseIndicatorContent != null)
-                    _pullAndReleaseIndicatorContent.Content = PullToRefreshContent;
+                    if (_defaultIndicatorContent != null)
+                    {
+                        _defaultIndicatorContent.Text = PullToRefreshLabel;
+                    }
+
+                    if (_pullAndReleaseIndicatorContent != null)
+                    {
+                        _pullAndReleaseIndicatorContent.Content = PullToRefreshContent;
+                    }
                 }
 
                 CompositionTarget.Rendering += CompositionTarget_Rendering;
@@ -294,10 +300,15 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 pullProgress = 1.0;
                 if (RefreshIndicatorContent == null)
                 {
-                    if(_defaultIndicatorContent != null)
-                    _defaultIndicatorContent.Text = ReleaseToRefreshLabel;
-                    if(_pullAndReleaseIndicatorContent != null)
-                    _pullAndReleaseIndicatorContent.Content = ReleaseToRefreshContent;
+                    if (_defaultIndicatorContent != null)
+                    {
+                        _defaultIndicatorContent.Text = ReleaseToRefreshLabel;
+                    }
+
+                    if (_pullAndReleaseIndicatorContent != null)
+                    {
+                        _pullAndReleaseIndicatorContent.Content = ReleaseToRefreshContent;
+                    }
                 }
             }
             else if (_lastRefreshActivation != DateTime.MinValue)
@@ -312,10 +323,15 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                     pullProgress = _pullDistance / PullThreshold;
                     if (RefreshIndicatorContent == null)
                     {
-                        if(_defaultIndicatorContent != null)
-                        _defaultIndicatorContent.Text = PullToRefreshLabel;
-                        if(_pullAndReleaseIndicatorContent != null)
-                        _pullAndReleaseIndicatorContent.Content = PullToRefreshContent;
+                        if (_defaultIndicatorContent != null)
+                        {
+                            _defaultIndicatorContent.Text = PullToRefreshLabel;
+                        }
+
+                        if (_pullAndReleaseIndicatorContent != null)
+                        {
+                            _pullAndReleaseIndicatorContent.Content = PullToRefreshContent;
+                        }
                     }
                 }
                 else
@@ -408,7 +424,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 {
                     _pullAndReleaseIndicatorContent.Visibility = value == null ? Visibility.Visible : Visibility.Collapsed;
                 }
-
 
                 SetValue(RefreshIndicatorContentProperty, value);
             }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/PullToRefreshListView/PullToRefreshListView.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/PullToRefreshListView/PullToRefreshListView.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
     [TemplatePart(Name = PartScrollerContent, Type = typeof(Grid))]
     [TemplatePart(Name = PartRefreshIndicatorBorder, Type = typeof(Border))]
     [TemplatePart(Name = PartIndicatorTransform, Type = typeof(CompositeTransform))]
-    [TemplatePart(Name = PartDefaultIndicatorContent, Type = typeof(TextBlock))]
+    [TemplatePart(Name = PartDefaultIndicatorContent, Type = typeof(ContentControl))]
     public class PullToRefreshListView : ListView
     {
         /// <summary>
@@ -59,13 +59,13 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// Identifies the <see cref="PullToRefreshLabel"/> property.
         /// </summary>
         public static readonly DependencyProperty PullToRefreshLabelProperty =
-            DependencyProperty.Register("PullToRefreshLabel", typeof(string), typeof(PullToRefreshListView), new PropertyMetadata("Pull To Refresh"));
+            DependencyProperty.Register("PullToRefreshLabel", typeof(object), typeof(PullToRefreshListView), new PropertyMetadata("Pull To Refresh"));
 
         /// <summary>
         /// Identifies the <see cref="ReleaseToRefreshLabel"/> property.
         /// </summary>
         public static readonly DependencyProperty ReleaseToRefreshLabelProperty =
-            DependencyProperty.Register("ReleaseToRefreshLabel", typeof(string), typeof(PullToRefreshListView), new PropertyMetadata("Release to Refresh"));
+            DependencyProperty.Register("ReleaseToRefreshLabel", typeof(object), typeof(PullToRefreshListView), new PropertyMetadata("Release to Refresh"));
 
         private const string PartRoot = "Root";
         private const string PartScroller = "ScrollViewer";
@@ -81,7 +81,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         private ScrollViewer _scroller;
         private CompositeTransform _contentTransform;
         private ItemsPresenter _scrollerContent;
-        private TextBlock _defaultIndicatorContent;
+        private ContentPresenter _defaultIndicatorContent;
         private double _lastOffset = 0.0;
         private double _pullDistance = 0.0;
         private DateTime _lastRefreshActivation = default(DateTime);
@@ -142,7 +142,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             _scrollerContent = GetTemplateChild(PartScrollerContent) as ItemsPresenter;
             _refreshIndicatorBorder = GetTemplateChild(PartRefreshIndicatorBorder) as Border;
             _refreshIndicatorTransform = GetTemplateChild(PartIndicatorTransform) as CompositeTransform;
-            _defaultIndicatorContent = GetTemplateChild(PartDefaultIndicatorContent) as TextBlock;
+            _defaultIndicatorContent = GetTemplateChild(PartDefaultIndicatorContent) as ContentPresenter;
 
             if (_root != null &&
                 _scroller != null &&
@@ -176,7 +176,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             {
                 if (RefreshIndicatorContent == null)
                 {
-                    _defaultIndicatorContent.Text = PullToRefreshLabel;
+                    _defaultIndicatorContent.Content = PullToRefreshLabel;
                 }
 
                 CompositionTarget.Rendering += CompositionTarget_Rendering;
@@ -267,7 +267,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 pullProgress = 1.0;
                 if (RefreshIndicatorContent == null)
                 {
-                    _defaultIndicatorContent.Text = ReleaseToRefreshLabel;
+                    _defaultIndicatorContent.Content = ReleaseToRefreshLabel;
                 }
             }
             else if (_lastRefreshActivation != DateTime.MinValue)
@@ -282,7 +282,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                     pullProgress = _pullDistance / PullThreshold;
                     if (RefreshIndicatorContent == null)
                     {
-                        _defaultIndicatorContent.Text = PullToRefreshLabel;
+                        _defaultIndicatorContent.Content = PullToRefreshLabel;
                     }
                 }
                 else
@@ -365,9 +365,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// Gets or sets the label that will be shown when the user pulls down to refresh.
         /// Note: This label will only show up if <see cref="RefreshIndicatorContent" /> is null/>
         /// </summary>
-        public string PullToRefreshLabel
+        public object PullToRefreshLabel
         {
-            get { return (string)GetValue(PullToRefreshLabelProperty); }
+            get { return (object)GetValue(PullToRefreshLabelProperty); }
             set { SetValue(PullToRefreshLabelProperty, value); }
         }
 
@@ -375,9 +375,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         // Gets or sets the label that will be shown when the user needs to release to refresh.
         // Note: This label will only show up if <see cref="RefreshIndicatorContent" /> is null/>
         // </summary>
-        public string ReleaseToRefreshLabel
+        public object ReleaseToRefreshLabel
         {
-            get { return (string)GetValue(ReleaseToRefreshLabelProperty); }
+            get { return (object)GetValue(ReleaseToRefreshLabelProperty); }
             set { SetValue(ReleaseToRefreshLabelProperty, value); }
         }
     }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/PullToRefreshListView/PullToRefreshListView.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/PullToRefreshListView/PullToRefreshListView.cs
@@ -60,25 +60,25 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// Identifies the <see cref="PullToRefreshLabel"/> property.
         /// </summary>
         public static readonly DependencyProperty PullToRefreshLabelProperty =
-            DependencyProperty.Register("PullToRefreshLabel", typeof(object), typeof(PullToRefreshListView), new PropertyMetadata("Pull To Refresh", OnPullToRefreshLabelChanged));
-        
+            DependencyProperty.Register(nameof(PullToRefreshLabel), typeof(object), typeof(PullToRefreshListView), new PropertyMetadata("Pull To Refresh", OnPullToRefreshLabelChanged));
+
         /// <summary>
         /// Identifies the <see cref="ReleaseToRefreshLabel"/> property.
         /// </summary>
         public static readonly DependencyProperty ReleaseToRefreshLabelProperty =
-            DependencyProperty.Register("ReleaseToRefreshLabel", typeof(object), typeof(PullToRefreshListView), new PropertyMetadata("Release to Refresh", OnReleaseToRefreshLabelChanged));
-        
+            DependencyProperty.Register(nameof(ReleaseToRefreshLabel), typeof(object), typeof(PullToRefreshListView), new PropertyMetadata("Release to Refresh", OnReleaseToRefreshLabelChanged));
+
         /// <summary>
         /// Identifies the <see cref="PullToRefreshContent"/> property.
         /// </summary>
         public static readonly DependencyProperty PullToRefreshContentProperty =
-            DependencyProperty.Register("PullToRefreshContent", typeof(object), typeof(PullToRefreshListView), new PropertyMetadata("Pull To Refresh"));
+            DependencyProperty.Register(nameof(PullToRefreshContent), typeof(object), typeof(PullToRefreshListView), new PropertyMetadata("Pull To Refresh"));
 
         /// <summary>
         /// Identifies the <see cref="ReleaseToRefreshContent"/> property.
         /// </summary>
         public static readonly DependencyProperty ReleaseToRefreshContentProperty =
-            DependencyProperty.Register("ReleaseToRefreshContent", typeof(object), typeof(PullToRefreshListView), new PropertyMetadata("Release to Refresh"));
+            DependencyProperty.Register(nameof(ReleaseToRefreshContent), typeof(object), typeof(PullToRefreshListView), new PropertyMetadata("Release to Refresh"));
 
         private const string PartRoot = "Root";
         private const string PartScroller = "ScrollViewer";

--- a/Microsoft.Toolkit.Uwp.UI.Controls/PullToRefreshListView/PullToRefreshListView.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/PullToRefreshListView/PullToRefreshListView.xaml
@@ -40,9 +40,8 @@
                         <Grid>
                             <Border x:Name="RefreshIndicator" VerticalAlignment="Top">
                                 <Grid>
-                                    <!--<TextBlock x:Name="DefaultIndicatorContent" HorizontalAlignment="Center" FontSize="20"></TextBlock>-->
-                                    <ContentPresenter x:Name="PullAndReleaseIndicatorContent" HorizontalAlignment="Center" FontSize="20"></ContentPresenter>
-                                    <ContentPresenter Content="{TemplateBinding RefreshIndicatorContent}"></ContentPresenter>
+                                    <ContentPresenter x:Name="PullAndReleaseIndicatorContent" HorizontalAlignment="Center" FontSize="20" />
+                                    <ContentPresenter Content="{TemplateBinding RefreshIndicatorContent}" />
                                 </Grid>
                                 <Border.RenderTransform>
                                     <CompositeTransform x:Name="RefreshIndicatorTransform"></CompositeTransform>

--- a/Microsoft.Toolkit.Uwp.UI.Controls/PullToRefreshListView/PullToRefreshListView.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/PullToRefreshListView/PullToRefreshListView.xaml
@@ -40,7 +40,7 @@
                         <Grid>
                             <Border x:Name="RefreshIndicator" VerticalAlignment="Top">
                                 <Grid>
-                                    <TextBlock x:Name="DefaultIndicatorContent" HorizontalAlignment="Center" FontSize="20"></TextBlock>
+                                    <ContentPresenter x:Name="DefaultIndicatorContent" HorizontalAlignment="Center" FontSize="20"></ContentPresenter>
                                     <ContentPresenter Content="{TemplateBinding RefreshIndicatorContent}"></ContentPresenter>
                                 </Grid>
                                 <Border.RenderTransform>

--- a/Microsoft.Toolkit.Uwp.UI.Controls/PullToRefreshListView/PullToRefreshListView.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/PullToRefreshListView/PullToRefreshListView.xaml
@@ -40,7 +40,8 @@
                         <Grid>
                             <Border x:Name="RefreshIndicator" VerticalAlignment="Top">
                                 <Grid>
-                                    <ContentPresenter x:Name="DefaultIndicatorContent" HorizontalAlignment="Center" FontSize="20"></ContentPresenter>
+                                    <!--<TextBlock x:Name="DefaultIndicatorContent" HorizontalAlignment="Center" FontSize="20"></TextBlock>-->
+                                    <ContentPresenter x:Name="PullAndReleaseIndicatorContent" HorizontalAlignment="Center" FontSize="20"></ContentPresenter>
                                     <ContentPresenter Content="{TemplateBinding RefreshIndicatorContent}"></ContentPresenter>
                                 </Grid>
                                 <Border.RenderTransform>

--- a/Microsoft.Toolkit.Uwp.UI.Controls/PullToRefreshListView/PullToRefreshListView.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/PullToRefreshListView/PullToRefreshListView.xaml
@@ -1,78 +1,87 @@
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:local="using:Microsoft.Toolkit.Uwp.UI.Controls">
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Microsoft.Toolkit.Uwp.UI.Controls">
 
     <Style TargetType="local:PullToRefreshListView">
-        <Setter Property="IsTabStop" Value="False"/>
-        <Setter Property="TabNavigation" Value="Once"/>
-        <Setter Property="IsSwipeEnabled" Value="True"/>
-        <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled"/>
-        <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto"/>
-        <Setter Property="ScrollViewer.HorizontalScrollMode" Value="Disabled"/>
-        <Setter Property="ScrollViewer.IsHorizontalRailEnabled" Value="False"/>
-        <Setter Property="ScrollViewer.VerticalScrollMode" Value="Enabled"/>
-        <Setter Property="ScrollViewer.IsVerticalRailEnabled" Value="True"/>
-        <Setter Property="ScrollViewer.ZoomMode" Value="Disabled"/>
-        <Setter Property="ScrollViewer.IsDeferredScrollingEnabled" Value="False"/>
-        <Setter Property="ScrollViewer.BringIntoViewOnFocusChange" Value="True"/>
-        <Setter Property="OverscrollLimit" Value="0.4"></Setter>
+        <Setter Property="IsTabStop" Value="False" />
+        <Setter Property="TabNavigation" Value="Once" />
+        <Setter Property="IsSwipeEnabled" Value="True" />
+        <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled" />
+        <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
+        <Setter Property="ScrollViewer.HorizontalScrollMode" Value="Disabled" />
+        <Setter Property="ScrollViewer.IsHorizontalRailEnabled" Value="False" />
+        <Setter Property="ScrollViewer.VerticalScrollMode" Value="Enabled" />
+        <Setter Property="ScrollViewer.IsVerticalRailEnabled" Value="True" />
+        <Setter Property="ScrollViewer.ZoomMode" Value="Disabled" />
+        <Setter Property="ScrollViewer.IsDeferredScrollingEnabled" Value="False" />
+        <Setter Property="ScrollViewer.BringIntoViewOnFocusChange" Value="True" />
+        <Setter Property="OverscrollLimit" Value="0.4" />
         <Setter Property="ItemContainerTransitions">
             <Setter.Value>
                 <TransitionCollection>
-                    <AddDeleteThemeTransition/>
-                    <ContentThemeTransition/>
-                    <ReorderThemeTransition/>
-                    <EntranceThemeTransition IsStaggeringEnabled="False"/>
+                    <AddDeleteThemeTransition />
+                    <ContentThemeTransition />
+                    <ReorderThemeTransition />
+                    <EntranceThemeTransition IsStaggeringEnabled="False" />
                 </TransitionCollection>
             </Setter.Value>
         </Setter>
         <Setter Property="ItemsPanel">
             <Setter.Value>
                 <ItemsPanelTemplate>
-                    <ItemsStackPanel Orientation="Vertical"/>
+                    <ItemsStackPanel Orientation="Vertical" />
                 </ItemsPanelTemplate>
             </Setter.Value>
         </Setter>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="local:PullToRefreshListView">
-                    <Border x:Name="Root"  BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}">
+                    <Border
+                        x:Name="Root"
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}">
                         <Grid>
                             <Border x:Name="RefreshIndicator" VerticalAlignment="Top">
                                 <Grid>
-                                    <ContentPresenter x:Name="PullAndReleaseIndicatorContent" HorizontalAlignment="Center" FontSize="20" />
+                                    <ContentPresenter
+                                        x:Name="PullAndReleaseIndicatorContent"
+                                        HorizontalAlignment="Center"
+                                        FontSize="20" />
                                     <ContentPresenter Content="{TemplateBinding RefreshIndicatorContent}" />
                                 </Grid>
                                 <Border.RenderTransform>
-                                    <CompositeTransform x:Name="RefreshIndicatorTransform"></CompositeTransform>
+                                    <CompositeTransform x:Name="RefreshIndicatorTransform" />
                                 </Border.RenderTransform>
                             </Border>
-                            <ScrollViewer x:Name="ScrollViewer" 
-                                      AutomationProperties.AccessibilityView="Raw" 
-                                      BringIntoViewOnFocusChange="{TemplateBinding ScrollViewer.BringIntoViewOnFocusChange}" 
-                                      HorizontalScrollMode="{TemplateBinding ScrollViewer.HorizontalScrollMode}" 
-                                      HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}" 
-                                      IsHorizontalRailEnabled="{TemplateBinding ScrollViewer.IsHorizontalRailEnabled}" 
-                                      IsHorizontalScrollChainingEnabled="{TemplateBinding ScrollViewer.IsHorizontalScrollChainingEnabled}" 
-                                      IsVerticalScrollChainingEnabled="{TemplateBinding ScrollViewer.IsVerticalScrollChainingEnabled}" 
-                                      IsVerticalRailEnabled="{TemplateBinding ScrollViewer.IsVerticalRailEnabled}" 
-                                      IsDeferredScrollingEnabled="{TemplateBinding ScrollViewer.IsDeferredScrollingEnabled}" 
-                                      TabNavigation="{TemplateBinding TabNavigation}" 
-                                      VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}" 
-                                      VerticalScrollMode="{TemplateBinding ScrollViewer.VerticalScrollMode}" 
-                                      ZoomMode="{TemplateBinding ScrollViewer.ZoomMode}">
-                                    <ItemsPresenter FooterTransitions="{TemplateBinding FooterTransitions}" 
-                                                FooterTemplate="{TemplateBinding FooterTemplate}" 
-                                                Footer="{TemplateBinding Footer}" 
-                                                HeaderTemplate="{TemplateBinding HeaderTemplate}" 
-                                                Header="{TemplateBinding Header}" 
-                                                HeaderTransitions="{TemplateBinding HeaderTransitions}" 
-                                                Padding="{TemplateBinding Padding}"
-                                                x:Name="ItemsPresenter">
-                                    </ItemsPresenter>
+                            <ScrollViewer
+                                x:Name="ScrollViewer"
+                                AutomationProperties.AccessibilityView="Raw"
+                                BringIntoViewOnFocusChange="{TemplateBinding ScrollViewer.BringIntoViewOnFocusChange}"
+                                HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
+                                HorizontalScrollMode="{TemplateBinding ScrollViewer.HorizontalScrollMode}"
+                                IsDeferredScrollingEnabled="{TemplateBinding ScrollViewer.IsDeferredScrollingEnabled}"
+                                IsHorizontalRailEnabled="{TemplateBinding ScrollViewer.IsHorizontalRailEnabled}"
+                                IsHorizontalScrollChainingEnabled="{TemplateBinding ScrollViewer.IsHorizontalScrollChainingEnabled}"
+                                IsVerticalRailEnabled="{TemplateBinding ScrollViewer.IsVerticalRailEnabled}"
+                                IsVerticalScrollChainingEnabled="{TemplateBinding ScrollViewer.IsVerticalScrollChainingEnabled}"
+                                TabNavigation="{TemplateBinding TabNavigation}"
+                                VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}"
+                                VerticalScrollMode="{TemplateBinding ScrollViewer.VerticalScrollMode}"
+                                ZoomMode="{TemplateBinding ScrollViewer.ZoomMode}">
+                                <ItemsPresenter
+                                    x:Name="ItemsPresenter"
+                                    Padding="{TemplateBinding Padding}"
+                                    Footer="{TemplateBinding Footer}"
+                                    FooterTemplate="{TemplateBinding FooterTemplate}"
+                                    FooterTransitions="{TemplateBinding FooterTransitions}"
+                                    Header="{TemplateBinding Header}"
+                                    HeaderTemplate="{TemplateBinding HeaderTemplate}"
+                                    HeaderTransitions="{TemplateBinding HeaderTransitions}" />
                             </ScrollViewer>
                         </Grid>
-                        
+
                     </Border>
                 </ControlTemplate>
             </Setter.Value>


### PR DESCRIPTION
This PR allows the developer to use custom objects instead of string for `Rull/ReleaseToRefreshLabel`. It extends the control by adding `PullToRefreshContent`, `ReleaseToRefreshContent`.

What has changed
---

 - Add Property `PullToRefreshContent`, `ReleaseToRefreshContent`. 
 - Add Obsolete to `PullToRefreshLabel`, `ReleaseToRefreshLabel`
 - If a value is set to `PullToRefreshLabel` or `ReleaseToRefreshLabel` then the value is set to `PullToRefreshContent`, `ReleaseToRefreshContent` respectively

Compatability
----
It is possible to have either `PartDefaultIndicatorContent` (backward compatibility) or `PullAndReleaseIndicatorContent` as pull-down indicator.

For further versions `PartDefaultIndicatorContent` can be removed.

Because TextBlock is is still existing there should be no breaking changes.

---
Reference to https://github.com/Microsoft/UWPCommunityToolkit/issues/186