### PR TITLE
Add IsDetailsOpen property to MasterDetailsView

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.Events.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.Events.cs
@@ -10,6 +10,7 @@
 // THE CODE OR THE USE OR OTHER DEALINGS IN THE CODE.
 // ******************************************************************
 
+using System;
 using Windows.UI.Xaml.Controls;
 
 namespace Microsoft.Toolkit.Uwp.UI.Controls
@@ -24,6 +25,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// Occurs when the currently selected item changes.
         /// </summary>
         public event SelectionChangedEventHandler SelectionChanged;
+
+        /// <summary>
+        /// Occurs when the view state changes
+        /// </summary>
+        public event EventHandler<MasterDetailsViewState> ViewStateChanged;
 
         private void OnSelectionChanged(SelectionChangedEventArgs e)
         {

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.Properties.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.Properties.cs
@@ -103,6 +103,16 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             new PropertyMetadata(null));
 
         /// <summary>
+        /// Identifies the <see cref="ViewState"/> dependency property
+        /// </summary>
+        /// <returns>The identifier for the <see cref="ViewState"/> dependency property.</returns>
+        public static readonly DependencyProperty ViewStateProperty = DependencyProperty.Register(
+            nameof(ViewState),
+            typeof(MasterDetailsViewState),
+            typeof(MasterDetailsView),
+            new PropertyMetadata(default(MasterDetailsViewState)));
+
+        /// <summary>
         /// Gets or sets the selected item.
         /// </summary>
         /// <returns>The selected item. The default is null.</returns>
@@ -188,6 +198,15 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         {
             get { return (DataTemplate)GetValue(NoSelectionContentTemplateProperty); }
             set { SetValue(NoSelectionContentTemplateProperty, value); }
+        }
+
+        /// <summary>
+        /// Gets the current visual state of the control
+        /// </summary>
+        public MasterDetailsViewState ViewState
+        {
+            get { return (MasterDetailsViewState)GetValue(ViewStateProperty); }
+            private set { SetValue(ViewStateProperty, value); }
         }
 
         /// <summary>

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.cs
@@ -147,6 +147,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             _stateGroup.CurrentStateChanged += OnVisualStateChanged;
 
             _narrowState = GetTemplateChild(NarrowState) as VisualState;
+
+            UpdateViewState();
         }
 
         private void OnUnloaded(object sender, RoutedEventArgs e)
@@ -187,7 +189,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// <param name="args">The event args</param>
         private void OnBackRequested(object sender, BackRequestedEventArgs args)
         {
-            if (((_stateGroup.CurrentState == _narrowState) || (_stateGroup.CurrentState == null)) && (SelectedItem != null))
+            if (ViewState == MasterDetailsViewState.Details)
             {
                 SelectedItem = null;
                 args.Handled = true;
@@ -218,7 +220,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// </summary>
         private void SetBackButtonVisibility(VisualState currentState)
         {
-            if ((currentState == _narrowState) && (SelectedItem != null))
+            UpdateViewState();
+
+            if (ViewState == MasterDetailsViewState.Details)
             {
                 SystemNavigationManager.GetForCurrentView().AppViewBackButtonVisibility =
                     AppViewBackButtonVisibility.Visible;
@@ -252,6 +256,18 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             animation.Duration = TimeSpan.FromMilliseconds(250);
 
             targetVisual.StartAnimation("Offset", animation);
+        }
+
+        private void UpdateViewState()
+        {
+            if (_stateGroup.CurrentState == _narrowState || _stateGroup.CurrentState == null)
+            {
+                ViewState = SelectedItem == null ? MasterDetailsViewState.Master : MasterDetailsViewState.Details;
+            }
+            else
+            {
+                ViewState = MasterDetailsViewState.Both;
+            }
         }
     }
 }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.cs
@@ -260,6 +260,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
         private void UpdateViewState()
         {
+            var before = ViewState;
+
             if (_stateGroup.CurrentState == _narrowState || _stateGroup.CurrentState == null)
             {
                 ViewState = SelectedItem == null ? MasterDetailsViewState.Master : MasterDetailsViewState.Details;
@@ -267,6 +269,13 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             else
             {
                 ViewState = MasterDetailsViewState.Both;
+            }
+
+            var after = ViewState;
+
+            if (before != after)
+            {
+                ViewStateChanged?.Invoke(this, after);
             }
         }
     }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsViewState.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsViewState.cs
@@ -1,0 +1,32 @@
+﻿// ******************************************************************
+// Copyright (c) Microsoft. All rights reserved.
+// This code is licensed under the MIT License (MIT).
+// THE CODE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH
+// THE CODE OR THE USE OR OTHER DEALINGS IN THE CODE.
+// ******************************************************************
+
+namespace Microsoft.Toolkit.Uwp.UI.Controls
+{
+    public enum MasterDetailsViewState
+    {
+        /// <summary>
+        /// Only the Master view is shown
+        /// </summary>
+        Master,
+
+        /// <summary>
+        /// Only the Details view is shown
+        /// </summary>
+        Details,
+
+        /// <summary>
+        /// Both the Master and Details views are shown
+        /// </summary>
+        Both
+    }
+}

--- a/Microsoft.Toolkit.Uwp.UI.Controls/Microsoft.Toolkit.Uwp.UI.Controls.csproj
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/Microsoft.Toolkit.Uwp.UI.Controls.csproj
@@ -71,6 +71,7 @@
     <Compile Include="MasterDetailsView\MasterDetailsView.Events.cs" />
     <Compile Include="MasterDetailsView\MasterDetailsView.Properties.cs" />
     <Compile Include="BladeView\BladeItem.Events.cs" />
+    <Compile Include="MasterDetailsView\MasterDetailsViewState.cs" />
     <Compile Include="SlidableListItem\SwipeStatus.cs" />
     <Compile Include="SlidableListItem\SwipeStatusChangedEventArgs.cs" />
     <None Include="Microsoft.Toolkit.Uwp.UI.Controls.ruleset" />

--- a/docs/controls/MasterDetailsView.md
+++ b/docs/controls/MasterDetailsView.md
@@ -1,6 +1,6 @@
 # MasterDetailsView XAML Control 
 
-The **MasterDetailsView Control** presents items in a master/details pattern. It shows a collection of items within the "master panel" and the details for that item within the "details panel". The MasterDetailsView reacts to the width it is given to determine if it should show both the master and details or just one of the two.
+The **MasterDetailsView Control** presents items in a master/details pattern. It shows a collection of items within the "master panel" and the details for that item within the "details panel". The MasterDetailsView reacts to the width it is given to determine if it should show both the master and details or just one of the two. There is a dependency property `ViewState` or an event `ViewStateChanged` that can be used to track which state the control is in.
 
 ## Syntax
 


### PR DESCRIPTION
This adds a readonly property to the MasterDetailsView to allow an easy way to query whether or not the MasterDetailsView is in the open state. 

Fixes #660