### PR TITLE
Dispatcher helper improvement

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/DispatcherHelper/DispatcherHelperPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/DispatcherHelper/DispatcherHelperPage.xaml.cs
@@ -32,13 +32,16 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
         {
             int crossThreadReturnedValue = await Task.Run<int>(async () =>
             {
-                int returnedFromUIThread = await DispatcherHelper.ExecuteOnUIThreadAsync<int>(() =>
+                int returnedFromOtherThread = await DispatcherHelper.ExecuteOnUIThreadAsync(async () =>
                 {
                     NormalTextBlock.Text = "Updated from a random thread!";
-                    return 1;
+
+                    int value = await Task.Run(() => { return 1 + 1; });
+
+                    return value;
                 });
 
-                return returnedFromUIThread + 1;
+                return returnedFromOtherThread + 1;
             });
 
             await Task.Delay(200);

--- a/Microsoft.Toolkit.Uwp/Helpers/DispatcherHelper.cs
+++ b/Microsoft.Toolkit.Uwp/Helpers/DispatcherHelper.cs
@@ -253,7 +253,7 @@ namespace Microsoft.Toolkit.Uwp
 
                     if (task == null)
                     {
-                        new InvalidOperationException("Task returned from async function parameter cannot be null!");
+                        throw new InvalidOperationException("Task returned from async function parameter cannot be null!");
                     }
 
                     await task.ConfigureAwait(false);

--- a/Microsoft.Toolkit.Uwp/Helpers/DispatcherHelper.cs
+++ b/Microsoft.Toolkit.Uwp/Helpers/DispatcherHelper.cs
@@ -23,51 +23,26 @@ namespace Microsoft.Toolkit.Uwp
     public static class DispatcherHelper
     {
         /// <summary>
-        /// Execute the given function asynchronously on UI thread of the main view
+        /// Execute the given function asynchronously on given view's UI thread. Default view is the main view.
         /// </summary>
-        /// <typeparam name="T">returned data type of the function</typeparam>
         /// <param name="function">Asynchronous function to be executed asynchronously on UI thread</param>
         /// <param name="priority">Dispatcher execution priority, default is normal</param>
-        /// <returns>Awaitable Task with type <typeparamref name="T"/></returns>
-        public static Task<T> ExecuteOnUIThreadAsync<T>(Func<Task<T>> function, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
+        /// <returns>Awaitable Task/></returns>
+        public static Task ExecuteOnUIThreadAsync(Action function, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
         {
-            return ExecuteOnUIThreadAsync<T>(CoreApplication.MainView, function, priority);
+            return ExecuteOnUIThreadAsync(CoreApplication.MainView, function, priority);
         }
 
         /// <summary>
         /// Execute the given function asynchronously on given view's UI thread. Default view is the main view.
         /// </summary>
         /// <typeparam name="T">returned data type of the function</typeparam>
-        /// <param name="viewToExecuteOn">View for the <paramref name="function"/>  to be executed on </param>
-        /// <param name="function">Asynchronous function to be executed asynchronously on UI thread</param>
+        /// <param name="function">Synchronous function to be executed on UI thread</param>
         /// <param name="priority">Dispatcher execution priority, default is normal</param>
-        /// <returns>Awaitable Task with type <typeparamref name="T"/></returns>
-        public static Task<T> ExecuteOnUIThreadAsync<T>(CoreApplicationView viewToExecuteOn, Func<Task<T>> function, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
+        /// <returns>Awaitable Task </returns>
+        public static Task<T> ExecuteOnUIThreadAsync<T>(Func<T> function, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
         {
-            if (viewToExecuteOn == null)
-            {
-                throw new ArgumentNullException("viewToExecuteOn can't be null!");
-            }
-
-            return viewToExecuteOn.Dispatcher.AwaitableRunAsync<T>(function, priority);
-        }
-
-        /// <summary>
-        /// Execute the given function asynchronously on given view's UI thread. Default view is the main view.
-        /// </summary>
-        /// <param name="viewToExecuteOn">View for the <paramref name="function"/>  to be executed on </param>
-        /// <param name="function">Asynchronous function to be executed asynchronously on UI thread</param>
-        /// <param name="priority">Dispatcher execution priority, default is normal</param>
-        /// <returns>Awaitable Task</returns>
-        public static Task ExecuteOnUIThreadAsync(CoreApplicationView viewToExecuteOn, Func<Task> function, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
-        {
-            return ExecuteOnUIThreadAsync<object>(
-                viewToExecuteOn,
-                async () =>
-                {
-                    await function().ConfigureAwait(false);
-                    return null;
-                }, priority);
+            return ExecuteOnUIThreadAsync(CoreApplication.MainView, function, priority);
         }
 
         /// <summary>
@@ -78,12 +53,19 @@ namespace Microsoft.Toolkit.Uwp
         /// <returns>Awaitable Task</returns>
         public static Task ExecuteOnUIThreadAsync(Func<Task> function, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
         {
-            return ExecuteOnUIThreadAsync<object>(
-                async () =>
-                {
-                    await function().ConfigureAwait(false);
-                    return null;
-                }, priority);
+            return ExecuteOnUIThreadAsync(CoreApplication.MainView, function, priority);
+        }
+
+        /// <summary>
+        /// Execute the given function asynchronously on UI thread of the main view
+        /// </summary>
+        /// <typeparam name="T">returned data type of the function</typeparam>
+        /// <param name="function">Asynchronous function to be executed asynchronously on UI thread</param>
+        /// <param name="priority">Dispatcher execution priority, default is normal</param>
+        /// <returns>Awaitable Task with type <typeparamref name="T"/></returns>
+        public static Task<T> ExecuteOnUIThreadAsync<T>(Func<Task<T>> function, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
+        {
+            return ExecuteOnUIThreadAsync<T>(CoreApplication.MainView, function, priority);
         }
 
         /// <summary>
@@ -101,17 +83,6 @@ namespace Microsoft.Toolkit.Uwp
             }
 
             return viewToExecuteOn.Dispatcher.AwaitableRunAsync(function, priority);
-        }
-
-        /// <summary>
-        /// Execute the given function asynchronously on given view's UI thread. Default view is the main view.
-        /// </summary>
-        /// <param name="function">Asynchronous function to be executed asynchronously on UI thread</param>
-        /// <param name="priority">Dispatcher execution priority, default is normal</param>
-        /// <returns>Awaitable Task/></returns>
-        public static Task ExecuteOnUIThreadAsync(Action function, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
-        {
-            return ExecuteOnUIThreadAsync(CoreApplication.MainView, function, priority);
         }
 
         /// <summary>
@@ -135,71 +106,103 @@ namespace Microsoft.Toolkit.Uwp
         /// <summary>
         /// Execute the given function asynchronously on given view's UI thread. Default view is the main view.
         /// </summary>
-        /// <typeparam name="T">returned data type of the function</typeparam>
-        /// <param name="function">Synchronous function to be executed on UI thread</param>
-        /// <param name="priority">Dispatcher execution priority, default is normal</param>
-        /// <returns>Awaitable Task </returns>
-        public static Task<T> ExecuteOnUIThreadAsync<T>(Func<T> function, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
-        {
-            return ExecuteOnUIThreadAsync(CoreApplication.MainView, function, priority);
-        }
-
-        /// <summary>
-        /// Extension method for CoreDispatcher. Offering an actual awaitable Task with optional result that will be executed on the given dispatcher
-        /// </summary>
-        /// <typeparam name="T">returned data type of the function</typeparam>
-        /// <param name="dispatcher">Dispatcher of a thread to run <paramref name="function"/></param>
-        /// <param name="function">Asynchrounous function to be executed asynchrounously on the given dispatcher</param>
-        /// <param name="priority">Dispatcher execution priority, default is normal</param>
-        /// <returns>Awaitable Task with type <typeparamref name="T"/></returns>
-        public static Task<T> AwaitableRunAsync<T>(this CoreDispatcher dispatcher, Func<Task<T>> function, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
-        {
-            if (function == null)
-            {
-                throw new ArgumentNullException("function can't be null!");
-            }
-
-            TaskCompletionSource<T> taskCompletionSource = new TaskCompletionSource<T>();
-
-            var ignored = dispatcher.RunAsync(priority, async () =>
-             {
-                 try
-                 {
-                     var awaitableResult = function();
-                     if (awaitableResult != null)
-                     {
-                         var result = await awaitableResult.ConfigureAwait(false);
-                         taskCompletionSource.SetResult(result);
-                     }
-                     else
-                     {
-                         taskCompletionSource.SetResult(default(T));
-                     }
-                 }
-                 catch (Exception e)
-                 {
-                     taskCompletionSource.SetException(e);
-                 }
-             });
-
-            return taskCompletionSource.Task;
-        }
-
-        /// <summary>
-        /// Extension method for CoreDispatcher. Offering an actual awaitable Task with optional result that will be executed on the given dispatcher
-        /// </summary>
-        /// <param name="dispatcher">Dispatcher of a thread to run <paramref name="function"/></param>
-        /// <param name="function">Asynchrounous function to be executed asynchrounously on the given dispatcher</param>
+        /// <param name="viewToExecuteOn">View for the <paramref name="function"/>  to be executed on </param>
+        /// <param name="function">Asynchronous function to be executed asynchronously on UI thread</param>
         /// <param name="priority">Dispatcher execution priority, default is normal</param>
         /// <returns>Awaitable Task</returns>
-        public static Task AwaitableRunAsync(this CoreDispatcher dispatcher, Func<Task> function, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
+        public static Task ExecuteOnUIThreadAsync(CoreApplicationView viewToExecuteOn, Func<Task> function, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
+        {
+            if (viewToExecuteOn == null)
+            {
+                throw new ArgumentNullException("viewToExecuteOn can't be null!");
+            }
+
+            return viewToExecuteOn.Dispatcher.AwaitableRunAsync(function, priority);
+        }
+
+        /// <summary>
+        /// Execute the given function asynchronously on given view's UI thread. Default view is the main view.
+        /// </summary>
+        /// <typeparam name="T">returned data type of the function</typeparam>
+        /// <param name="viewToExecuteOn">View for the <paramref name="function"/>  to be executed on </param>
+        /// <param name="function">Asynchronous function to be executed asynchronously on UI thread</param>
+        /// <param name="priority">Dispatcher execution priority, default is normal</param>
+        /// <returns>Awaitable Task with type <typeparamref name="T"/></returns>
+        public static Task<T> ExecuteOnUIThreadAsync<T>(CoreApplicationView viewToExecuteOn, Func<Task<T>> function, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
+        {
+            if (viewToExecuteOn == null)
+            {
+                throw new ArgumentNullException("viewToExecuteOn can't be null!");
+            }
+
+            return viewToExecuteOn.Dispatcher.AwaitableRunAsync<T>(function, priority);
+        }
+
+        /// <summary>
+        /// Extension method for CoreApplicationView. Execute given function asynchronously on the main dispatcher of the current view.
+        /// </summary>
+        /// <param name="currentView">View that will have its UI thread execute the specified function</param>
+        /// <param name="function">Function to execute asynchronously on UI thread of the current view.</param>
+        /// <param name="priority">Execute priority within the UI Thread. Default to normal </param>
+        /// <returns>Awaitable Task</returns>
+        public static Task ExecuteAsync(this CoreApplicationView currentView, Action function, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
+        {
+            return currentView.Dispatcher.AwaitableRunAsync(function, priority);
+        }
+
+        /// <summary>
+        /// Extension method for CoreApplicationView. Execute given function asynchronously on the main dispatcher of the current view with a return value.
+        /// </summary>
+        /// <typeparam name="T">Type of return value</typeparam>
+        /// <param name="currentView">View that will have its UI thread execute the specified function</param>
+        /// <param name="function">Function to execute asynchronously on UI thread of the current view with a return type <typeparamref name="T"/>.</param>
+        /// <param name="priority">Execute priority within the UI Thread. Default to normal </param>
+        /// <returns>Awaitable Task with return type <typeparamref name="T"/></returns>
+        public static Task<T> ExecuteAsync<T>(this CoreApplicationView currentView, Func<T> function, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
+        {
+            return currentView.Dispatcher.AwaitableRunAsync<T>(function, priority);
+        }
+
+        /// <summary>
+        /// Extension method for CoreApplicationView. Execute given function asynchronously on the main dispatcher of the current view.
+        /// </summary>
+        /// <param name="currentView">View that will have its UI thread execute the specified function</param>
+        /// <param name="function">Asynchronous Function to execute asynchronously on UI thread of the current view.</param>
+        /// <param name="priority">Execute priority within the UI Thread. Default to normal </param>
+        /// <returns>Awaitable Task</returns>
+        public static Task ExecuteAsync(this CoreApplicationView currentView, Func<Task> function, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
+        {
+            return currentView.Dispatcher.AwaitableRunAsync(function, priority);
+        }
+
+        /// <summary>
+        /// Extension method for CoreApplicationView. Execute given function asynchronously on the main dispatcher of the current view with a return value.
+        /// </summary>
+        /// <typeparam name="T">Type of return value</typeparam>
+        /// <param name="currentView">View that will have its UI thread execute the specified function</param>
+        /// <param name="function">Asynchronous function to execute asynchronously on UI thread of the current view with a return type <typeparamref name="T"/>.</param>
+        /// <param name="priority">Execute priority within the UI Thread. Default to normal </param>
+        /// <returns>Awaitable Task with return type <typeparamref name="T"/></returns>
+        public static Task<T> ExecuteAsync<T>(this CoreApplicationView currentView, Func<Task<T>> function, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
+        {
+            return currentView.Dispatcher.AwaitableRunAsync<T>(function, priority);
+        }
+
+        /// <summary>
+        /// Extension method for CoreDispatcher. Offering an actual awaitable Task with optional result that will be executed on the given dispatcher
+        /// </summary>
+        /// <param name="dispatcher">Dispatcher of a thread to run <paramref name="function"/></param>
+        /// <param name="function"> Function to be executed asynchrounously on the given dispatcher</param>
+        /// <param name="priority">Dispatcher execution priority, default is normal</param>
+        /// <returns>Awaitable Task</returns>
+        public static Task AwaitableRunAsync(this CoreDispatcher dispatcher, Action function, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
         {
             return dispatcher.AwaitableRunAsync<object>(
-                async () =>
-            {
-                await function().ConfigureAwait(false);
-                return null;
-            }, priority);
+                () =>
+                {
+                    function();
+                    return new object();
+                }, priority);
         }
 
         /// <summary>
@@ -238,17 +241,65 @@ namespace Microsoft.Toolkit.Uwp
         /// Extension method for CoreDispatcher. Offering an actual awaitable Task with optional result that will be executed on the given dispatcher
         /// </summary>
         /// <param name="dispatcher">Dispatcher of a thread to run <paramref name="function"/></param>
-        /// <param name="function"> Function to be executed asynchrounously on the given dispatcher</param>
+        /// <param name="function">Asynchrounous function to be executed asynchrounously on the given dispatcher</param>
         /// <param name="priority">Dispatcher execution priority, default is normal</param>
         /// <returns>Awaitable Task</returns>
-        public static Task AwaitableRunAsync(this CoreDispatcher dispatcher, Action function, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
+        public static Task AwaitableRunAsync(this CoreDispatcher dispatcher, Func<Task> function, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
         {
             return dispatcher.AwaitableRunAsync<object>(
-                () =>
+                async () =>
                 {
-                    function();
-                    return null;
+                    var task = function();
+
+                    if (task == null)
+                    {
+                        new InvalidOperationException("Task returned from async function parameter cannot be null!");
+                    }
+
+                    await task.ConfigureAwait(false);
+                    return new object();
                 }, priority);
+        }
+
+        /// <summary>
+        /// Extension method for CoreDispatcher. Offering an actual awaitable Task with optional result that will be executed on the given dispatcher
+        /// </summary>
+        /// <typeparam name="T">returned data type of the function</typeparam>
+        /// <param name="dispatcher">Dispatcher of a thread to run <paramref name="function"/></param>
+        /// <param name="function">Asynchrounous function to be executed asynchrounously on the given dispatcher</param>
+        /// <param name="priority">Dispatcher execution priority, default is normal</param>
+        /// <returns>Awaitable Task with type <typeparamref name="T"/></returns>
+        public static Task<T> AwaitableRunAsync<T>(this CoreDispatcher dispatcher, Func<Task<T>> function, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
+        {
+            if (function == null)
+            {
+                throw new ArgumentNullException("function can't be null!");
+            }
+
+            TaskCompletionSource<T> taskCompletionSource = new TaskCompletionSource<T>();
+
+            var ignored = dispatcher.RunAsync(priority, async () =>
+             {
+                 try
+                 {
+                     var awaitableResult = function();
+                     if (awaitableResult != null)
+                     {
+                         var result = await awaitableResult.ConfigureAwait(false);
+                         taskCompletionSource.SetResult(result);
+                     }
+                     else
+                     {
+                         taskCompletionSource.SetException(new InvalidOperationException("Task returned from async function parameter cannot be null!"));
+                     }
+                 }
+                 catch (Exception e)
+                 {
+                     taskCompletionSource.SetException(e);
+                 }
+             });
+
+            return taskCompletionSource.Task;
         }
     }
 }


### PR DESCRIPTION
Addressing issue #617 and stealing the thunder of @lukasf :) 

Things to discuss:
- The name of the overloads + extension method. This helper contains `ExecuteOnUIThread` helper methods that have overloads that accept `CoreApplicationView` as a parameter. But now introducing another `CoreApplicationView` extension method that was requested on PR #551 , with the name of `ExecuteAsync`. In need of feedback on the naming scheme before the release of 1.2 to prevent any breaking change later on. 