### PR TITLE
Blade warnings

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/BladeControl/BladePage.xaml
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/BladeControl/BladePage.xaml
@@ -61,7 +61,6 @@
 
             <controls:BladeItem Title="Default blade"
                             x:Name="SecondBlade"
-                            BladeId="BladeTest1"
                             IsOpen="False"
                             Width="400"
                             Background="{StaticResource Brush-White}"
@@ -74,7 +73,6 @@
 
             <controls:BladeItem Title="Custom title bar"
                             x:Name="ThirdBlade"
-                            BladeId="BladeTest2"
                             IsOpen="False"
                             Width="400"
                             TitleBarBackground="{StaticResource Brush-Blue-01}"
@@ -90,7 +88,6 @@
 
             <controls:BladeItem Title="Custom close button color"
                             x:Name="FourthBlade"
-                            BladeId="BladeTest3"
                             Width="400"
                             CloseButtonBackground="{StaticResource Brush-Grey-01}"
                             CloseButtonForeground="{StaticResource Brush-White}"

--- a/Microsoft.Toolkit.Uwp.UI.Controls/BladeControl/Blade.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/BladeControl/Blade.cs
@@ -19,6 +19,12 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
     public class Blade : BladeItem
     {
         /// <summary>
+        /// Identifies the <see cref="BladeId"/> dependency property.
+        /// </summary>
+        [Deprecated("This property is no longer required along with the attached ToggleBlade property. Please use the IsOpen property instead.", DeprecationType.Deprecate, 1)]
+        public static readonly DependencyProperty BladeIdProperty = DependencyProperty.Register(nameof(BladeId), typeof(string), typeof(BladeItem), new PropertyMetadata(default(string)));
+
+        /// <summary>
         /// Gets or sets the visual content of this blade
         /// </summary>
         [Deprecated("This property has been replaced with the Content property of the control. It is no longer required to place content within the Element property.", DeprecationType.Deprecate, 1)]
@@ -33,6 +39,16 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// </summary>
         [Deprecated("This property has been replaced with the Content property of the control. It is no longer required to place content within the Element property.", DeprecationType.Deprecate, 1)]
         public static readonly DependencyProperty ElementProperty = DependencyProperty.Register(nameof(Element), typeof(UIElement), typeof(Blade), new PropertyMetadata(null, OnElementChanged));
+
+        /// <summary>
+        /// Gets or sets the Blade Id, this needs to be set in order to use the attached property to toggle a blade
+        /// </summary>
+        [Deprecated("This property is no longer required along with the attached ToggleBlade property. Please use the IsOpen property instead.", DeprecationType.Deprecate, 1)]
+        public string BladeId
+        {
+            get { return (string)GetValue(BladeIdProperty); }
+            set { SetValue(BladeIdProperty, value); }
+        }
 
         private static void OnElementChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {

--- a/Microsoft.Toolkit.Uwp.UI.Controls/BladeControl/Blade.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/BladeControl/Blade.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
         private static void OnElementChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
-            var blade = (Blade) d;
+            var blade = (Blade)d;
             blade.Content = e.NewValue;
         }
     }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/BladeControl/BladeControl.Properties.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/BladeControl/BladeControl.Properties.cs
@@ -87,6 +87,14 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             return element.GetValue(ToggleBladeProperty).ToString();
         }
 
+        /// <summary>
+        /// Fired when the deprecated Blades property changes.
+        /// Handles moving items from the Blades collection to the Items collection.
+        /// Subscribes to the CollectionChanged event if Blades implements INotifyCollectionChanged
+        /// in order to add or remove Blades from the Items collection.
+        /// </summary>
+        /// <param name="d">The sender.</param>
+        /// <param name="e">The event args.</param>
         private static void OnBladesChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             var bladeControl = (BladeControl)d;

--- a/Microsoft.Toolkit.Uwp.UI.Controls/BladeControl/BladeControl.Properties.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/BladeControl/BladeControl.Properties.cs
@@ -121,9 +121,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             Button pressedButton = sender as Button;
 #pragma warning disable CS0618 // Type or member is obsolete
             string bladeName = GetToggleBlade(pressedButton);
-#pragma warning restore CS0618 // Type or member is obsolete
             BladeControl container = pressedButton.FindVisualAscendant<BladeControl>();
-            var blade = container.Items.OfType<BladeItem>().FirstOrDefault(_ => _.BladeId == bladeName);
+            var blade = container.Items.OfType<Blade>().FirstOrDefault(_ => _.BladeId == bladeName);
+#pragma warning restore CS0618 // Type or member is obsolete
 
             if (blade == null)
             {

--- a/Microsoft.Toolkit.Uwp.UI.Controls/BladeControl/BladeControl.Properties.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/BladeControl/BladeControl.Properties.cs
@@ -90,14 +90,17 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         private static void OnBladesChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             var bladeControl = (BladeControl)d;
-            if (bladeControl.Blades != null)
+#pragma warning disable CS0618 // Type or member is obsolete
+            IList<Blade> blades = bladeControl.Blades;
+#pragma warning restore CS0618 // Type or member is obsolete
+            if (blades != null)
             {
-                foreach (var blade in bladeControl.Blades)
+                foreach (var blade in blades)
                 {
                     bladeControl.Items.Add(blade);
                 }
 
-                var collection = bladeControl.Blades as INotifyCollectionChanged;
+                var collection = blades as INotifyCollectionChanged;
                 if (collection != null)
                 {
                     collection.CollectionChanged += bladeControl.OnBladeCollectionChanged;
@@ -108,7 +111,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         private static void ToggleBlade(object sender, TappedRoutedEventArgs tappedRoutedEventArgs)
         {
             Button pressedButton = sender as Button;
+#pragma warning disable CS0618 // Type or member is obsolete
             string bladeName = GetToggleBlade(pressedButton);
+#pragma warning restore CS0618 // Type or member is obsolete
             BladeControl container = pressedButton.FindVisualAscendant<BladeControl>();
             var blade = container.Items.OfType<BladeItem>().FirstOrDefault(_ => _.BladeId == bladeName);
 
@@ -122,6 +127,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
         private void OnBladeCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             if (e.OldItems != null)
             {
                 foreach (var blade in e.OldItems.OfType<Blade>())
@@ -137,6 +143,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                     Items.Add(blade);
                 }
             }
+#pragma warning restore CS0618 // Type or member is obsolete
+
         }
     }
 }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/BladeControl/BladeControl.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/BladeControl/BladeControl.cs
@@ -31,7 +31,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         public BladeControl()
         {
             DefaultStyleKey = typeof(BladeControl);
+#pragma warning disable CS0618 // Type or member is obsolete
             Blades = new ObservableCollection<Blade>();
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         /// <summary>

--- a/Microsoft.Toolkit.Uwp.UI.Controls/BladeControl/BladeItem.Properties.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/BladeControl/BladeItem.Properties.cs
@@ -10,6 +10,7 @@
 // THE CODE OR THE USE OR OTHER DEALINGS IN THE CODE.
 // ******************************************************************
 
+using Windows.Foundation.Metadata;
 using Windows.UI;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Media;
@@ -45,11 +46,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// Identifies the <see cref="IsOpen"/> dependency property.
         /// </summary>
         public static readonly DependencyProperty IsOpenProperty = DependencyProperty.Register(nameof(IsOpen), typeof(bool), typeof(BladeItem), new PropertyMetadata(true, IsOpenChangedCallback));
-
-        /// <summary>
-        /// Identifies the <see cref="BladeId"/> dependency property.
-        /// </summary>
-        public static readonly DependencyProperty BladeIdProperty = DependencyProperty.Register(nameof(BladeId), typeof(string), typeof(BladeItem), new PropertyMetadata(default(string)));
 
         /// <summary>
         /// Identifies the <see cref="TitleBarForeground"/> dependency property
@@ -122,15 +118,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         {
             get { return (bool)GetValue(IsOpenProperty); }
             set { SetValue(IsOpenProperty, value); }
-        }
-
-        /// <summary>
-        /// Gets or sets the Blade Id, this needs to be set in order to use the attached property to toggle a blade
-        /// </summary>
-        public string BladeId
-        {
-            get { return (string)GetValue(BladeIdProperty); }
-            set { SetValue(BladeIdProperty, value); }
         }
 
         private static void IsOpenChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)

--- a/Microsoft.Toolkit.Uwp.UI.Controls/BladeControl/BladeItem.Properties.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/BladeControl/BladeItem.Properties.cs
@@ -10,7 +10,6 @@
 // THE CODE OR THE USE OR OTHER DEALINGS IN THE CODE.
 // ******************************************************************
 
-using Windows.Foundation.Metadata;
 using Windows.UI;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Media;


### PR DESCRIPTION
Ignore warnings for deprecated Blade properties. 
Move the BladeId property to the Blade class and mark as Deprecated