### PR TITLE
Revert to using Hash for Cached item file name without extension.

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/ImageEx/ImageEx.Source.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/ImageEx/ImageEx.Source.cs
@@ -107,7 +107,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                     var ogUri = _uri;
                     try
                     {
-                        var img = await ImageCache.Instance.GetFromCacheAsync(ogUri, Path.GetFileName(ogUri.ToString()), true);
+                        var img = await ImageCache.Instance.GetFromCacheAsync(ogUri, true);
 
                         lock (_lockObj)
                         {

--- a/Microsoft.Toolkit.Uwp.UI/Cache/CacheBase.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Cache/CacheBase.cs
@@ -152,25 +152,23 @@ namespace Microsoft.Toolkit.Uwp.UI
         /// Assures that image is available in the cache
         /// </summary>
         /// <param name="uri">Uri of the image</param>
-        /// <param name="fileName">fileName to for local storage</param>
         /// <param name="throwOnError">Indicates whether or not exception should be thrown if imagge cannot be loaded</param>
         /// <param name="storeToMemoryCache">Indicates if image should be available also in memory cache</param>
         /// <returns>void</returns>
-        public Task PreCacheAsync(Uri uri, string fileName, bool throwOnError = false, bool storeToMemoryCache = false)
+        public Task PreCacheAsync(Uri uri, bool throwOnError = false, bool storeToMemoryCache = false)
         {
-            return GetItemAsync(uri, fileName, throwOnError, !storeToMemoryCache);
+            return GetItemAsync(uri, throwOnError, !storeToMemoryCache);
         }
 
         /// <summary>
         /// Load a specific image from the cache. If the image is not in the cache, ImageCache will try to download and store it.
         /// </summary>
         /// <param name="uri">Uri of the image.</param>
-        /// <param name="fileName">fileName to for local storage</param>
         /// <param name="throwOnError">Indicates whether or not exception should be thrown if imagge cannot be loaded</param>
         /// <returns>a BitmapImage</returns>
-        public Task<T> GetFromCacheAsync(Uri uri, string fileName, bool throwOnError = false)
+        public Task<T> GetFromCacheAsync(Uri uri, bool throwOnError = false)
         {
-            return GetItemAsync(uri, fileName, throwOnError, false);
+            return GetItemAsync(uri, throwOnError, false);
         }
 
         /// <summary>
@@ -187,9 +185,29 @@ namespace Microsoft.Toolkit.Uwp.UI
         /// <returns>awaitable task</returns>
         protected abstract Task<T> InitializeTypeAsync(StorageFile baseFile);
 
-        private async Task<T> GetItemAsync(Uri uri, string fileName, bool throwOnError, bool preCacheOnly)
+        private static string GetCacheFileName(Uri uri)
+        {
+            return CreateHash64(uri.ToString()).ToString();
+        }
+
+        private static ulong CreateHash64(string str)
+        {
+            byte[] utf8 = System.Text.Encoding.UTF8.GetBytes(str);
+
+            ulong value = (ulong)utf8.Length;
+            for (int n = 0; n < utf8.Length; n++)
+            {
+                value += (ulong)utf8[n] << ((n * 5) % 56);
+            }
+
+            return value;
+        }
+
+        private async Task<T> GetItemAsync(Uri uri, bool throwOnError, bool preCacheOnly)
         {
             T instance = default(T);
+
+            string fileName = GetCacheFileName(uri);
 
             ConcurrentRequest request = null;
 

--- a/docs/helpers/ImageCache.md
+++ b/docs/helpers/ImageCache.md
@@ -15,7 +15,7 @@ The **ImageCache** provides methods and tools to cache images in a temporary loc
 	var distantUri = new Uri("http://www.myserver.com/image.jpg");
 
 	// Load a specific image from the cache. If the image is not in the cache, ImageCache will try to download and store it
-	var bitmapImage = await ImageCache.Instance.GetFromCacheAsync(distantUri, Path.GetFileName(distantUri.ToString()));
+	var bitmapImage = await ImageCache.Instance.GetFromCacheAsync(distantUri));
 
 	// Clear the cache. Please note that you can provide a parameter to define a timespan from now to select cache entries to delete.
 	await ImageCache.Instance.ClearAsync();	


### PR DESCRIPTION
Reverting to using hash function to create filename.
This addresses issue #546 