### PR TITLE
Fixing Dispatcher.AwaitableRunAsync Null problem

### DIFF
--- a/Microsoft.Toolkit.Uwp/Helpers/DispatcherHelper.cs
+++ b/Microsoft.Toolkit.Uwp/Helpers/DispatcherHelper.cs
@@ -165,7 +165,16 @@ namespace Microsoft.Toolkit.Uwp
              {
                  try
                  {
-                     taskCompletionSource.SetResult(await function().ConfigureAwait(false));
+                     var awaitableResult = function();
+                     if (awaitableResult != null)
+                     {
+                         var result = await awaitableResult.ConfigureAwait(false);
+                         taskCompletionSource.SetResult(result);
+                     }
+                     else
+                     {
+                         taskCompletionSource.SetResult(default(T));
+                     }
                  }
                  catch (Exception e)
                  {


### PR DESCRIPTION
Fixing Dispatcher.AwaitableRunAsync Null problem
await function().ConfigureAwait(false) was throwing a null reference exception.
#608 