### PR TITLE
Fixed WebViewExtensions bug & documentation

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI/Extensions/WebViewExtensions.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/WebViewExtensions.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Toolkit.Uwp.UI
 
             var content = e.NewValue as string;
 
-            if (!string.IsNullOrEmpty(content))
+            if (string.IsNullOrEmpty(content))
             {
                 return;
             }

--- a/docs/helpers/WebViewExtensions.md
+++ b/docs/helpers/WebViewExtensions.md
@@ -1,4 +1,4 @@
-# HyperlinkExtensions
+# WebViewExtensions
 
 The **WebViewExtensions** allows attaching HTML content to WebView.
 


### PR DESCRIPTION
- WebViewExtensions was not working as it did not navigate to the new string when it was not empty.
- Fixed wrong heading in Documentation for WebViewExtensions 
