### PR TITLE
Fix DispatcherHelper open issues

### DIFF
--- a/Microsoft.Toolkit.Uwp/Helpers/DispatcherHelper.cs
+++ b/Microsoft.Toolkit.Uwp/Helpers/DispatcherHelper.cs
@@ -65,7 +65,12 @@ namespace Microsoft.Toolkit.Uwp
                 viewToExecuteOn,
                 async () =>
                 {
-                    await function().ConfigureAwait(false);
+                    var task = function();
+                    if (task == null)
+                    {
+                        throw new InvalidOperationException("The Task returned by function cannot be null.");
+                    }
+                    await task.ConfigureAwait(false);
                     return null;
                 }, priority);
         }
@@ -81,7 +86,12 @@ namespace Microsoft.Toolkit.Uwp
             return ExecuteOnUIThreadAsync<object>(
                 async () =>
                 {
-                    await function().ConfigureAwait(false);
+                    var task = function();
+                    if (task == null)
+                    {
+                        throw new InvalidOperationException("The Task returned by function cannot be null.");
+                    }
+                    await task.ConfigureAwait(false);
                     return null;
                 }, priority);
         }
@@ -173,7 +183,7 @@ namespace Microsoft.Toolkit.Uwp
                      }
                      else
                      {
-                         taskCompletionSource.SetResult(default(T));
+                         taskCompletionSource.SetException(new InvalidOperationException("The Task returned by function cannot be null."));
                      }
                  }
                  catch (Exception e)

--- a/Microsoft.Toolkit.Uwp/Helpers/DispatcherHelper.cs
+++ b/Microsoft.Toolkit.Uwp/Helpers/DispatcherHelper.cs
@@ -266,7 +266,6 @@ namespace Microsoft.Toolkit.Uwp
                     function();
                     return (object)null;
                 }, priority);
-            }
         }
     }
 }

--- a/Microsoft.Toolkit.Uwp/Helpers/DispatcherHelper.cs
+++ b/Microsoft.Toolkit.Uwp/Helpers/DispatcherHelper.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Toolkit.Uwp
         /// <param name="function">Asynchronous function to be executed asynchronously on UI thread</param>
         /// <param name="priority">Dispatcher execution priority, default is normal</param>
         /// <returns>Awaitable Task with type <typeparamref name="T"/></returns>
-        public static Task<T> ExecuteOnUIThreadAsync<T>(CoreApplicationView viewToExecuteOn, Func<Task<T>> function, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
+        public static Task<T> ExecuteOnUIThreadAsync<T>(this CoreApplicationView viewToExecuteOn, Func<Task<T>> function, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
         {
             if (viewToExecuteOn == null)
             {
@@ -59,7 +59,7 @@ namespace Microsoft.Toolkit.Uwp
         /// <param name="function">Asynchronous function to be executed asynchronously on UI thread</param>
         /// <param name="priority">Dispatcher execution priority, default is normal</param>
         /// <returns>Awaitable Task</returns>
-        public static Task ExecuteOnUIThreadAsync(CoreApplicationView viewToExecuteOn, Func<Task> function, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
+        public static Task ExecuteOnUIThreadAsync(this CoreApplicationView viewToExecuteOn, Func<Task> function, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
         {
             if (viewToExecuteOn == null)
             {
@@ -87,7 +87,7 @@ namespace Microsoft.Toolkit.Uwp
         /// <param name="function">Asynchronous function to be executed asynchronously on UI thread</param>
         /// <param name="priority">Dispatcher execution priority, default is normal</param>
         /// <returns>Awaitable Task/></returns>
-        public static Task ExecuteOnUIThreadAsync(CoreApplicationView viewToExecuteOn, Action function, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
+        public static Task ExecuteOnUIThreadAsync(this CoreApplicationView viewToExecuteOn, Action function, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
         {
             if (viewToExecuteOn == null)
             {
@@ -116,7 +116,7 @@ namespace Microsoft.Toolkit.Uwp
         /// <param name="function">Synchronous function with return type <typeparamref name="T"/> to be executed on UI thread</param>
         /// <param name="priority">Dispatcher execution priority, default is normal</param>
         /// <returns>Awaitable Task with type <typeparamref name="T"/></returns>
-        public static Task<T> ExecuteOnUIThreadAsync<T>(CoreApplicationView viewToExecuteOn, Func<T> function, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
+        public static Task<T> ExecuteOnUIThreadAsync<T>(this CoreApplicationView viewToExecuteOn, Func<T> function, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
         {
             if (viewToExecuteOn == null)
             {

--- a/Microsoft.Toolkit.Uwp/Helpers/DispatcherHelper.cs
+++ b/Microsoft.Toolkit.Uwp/Helpers/DispatcherHelper.cs
@@ -207,7 +207,12 @@ namespace Microsoft.Toolkit.Uwp
             return dispatcher.AwaitableRunAsync<object>(
                 async () =>
             {
-                await function().ConfigureAwait(false);
+                var task = function();
+                if (task == null)
+                {
+                    throw new InvalidOperationException("The Task returned by function cannot be null.");
+                }
+                await task.ConfigureAwait(false);
                 return null;
             }, priority);
         }

--- a/Microsoft.Toolkit.Uwp/Helpers/DispatcherHelper.cs
+++ b/Microsoft.Toolkit.Uwp/Helpers/DispatcherHelper.cs
@@ -260,27 +260,13 @@ namespace Microsoft.Toolkit.Uwp
         /// <returns>Awaitable Task</returns>
         public static Task AwaitableRunAsync(this CoreDispatcher dispatcher, Action function, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
         {
-            if (function == null)
-            {
-                throw new ArgumentNullException("function can't be null!");
-            }
-
-            var taskCompletionSource = new TaskCompletionSource<object>();
-
-            var ignored = dispatcher.RunAsync(priority, () =>
-            {
-                try
+            return dispatcher.AwaitableRunAsync(
+                () =>
                 {
                     function();
-                    taskCompletionSource.SetResult(null);
-                }
-                catch (Exception e)
-                {
-                    taskCompletionSource.SetException(e);
-                }
-            });
-
-            return taskCompletionSource.Task;
+                    return (object)null;
+                }, priority);
+            }
         }
     }
 }

--- a/docs/helpers/DispatcherHelper.md
+++ b/docs/helpers/DispatcherHelper.md
@@ -1,10 +1,11 @@
 # DispatcherHelper
 
-The DispatcherHelper class enables easy interaction with [CoreDispatcher](https://msdn.microsoft.com/en-us/library/windows/apps/windows.ui.core.coredispatcher.aspx), mainly in the case of executing a block of code in UI thread from a non-UI thread.
+The DispatcherHelper class enables easy interaction with [CoreDispatcher](https://msdn.microsoft.com/en-us/library/windows/apps/windows.ui.core.coredispatcher.aspx), mainly in the case of executing a block of code on the UI thread from a non-UI thread.
 
 _What is included in the helper?_
 - Extension method with overloads for [CoreDispatcher](https://msdn.microsoft.com/en-us/library/windows/apps/windows.ui.core.coredispatcher.aspx) class.
-- Static helper methods of executing a specific function in UI thread current application's main window (configu)
+- Extension method with overloads for [CoreApplicationView](https://msdn.microsoft.com/en-us/library/windows/apps/windows.applicationmodel.core.coreapplicationview.aspx) (for multi window applications).
+- Static helper methods for executing a specific function on the UI thread of the current application's main window.
 
 
 ## Example
@@ -14,7 +15,7 @@ _What is included in the helper?_
     // Executing from a non-UI thread with helper method
      int returnedFromUIThread = await DispatcherHelper.ExecuteOnUIThreadAsync<int>(() =>
      {
-         // Code to execute with UI thread
+         // Code to execute on main window's UI thread
          NormalTextBlock.Text = "Updated from a random thread!";
          return 1;
      });
@@ -39,5 +40,5 @@ _What is included in the helper?_
 
 ## API
 
-* [Connection Helper source code](https://github.com/Microsoft/UWPCommunityToolkit/blob/master/Microsoft.Toolkit.Uwp/Helpers/DispatcherHelper.cs)
+* [DispatcherHelper source code](https://github.com/Microsoft/UWPCommunityToolkit/blob/master/Microsoft.Toolkit.Uwp/Helpers/DispatcherHelper.cs)
 


### PR DESCRIPTION
This addresses two issues mentioned in #617.

1. Use fail fast strategy if the Func<Task> or Func<Task<T>> returns null instead of a task.

2. Also check for null in other occurances of the same problem.