### PR TITLE
HttpHelper expose constructor

### DIFF
--- a/Microsoft.Toolkit.Uwp/Helpers/HttpHelper/HttpHelper.cs
+++ b/Microsoft.Toolkit.Uwp/Helpers/HttpHelper/HttpHelper.cs
@@ -27,19 +27,21 @@ namespace Microsoft.Toolkit.Uwp
         /// <summary>
         /// Maximum number of Http Clients that can be pooled.
         /// </summary>
-        private const int MaxPoolSize = 10;
+        private const int DefaultPoolSize = 10;
 
         /// <summary>
         /// Private singleton field.
         /// </summary>
         private static HttpHelper _instance;
 
-        private SemaphoreSlim _semaphore = new SemaphoreSlim(MaxPoolSize);
+        private SemaphoreSlim _semaphore = null;
 
         /// <summary>
         /// Private instance field.
         /// </summary>
         private ConcurrentQueue<HttpClient> _httpClientQueue = null;
+
+        private IHttpFilter _httpFilter = null;
 
         /// <summary>
         /// Gets public singleton property.
@@ -49,8 +51,20 @@ namespace Microsoft.Toolkit.Uwp
         /// <summary>
         /// Initializes a new instance of the <see cref="HttpHelper"/> class.
         /// </summary>
-        protected HttpHelper()
+        public HttpHelper()
+            : this(DefaultPoolSize, GetDefaultFilter())
         {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HttpHelper"/> class.
+        /// </summary>
+        /// <param name="poolSize">number of HttpClient instances allowed</param>
+        /// <param name="httpFilter">HttpFilter to use when instances of HttpClient are created</param>
+        public HttpHelper(int poolSize, IHttpFilter httpFilter)
+        {
+            _httpFilter = httpFilter;
+            _semaphore = new SemaphoreSlim(poolSize);
             _httpClientQueue = new ConcurrentQueue<HttpClient>();
         }
 
@@ -89,6 +103,14 @@ namespace Microsoft.Toolkit.Uwp
             }
         }
 
+        private static IHttpFilter GetDefaultFilter()
+        {
+            var filter = new HttpBaseProtocolFilter();
+            filter.CacheControl.ReadBehavior = HttpCacheReadBehavior.MostRecent;
+
+            return filter;
+        }
+
         private HttpClient GetHttpClientInstance()
         {
             HttpClient client = null;
@@ -96,10 +118,9 @@ namespace Microsoft.Toolkit.Uwp
             // Try and get HttpClient from the queue
             if (!_httpClientQueue.TryDequeue(out client))
             {
-                var filter = new HttpBaseProtocolFilter();
-                filter.CacheControl.ReadBehavior = HttpCacheReadBehavior.MostRecent;
+                
 
-                client = new HttpClient(filter);
+                client = new HttpClient(_httpFilter);
             }
 
             return client;


### PR DESCRIPTION
Addressing #602
Expose the default constructor
Create additional constructor that allows passing pool size and http filter

Tested on ImageCache and Bing Search service to ensure that existing functionality hasn't changed