### PR TITLE
Remove obsolete from PullToRefreshListview

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp/App.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/App.xaml.cs
@@ -12,6 +12,7 @@
 
 using System;
 using Microsoft.Toolkit.Uwp.SampleApp.Common;
+using Microsoft.Toolkit.Uwp.Helpers;
 using Windows.ApplicationModel;
 using Windows.ApplicationModel.Activation;
 using Windows.Foundation.Metadata;
@@ -21,7 +22,6 @@ using Windows.UI.ViewManagement;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Navigation;
-using Microsoft.Toolkit.Uwp.Helpers;
 
 namespace Microsoft.Toolkit.Uwp.SampleApp
 {

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/DispatcherHelper/DispatcherHelperPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/DispatcherHelper/DispatcherHelperPage.xaml.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
 
         private async void ExecuteFromDifferentThreadButton_Click(object sender, RoutedEventArgs e)
         {
-            int crossThreadReturnedValue = await Task.Run<int>( async () =>
+            int crossThreadReturnedValue = await Task.Run<int>(async () =>
             {
                 int returnedFromUIThread = await DispatcherHelper.ExecuteOnUIThreadAsync<int>(() =>
                 {

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/PullToRefreshListView/PullToRefreshListViewPage.xaml
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/PullToRefreshListView/PullToRefreshListViewPage.xaml
@@ -28,6 +28,11 @@
                         TextWrapping="WrapWholeWords" />
                 </DataTemplate>
             </controls:PullToRefreshListView.ItemTemplate>
+            <controls:PullToRefreshListView.PullToRefreshContent>
+                <TextBlock Text="Pull down to refresh data" 
+                           Opacity="0.5" 
+                           FontSize="16"/>
+            </controls:PullToRefreshListView.PullToRefreshContent>
         </controls:PullToRefreshListView>
     </Grid>
 </Page>

--- a/Microsoft.Toolkit.Uwp.UI.Controls/PullToRefreshListView/PullToRefreshListView.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/PullToRefreshListView/PullToRefreshListView.cs
@@ -57,21 +57,17 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         public static readonly DependencyProperty RefreshIndicatorContentProperty =
             DependencyProperty.Register(nameof(RefreshIndicatorContent), typeof(object), typeof(PullToRefreshListView), new PropertyMetadata(null));
 
-#pragma warning disable CS0618 // Type or member is obsolete
         /// <summary>
         /// Identifies the <see cref="PullToRefreshLabel"/> property.
         /// </summary>
         public static readonly DependencyProperty PullToRefreshLabelProperty =
             DependencyProperty.Register(nameof(PullToRefreshLabel), typeof(object), typeof(PullToRefreshListView), new PropertyMetadata("Pull To Refresh", OnPullToRefreshLabelChanged));
-#pragma warning restore CS0618 // Type or member is obsolete
 
-#pragma warning disable CS0618 // Type or member is obsolete
         /// <summary>
         /// Identifies the <see cref="ReleaseToRefreshLabel"/> property.
         /// </summary>
         public static readonly DependencyProperty ReleaseToRefreshLabelProperty =
             DependencyProperty.Register(nameof(ReleaseToRefreshLabel), typeof(object), typeof(PullToRefreshListView), new PropertyMetadata("Release to Refresh", OnReleaseToRefreshLabelChanged));
-#pragma warning restore CS0618 // Type or member is obsolete
 
         /// <summary>
         /// Identifies the <see cref="PullToRefreshContent"/> property.
@@ -106,7 +102,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         private ScrollViewer _scroller;
         private CompositeTransform _contentTransform;
         private ItemsPresenter _scrollerContent;
-        [Obsolete]
         private TextBlock _defaultIndicatorContent;
         private ContentPresenter _pullAndReleaseIndicatorContent;
         private double _lastOffset = 0.0;
@@ -165,7 +160,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 _refreshIndicatorBorder.SizeChanged -= RefreshIndicatorBorder_SizeChanged;
             }
 
-#pragma warning disable CS0612 // Type or member is obsolete
             _root = GetTemplateChild(PartRoot) as Border;
             _scroller = GetTemplateChild(PartScroller) as ScrollViewer;
             _scrollerContent = GetTemplateChild(PartScrollerContent) as ItemsPresenter;
@@ -181,7 +175,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 _refreshIndicatorTransform != null &&
                 (_defaultIndicatorContent != null || _pullAndReleaseIndicatorContent != null))
             {
-                // TODO: if _defaultIndicatorContent is removed check for _pullAndReleaseIndicatorContent only)
                 _root.ManipulationMode = ManipulationModes.TranslateY;
                 _root.ManipulationDelta += Scroller_ManipulationDelta;
                 _root.ManipulationStarted += Scroller_ManipulationStarted;
@@ -204,7 +197,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
                 _overscrollMultiplier = OverscrollLimit * 8;
             }
-#pragma warning restore CS0612 // Type or member is obsolete
+
             base.OnApplyTemplate();
         }
 
@@ -291,14 +284,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         {
             if (RefreshIndicatorContent == null)
             {
-#pragma warning disable CS0612 // Type or member is obsolete
-#pragma warning disable CS0618 // Type or member is obsolete
                 if (_defaultIndicatorContent != null)
                 {
                     _defaultIndicatorContent.Text = PullToRefreshLabel;
                 }
-#pragma warning restore CS0612 // Type or member is obsolete
-#pragma warning restore CS0618 // Type or member is obsolete
 
                 if (_pullAndReleaseIndicatorContent != null)
                 {
@@ -422,14 +411,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 pullProgress = 1.0;
                 if (RefreshIndicatorContent == null)
                 {
-#pragma warning disable CS0612 // Type or member is obsolete
-#pragma warning disable CS0618 // Type or member is obsolete
                     if (_defaultIndicatorContent != null)
                     {
                         _defaultIndicatorContent.Text = ReleaseToRefreshLabel;
                     }
-#pragma warning restore CS0612 // Type or member is obsolete
-#pragma warning restore CS0618 // Type or member is obsolete
 
                     if (_pullAndReleaseIndicatorContent != null)
                     {
@@ -449,14 +434,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                     pullProgress = _pullDistance / PullThreshold;
                     if (RefreshIndicatorContent == null)
                     {
-#pragma warning disable CS0612 // Type or member is obsolete
-#pragma warning disable CS0618 // Type or member is obsolete
                         if (_defaultIndicatorContent != null)
                         {
                             _defaultIndicatorContent.Text = PullToRefreshLabel;
                         }
-#pragma warning restore CS0612 // Type or member is obsolete
-#pragma warning restore CS0618 // Type or member is obsolete
 
                         if (_pullAndReleaseIndicatorContent != null)
                         {
@@ -541,7 +522,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
             set
             {
-#pragma warning disable CS0612 // Type or member is obsolete
                 if (_defaultIndicatorContent != null && _pullAndReleaseIndicatorContent != null)
                 {
                     _defaultIndicatorContent.Visibility = Visibility.Collapsed;
@@ -550,7 +530,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 {
                     _defaultIndicatorContent.Visibility = value == null ? Visibility.Visible : Visibility.Collapsed;
                 }
-#pragma warning restore CS0612 // Type or member is obsolete
 
                 if (_pullAndReleaseIndicatorContent != null)
                 {
@@ -565,7 +544,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// Gets or sets the label that will be shown when the user pulls down to refresh.
         /// Note: This label will only show up if <see cref="RefreshIndicatorContent" /> is null/>
         /// </summary>
-        [Obsolete("Use " + nameof(PullToRefreshContent))]
         public string PullToRefreshLabel
         {
             get { return (string)GetValue(PullToRefreshLabelProperty); }
@@ -576,7 +554,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// Gets or sets the label that will be shown when the user needs to release to refresh.
         /// Note: This label will only show up if <see cref="RefreshIndicatorContent" /> is null/>
         /// </summary>
-        [Obsolete("Use " + nameof(ReleaseToRefreshContent))]
         public string ReleaseToRefreshLabel
         {
             get { return (string)GetValue(ReleaseToRefreshLabelProperty); }
@@ -591,7 +568,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// </remarks>
         public object PullToRefreshContent
         {
-            get { return (string)GetValue(PullToRefreshContentProperty); }
+            get { return (object)GetValue(PullToRefreshContentProperty); }
             set { SetValue(PullToRefreshContentProperty, value); }
         }
 

--- a/docs/controls/PullToRefreshListview.md
+++ b/docs/controls/PullToRefreshListview.md
@@ -4,7 +4,11 @@ The **PullToRefreshListView Control**, is derived from the built-in List View in
 
 This control is very common on mobile devices, where the user can pull from the top to force a content refresh in applications like Twitter.
 
-By default, the control uses the properties *PullToRefreshLabel* and *ReleaseToRefreshLabel* to provide a visual indication to the user. The *RefreshIndicatorContent* can be used with the *PullProgressChanged* event to provide a custom visual for the user.  
+This control uses the *PullToRefreshLabel* and *ReleaseToRefreshLabel* properties to provide a visual indication to the user.
+
+If you want more than a text to display, you can then use *PullToRefreshContent* and *ReleaseToRefreshContent*. In this case the *PullToRefreshLabel* and *ReleaseToRefreshLabel* properties will be ignored.
+
+The *RefreshIndicatorContent* can be used with the *PullProgressChanged* event to provide a custom visual for the user.
 
 ## Syntax
 
@@ -16,7 +20,10 @@ By default, the control uses the properties *PullToRefreshLabel* and *ReleaseToR
 	PullThreshold="100"
 	RefreshRequested="ListView_RefreshCommand" 
 	PullProgressChanged="ListView_PullProgressChanged">
-</controls:PullToRefreshListView.ItemTemplate>
+	<controls:PullToRefreshListView.RefreshIndicatorContent>
+		<Border HorizontalAlignment="Center" x:Name="refreshindicator" CornerRadius="30" Height="20" Width="20" ></Border>
+	</controls:PullToRefreshListView.RefreshIndicatorContent>
+</controls:PullToRefreshListView>
 
 ```
 


### PR DESCRIPTION
Obsolete is actually not required. I updated the doc to explain the inner behavior
Control can then be use really simply with a simple string or with a more consistent control using the content control.

