### PR TITLE
Add Incremental Loading supporto for BingService

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Bing Service/BingCode.bind
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Bing Service/BingCode.bind
@@ -11,4 +11,11 @@ var searchConfig = new BingSearchConfig
     QueryType = BingQueryType.Search
 };
 
+// To perform a single call to get 50 items:
 ListView.ItemsSource = await BingService.Instance.RequestAsync(searchConfig, 50);
+
+// To make an incremental loading of search results:
+var service = BingService.GetIncrementalLoadingService(searchConfig);
+var collection = new IncrementalLoadingCollection<BingService, BingResult>(service, 50);
+ListView.ItemsSource = collection;
+

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Bing Service/BingCode.bind
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Bing Service/BingCode.bind
@@ -14,8 +14,6 @@ var searchConfig = new BingSearchConfig
 // To perform a single call to get 50 items:
 ListView.ItemsSource = await BingService.Instance.RequestAsync(searchConfig, 50);
 
-// To make an incremental loading of search results:
-var service = BingService.GetIncrementalLoadingService(searchConfig);
-var collection = new IncrementalLoadingCollection<BingService, BingResult>(service, 50);
-ListView.ItemsSource = collection;
+// To perform an incremental loading of search results (50 for each call):
+ListView.ItemsSource = BingService.GetAsIncrementalLoading(searchConfig, 50);
 

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Bing Service/BingPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Bing Service/BingPage.xaml.cs
@@ -13,8 +13,8 @@
 using System;
 using System.Linq;
 using Microsoft.Toolkit.Uwp.Services.Bing;
-using Windows.UI.Xaml;
 using Windows.UI.Core;
+using Windows.UI.Xaml;
 
 namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
 {
@@ -67,18 +67,9 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
             };
 
             // Gets an instance of BingService that is able to load search results incrementally.
-            var service = BingService.GetIncrementalLoadingService(searchConfig);
-            var collection = new IncrementalLoadingCollection<BingService, BingResult>(
-                source: service,
-                itemsPerPage: 50,
-                onStartLoading: async () =>
-                {
-                    await Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () => { Shell.Current.DisplayWaitRing = true; });
-                },
-                onEndLoading: async () =>
-                {
-                    await Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () => { Shell.Current.DisplayWaitRing = false; });
-                });
+            var collection = BingService.GetAsIncrementalLoading(searchConfig, 50);
+            collection.OnStartLoading = async () => await Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () => { Shell.Current.DisplayWaitRing = true; });
+            collection.OnEndLoading = async () => await Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () => { Shell.Current.DisplayWaitRing = false; });
 
             ListView.ItemsSource = collection;
         }

--- a/Microsoft.Toolkit.Uwp.Services/Core/DataProviderBase.cs
+++ b/Microsoft.Toolkit.Uwp.Services/Core/DataProviderBase.cs
@@ -30,10 +30,11 @@ namespace Microsoft.Toolkit.Uwp.Services
         /// <typeparam name="TSchema">Strong typed object to parse the response items into.</typeparam>
         /// <param name="config">Query configuration.</param>
         /// <param name="maxRecords">Upper record limit.</param>
+        /// <param name="pageIndex">The zero-based index of the page that corresponds to the items to retrieve.</param>
         /// <param name="parser">Parser to use for results.</param>
         /// <returns>Strong typed list of results.</returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "This is an async method, so nesting generic types is necessary.")]
-        public async Task<IEnumerable<TSchema>> LoadDataAsync<TSchema>(TConfig config, int maxRecords, IParser<TSchema> parser)
+        public async Task<IEnumerable<TSchema>> LoadDataAsync<TSchema>(TConfig config, int maxRecords, int pageIndex, IParser<TSchema> parser)
             where TSchema : SchemaBase
         {
             if (config == null)
@@ -48,7 +49,7 @@ namespace Microsoft.Toolkit.Uwp.Services
 
             ValidateConfig(config);
 
-            var result = await GetDataAsync(config, maxRecords, parser);
+            var result = await GetDataAsync(config, maxRecords, pageIndex, parser);
             if (result != null)
             {
                 return result
@@ -64,10 +65,11 @@ namespace Microsoft.Toolkit.Uwp.Services
         /// </summary>
         /// <param name="config">Configuration to use</param>
         /// <param name="maxRecords">Maximum number of records to return</param>
+        /// <param name="pageIndex">The zero-based index of the page that corresponds to the items to retrieve.</param>
         /// <param name="parser">Parser to use</param>
         /// <typeparam name="TSchema">Schema defining data returned</typeparam>
         /// <returns>List of data</returns>
-        protected abstract Task<IEnumerable<TSchema>> GetDataAsync<TSchema>(TConfig config, int maxRecords, IParser<TSchema> parser)
+        protected abstract Task<IEnumerable<TSchema>> GetDataAsync<TSchema>(TConfig config, int maxRecords, int pageIndex, IParser<TSchema> parser)
             where TSchema : SchemaBase;
 
         /// <summary>

--- a/Microsoft.Toolkit.Uwp.Services/Core/DataProviderBase{TConfig,TSchema}.cs
+++ b/Microsoft.Toolkit.Uwp.Services/Core/DataProviderBase{TConfig,TSchema}.cs
@@ -28,10 +28,11 @@ namespace Microsoft.Toolkit.Uwp.Services
         /// </summary>
         /// <param name="config">Query configuration.</param>
         /// <param name="maxRecords">Upper record limit.</param>
+        /// <param name="pageIndex">The zero-based index of the page that corresponds to the items to retrieve.</param>
         /// <returns>List of strong typed objects.</returns>
-        public Task<IEnumerable<TSchema>> LoadDataAsync(TConfig config, int maxRecords = 20)
+        public Task<IEnumerable<TSchema>> LoadDataAsync(TConfig config, int maxRecords = 20, int pageIndex = 0)
         {
-            return LoadDataAsync(config, maxRecords, GetDefaultParser(config));
+            return LoadDataAsync(config, maxRecords, pageIndex, GetDefaultParser(config));
         }
 
         /// <summary>

--- a/Microsoft.Toolkit.Uwp.Services/Core/IDataService{T,U,V}.cs
+++ b/Microsoft.Toolkit.Uwp.Services/Core/IDataService{T,U,V}.cs
@@ -33,7 +33,8 @@ namespace Microsoft.Toolkit.Uwp.Services.Core
         /// </summary>
         /// <param name="config">Describes the query on the list data request.</param>
         /// <param name="maxRecords">Specifies an upper limit to the number of records returned.</param>
+        /// <param name="pageIndex">The zero-based index of the page that corresponds to the items to retrieve.</param>
         /// <returns>Returns a strongly typed list of results from the service.</returns>
-        Task<List<U>> RequestAsync(V config, int maxRecords);
+        Task<List<U>> RequestAsync(V config, int maxRecords, int pageIndex = 0);
     }
 }

--- a/Microsoft.Toolkit.Uwp.Services/Services/Bing/BingDataProvider.cs
+++ b/Microsoft.Toolkit.Uwp.Services/Services/Bing/BingDataProvider.cs
@@ -37,9 +37,10 @@ namespace Microsoft.Toolkit.Uwp.Services.Bing
         /// <typeparam name="TSchema">Schema to use</typeparam>
         /// <param name="config">Query configuration.</param>
         /// <param name="maxRecords">Upper limit for records returned.</param>
+        /// <param name="pageIndex">The zero-based index of the page that corresponds to the items to retrieve.</param>
         /// <param name="parser">IParser implementation for interpreting results.</param>
         /// <returns>Strongly typed list of results.</returns>
-        protected override async Task<IEnumerable<TSchema>> GetDataAsync<TSchema>(BingSearchConfig config, int maxRecords, IParser<TSchema> parser)
+        protected override async Task<IEnumerable<TSchema>> GetDataAsync<TSchema>(BingSearchConfig config, int maxRecords, int pageIndex, IParser<TSchema> parser)
         {
             var countryValue = config.Country.GetStringValue();
             var languageValue = config.Language.GetStringValue();
@@ -70,7 +71,7 @@ namespace Microsoft.Toolkit.Uwp.Services.Bing
                     break;
             }
 
-            var uri = new Uri($"{BaseUrl}{queryTypeParameter}/search?q={locParameter}{languageParameter}{WebUtility.UrlEncode(config.Query)}&format=rss&count={maxRecords}");
+            var uri = new Uri($"{BaseUrl}{queryTypeParameter}/search?q={locParameter}{languageParameter}{WebUtility.UrlEncode(config.Query)}&format=rss&count={maxRecords}&first={(pageIndex * maxRecords) + (pageIndex > 0 ? 1 : 0)}");
 
             using (HttpHelperRequest request = new HttpHelperRequest(uri, HttpMethod.Get))
             {

--- a/Microsoft.Toolkit.Uwp.Services/Services/Bing/BingService.cs
+++ b/Microsoft.Toolkit.Uwp.Services/Services/Bing/BingService.cs
@@ -54,12 +54,16 @@ namespace Microsoft.Toolkit.Uwp.Services.Bing
         public static BingService Instance => instance ?? (instance = new BingService());
 
         /// <summary>
-        /// Gets an instance of <see cref="BingService"/> class that is able to load search data incrementally.
+        /// Gets an instance of <see cref="IncrementalLoadingCollection{TSource, IType}"/> class that is able to load search data incrementally.
         /// </summary>
         /// <param name="config">BingSearchConfig instance.</param>
-        /// <returns>An instance of <see cref="BingService"/> class that is able to load search data incrementally.</returns>
-        public static BingService GetIncrementalLoadingService(BingSearchConfig config)
-            => new BingService(config);
+        /// <param name="maxRecords">Upper limit of records to return.</param>
+        /// <returns>An instance of <see cref="IncrementalLoadingCollection{TSource, IType}"/> class that is able to load search data incrementally.</returns>
+        public static IncrementalLoadingCollection<BingService, BingResult> GetAsIncrementalLoading(BingSearchConfig config, int maxRecords = 20)
+        {
+            var service = new BingService(config);
+            return new IncrementalLoadingCollection<BingService, BingResult>(service, maxRecords);
+        }
 
         /// <summary>
         /// Gets a reference to an instance of the underlying data provider.

--- a/Microsoft.Toolkit.Uwp.Services/Services/Bing/BingService.cs
+++ b/Microsoft.Toolkit.Uwp.Services/Services/Bing/BingService.cs
@@ -11,6 +11,8 @@
 // ******************************************************************
 
 using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Toolkit.Uwp.Services.Core;
 
@@ -19,8 +21,10 @@ namespace Microsoft.Toolkit.Uwp.Services.Bing
     /// <summary>
     /// Class for connecting to Bing.
     /// </summary>
-    public class BingService : IDataService<BingDataProvider, BingResult, BingSearchConfig>
+    public class BingService : IDataService<BingDataProvider, BingResult, BingSearchConfig>, IIncrementalSource<BingResult>
     {
+        private readonly BingSearchConfig _config;
+
         private BingDataProvider bingDataProvider;
 
         /// <summary>
@@ -28,6 +32,15 @@ namespace Microsoft.Toolkit.Uwp.Services.Bing
         /// </summary>
         public BingService()
         {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BingService"/> class.
+        /// </summary>
+        /// <param name="config">BingSearchConfig instance.</param>
+        private BingService(BingSearchConfig config)
+        {
+            _config = config;
         }
 
         /// <summary>
@@ -41,6 +54,14 @@ namespace Microsoft.Toolkit.Uwp.Services.Bing
         public static BingService Instance => instance ?? (instance = new BingService());
 
         /// <summary>
+        /// Gets an instance of <see cref="BingService"/> class that is able to load search data incrementally.
+        /// </summary>
+        /// <param name="config">BingSearchConfig instance.</param>
+        /// <returns>An instance of <see cref="BingService"/> class that is able to load search data incrementally.</returns>
+        public static BingService GetIncrementalLoadingService(BingSearchConfig config)
+            => new BingService(config);
+
+        /// <summary>
         /// Gets a reference to an instance of the underlying data provider.
         /// </summary>
         public BingDataProvider Provider => bingDataProvider ?? (bingDataProvider = new BingDataProvider());
@@ -50,12 +71,13 @@ namespace Microsoft.Toolkit.Uwp.Services.Bing
         /// </summary>
         /// <param name="config">BingSearchConfig instance.</param>
         /// <param name="maxRecords">Upper limit of records to return.</param>
+        /// <param name="pageIndex">The zero-based index of the page that corresponds to the items to retrieve.</param>
         /// <returns>Strongly typed list of data returned from the service.</returns>
-        public async Task<List<BingResult>> RequestAsync(BingSearchConfig config, int maxRecords = 20)
+        public async Task<List<BingResult>> RequestAsync(BingSearchConfig config, int maxRecords = 20, int pageIndex = 0)
         {
             List<BingResult> queryResults = new List<BingResult>();
 
-            var results = await Provider.LoadDataAsync(config, maxRecords);
+            var results = await Provider.LoadDataAsync(config, maxRecords, pageIndex);
 
             foreach (var result in results)
             {
@@ -63,6 +85,27 @@ namespace Microsoft.Toolkit.Uwp.Services.Bing
             }
 
             return queryResults;
+        }
+
+        /// <summary>
+        /// Retrieves items based on <paramref name="pageIndex"/> and <paramref name="pageSize"/> arguments.
+        /// </summary>
+        /// <param name="pageIndex">
+        /// The zero-based index of the page that corresponds to the items to retrieve.
+        /// </param>
+        /// <param name="pageSize">
+        /// The number of records to retrieve for the specified <paramref name="pageIndex"/>.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// Used to propagate notification that operation should be canceled.
+        /// </param>
+        /// <returns>
+        /// Strongly typed list of data returned from the service.
+        /// </returns>
+        public async Task<IEnumerable<BingResult>> GetPagedItemsAsync(int pageIndex, int pageSize, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var queryResult = await RequestAsync(_config, pageSize, pageIndex);
+            return queryResult.AsEnumerable();
         }
     }
 }

--- a/Microsoft.Toolkit.Uwp.Services/Services/Twitter/TwitterDataProvider.cs
+++ b/Microsoft.Toolkit.Uwp.Services/Services/Twitter/TwitterDataProvider.cs
@@ -414,9 +414,10 @@ namespace Microsoft.Toolkit.Uwp.Services.Twitter
         /// <typeparam name="TSchema">Schema to use</typeparam>
         /// <param name="config">Query configuration.</param>
         /// <param name="maxRecords">Upper limit for records returned.</param>
+        /// <param name="pageIndex">The zero-based index of the page that corresponds to the items to retrieve.</param>
         /// <param name="parser">IParser implementation for interpreting results.</param>
         /// <returns>Strongly typed list of results.</returns>
-        protected override async Task<IEnumerable<TSchema>> GetDataAsync<TSchema>(TwitterDataConfig config, int maxRecords, IParser<TSchema> parser)
+        protected override async Task<IEnumerable<TSchema>> GetDataAsync<TSchema>(TwitterDataConfig config, int maxRecords, int pageIndex, IParser<TSchema> parser)
         {
             IEnumerable<TSchema> items;
             switch (config.QueryType)

--- a/Microsoft.Toolkit.Uwp/IncrementalLoadingCollection/IncrementalLoadingCollection.cs
+++ b/Microsoft.Toolkit.Uwp/IncrementalLoadingCollection/IncrementalLoadingCollection.cs
@@ -42,6 +42,21 @@ namespace Microsoft.Toolkit.Uwp
          where TSource : IIncrementalSource<IType>
     {
         /// <summary>
+        /// Gets or sets an <see cref="Action"/> that is called when a retrieval operation begins.
+        /// </summary>
+        public Action OnStartLoading { get; set; }
+
+        /// <summary>
+        /// Gets or sets an <see cref="Action"/> that is called when a retrieval operation ends.
+        /// </summary>
+        public Action OnEndLoading { get; set; }
+
+        /// <summary>
+        /// Gets or sets an <see cref="Action"/> that is called if an error occours during data retrieval. The actual <see cref="Exception"/> is passed as an argument.
+        /// </summary>
+        public Action<Exception> OnError { get; set; }
+
+        /// <summary>
         /// Gets a value indicating the source of incremental loading.
         /// </summary>
         protected TSource Source { get; }
@@ -55,10 +70,6 @@ namespace Microsoft.Toolkit.Uwp
         /// Gets or sets a value indicating The zero-based index of the current items page.
         /// </summary>
         protected int CurrentPageIndex { get; set; }
-
-        private readonly Action _onStartLoading;
-        private readonly Action _onEndLoading;
-        private readonly Action<Exception> _onError;
 
         private bool _isLoading;
         private bool _hasMoreItems;
@@ -83,11 +94,11 @@ namespace Microsoft.Toolkit.Uwp
 
                     if (_isLoading)
                     {
-                        _onStartLoading?.Invoke();
+                        OnStartLoading?.Invoke();
                     }
                     else
                     {
-                        _onEndLoading?.Invoke();
+                        OnEndLoading?.Invoke();
                     }
                 }
             }
@@ -167,9 +178,9 @@ namespace Microsoft.Toolkit.Uwp
 
             Source = source;
 
-            _onStartLoading = onStartLoading;
-            _onEndLoading = onEndLoading;
-            _onError = onError;
+            OnStartLoading = onStartLoading;
+            OnEndLoading = onEndLoading;
+            OnError = onError;
 
             ItemsPerPage = itemsPerPage;
             _hasMoreItems = true;
@@ -221,9 +232,9 @@ namespace Microsoft.Toolkit.Uwp
                     {
                         // The operation has been canceled using the Cancellation Token.
                     }
-                    catch (Exception ex) when (_onError != null)
+                    catch (Exception ex) when (OnError != null)
                     {
-                        _onError.Invoke(ex);
+                        OnError.Invoke(ex);
                     }
 
                     if (data != null && data.Any() && !_cancellationToken.IsCancellationRequested)


### PR DESCRIPTION
BingService now has the ability either to get all the requested data with a single call, or to incrementally load search results as the view requests them.
If this approach is OK, it can be extended also to TwitterService.