### PR TITLE
BindableValueHolder to inherit from FrameworkElement

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI/Helpers/BindableValueHolder.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Helpers/BindableValueHolder.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Helpers
     /// Can be used to change several objects' properties at a time.
     /// </summary>
     [ContentProperty(Name = nameof(Value))]
-    public class BindableValueHolder : DependencyObject
+    public class BindableValueHolder : FrameworkElement
     {
         /// <summary>
         /// Identifies the <see cref="Value"/> property.


### PR DESCRIPTION
This should have been FrameworkElement otherwise it can't actually be used in xaml.