### PR TITLE
Adding Latitude and Longitude to Twitter Status Update...

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp/Package.appxmanifest
+++ b/Microsoft.Toolkit.Uwp.SampleApp/Package.appxmanifest
@@ -37,5 +37,6 @@
   </Applications>
   <Capabilities>
     <Capability Name="internetClient" />
+    <DeviceCapability Name="location" />
   </Capabilities>
 </Package>

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Twitter Service/TwitterCode.bind
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Twitter Service/TwitterCode.bind
@@ -17,8 +17,28 @@ ListView.ItemsSource = await TwitterService.Instance.GetUserTimeLineAsync(user.S
 // Post a tweet
 await TwitterService.Instance.TweetStatusAsync(TweetText.Text);
 
+var status = new TwitterStatus
+{
+    Message = TweetText.Text,
+
+    // Optional parameters defined by the Twitter "update" API
+    // (they may all be null or false)
+
+    DisplayCoordinates = true,
+    InReplyToStatusId = "@ValidAccount",
+    Latitude = validLatitude,
+    Longitude = validLongitude,
+    PlaceId = "df51dec6f4ee2b2c",   // As defined by Twitter
+    PossiblySensitive = true,       // As defined by Twitter (nudity, violence, or medical procedures)
+    TrimUser = true
+}
+
+await TwitterService.Instance.TweetStatusAsync(status);
+
 // Post a tweet with a picture
 await TwitterService.Instance.TweetStatusAsync(TweetText.Text, stream);
+
+await TwitterService.Instance.TweetStatusAsync(status, stream);
 
 // Search for a specific tag
 ListView.ItemsSource = await TwitterService.Instance.SearchAsync(TagText.Text, 50);

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Twitter Service/TwitterPage.xaml
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Twitter Service/TwitterPage.xaml
@@ -187,6 +187,26 @@
                             <TextBox x:Name="TweetText"
                                      Margin="0,0,0,12"
                                      Header="Tweet" />
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition />
+                                    <ColumnDefinition />
+                                    <ColumnDefinition />
+                                </Grid.ColumnDefinitions>
+                                <TextBox x:Name="Latitude"
+                                         Margin="0,0,6,12"
+                                         Header="Latitude" />
+                                <TextBox x:Name="Longitude"
+                                         Grid.Column="1"
+                                         Margin="6,0,6,12"
+                                         Header="Longitude" />
+                                <CheckBox x:Name="DisplayCoordinates"
+                                          Grid.Column="2"
+                                          Margin="6,0,6,12"
+                                          VerticalAlignment="Bottom"
+                                          Content="Display Coords" />
+                            </Grid>
+
                             <StackPanel Orientation="Horizontal">
                                 <Button x:Name="ShareButton"
                                         Margin="0,0,12,0"
@@ -247,7 +267,8 @@
                               SelectionMode="None">
                         <ListView.ItemContainerStyle>
                             <Style TargetType="ListViewItem">
-                                <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                                <Setter Property="HorizontalContentAlignment"
+                                        Value="Stretch" />
                                 <Setter Property="Template">
                                     <Setter.Value>
                                         <ControlTemplate TargetType="ListViewItem">

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Twitter Service/TwitterPage.xaml
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Twitter Service/TwitterPage.xaml
@@ -189,19 +189,25 @@
                                      Header="Tweet" />
                             <Grid>
                                 <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" />
                                     <ColumnDefinition />
                                     <ColumnDefinition />
-                                    <ColumnDefinition />
+                                    <ColumnDefinition Width="Auto" />
                                 </Grid.ColumnDefinitions>
+                                <AppBarButton x:Name="GetLocation"
+                                              Label="Locate"
+                                              Icon="World"
+                                              Click="GetLocation_OnClick" />
                                 <TextBox x:Name="Latitude"
+                                         Grid.Column="1"
                                          Margin="0,0,6,12"
                                          Header="Latitude" />
                                 <TextBox x:Name="Longitude"
-                                         Grid.Column="1"
+                                         Grid.Column="2"
                                          Margin="6,0,6,12"
                                          Header="Longitude" />
                                 <CheckBox x:Name="DisplayCoordinates"
-                                          Grid.Column="2"
+                                          Grid.Column="3"
                                           Margin="6,0,6,12"
                                           VerticalAlignment="Bottom"
                                           Content="Display Coords" />

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Twitter Service/TwitterPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Twitter Service/TwitterPage.xaml.cs
@@ -97,8 +97,16 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
                 return;
             }
 
+            var status = new TwitterStatus
+            {
+                DisplayCoordinates = DisplayCoordinates.IsChecked == true,
+                Message = TweetText.Text,
+                Latitude = string.IsNullOrEmpty(Latitude.Text) ? (decimal?)null : Convert.ToDecimal(Latitude.Text),
+                Longitude = string.IsNullOrEmpty(Longitude.Text) ? (decimal?)null : Convert.ToDecimal(Longitude.Text)
+            };
+
             Shell.Current.DisplayWaitRing = true;
-            await TwitterService.Instance.TweetStatusAsync(TweetText.Text);
+            await TwitterService.Instance.TweetStatusAsync(status);
             Shell.Current.DisplayWaitRing = false;
         }
 

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Twitter Service/TwitterPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Twitter Service/TwitterPage.xaml.cs
@@ -11,6 +11,7 @@
 // ******************************************************************
 
 using System;
+using System.Globalization;
 using Microsoft.Toolkit.Uwp.Services.Twitter;
 using Windows.Devices.Geolocation;
 using Windows.Storage;
@@ -93,12 +94,21 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
 
         private async void GetLocation_OnClick(object sender, RoutedEventArgs e)
         {
-            var geolocator = new Geolocator();
+            try
+            {
+                var geolocator = new Geolocator();
 
-            var position = await geolocator.GetGeopositionAsync();
+                var position = await geolocator.GetGeopositionAsync();
 
-            Latitude.Text = position.Coordinate.Point.Position.Latitude.ToString();
-            Longitude.Text = position.Coordinate.Point.Position.Longitude.ToString();
+                var pos = position.Coordinate.Point.Position;
+
+                Latitude.Text = pos.Latitude.ToString(CultureInfo.InvariantCulture);
+                Longitude.Text = pos.Longitude.ToString(CultureInfo.InvariantCulture);
+            }
+            catch (Exception ex)
+            {
+                await new MessageDialog($"An error occured finding your location. Message: {ex.Message}").ShowAsync();
+            }
         }
 
         private async void ShareButton_OnClick(object sender, RoutedEventArgs e)
@@ -112,8 +122,8 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
             {
                 DisplayCoordinates = DisplayCoordinates.IsChecked == true,
                 Message = TweetText.Text,
-                Latitude = string.IsNullOrEmpty(Latitude.Text) ? (decimal?)null : Convert.ToDecimal(Latitude.Text),
-                Longitude = string.IsNullOrEmpty(Longitude.Text) ? (decimal?)null : Convert.ToDecimal(Longitude.Text)
+                Latitude = string.IsNullOrEmpty(Latitude.Text) ? (double?)null : Convert.ToDouble(Latitude.Text),
+                Longitude = string.IsNullOrEmpty(Longitude.Text) ? (double?)null : Convert.ToDouble(Longitude.Text)
             };
 
             Shell.Current.DisplayWaitRing = true;

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Twitter Service/TwitterPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Twitter Service/TwitterPage.xaml.cs
@@ -12,6 +12,7 @@
 
 using System;
 using Microsoft.Toolkit.Uwp.Services.Twitter;
+using Windows.Devices.Geolocation;
 using Windows.Storage;
 using Windows.Storage.Pickers;
 using Windows.UI.Popups;
@@ -88,6 +89,16 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
             ListView.ItemsSource = await TwitterService.Instance.GetUserTimeLineAsync(user.ScreenName, 50);
 
             Shell.Current.DisplayWaitRing = false;
+        }
+
+        private async void GetLocation_OnClick(object sender, RoutedEventArgs e)
+        {
+            var geolocator = new Geolocator();
+
+            var position = await geolocator.GetGeopositionAsync();
+
+            Latitude.Text = position.Coordinate.Point.Position.Latitude.ToString();
+            Longitude.Text = position.Coordinate.Point.Position.Longitude.ToString();
         }
 
         private async void ShareButton_OnClick(object sender, RoutedEventArgs e)

--- a/Microsoft.Toolkit.Uwp.Services/Microsoft.Toolkit.Uwp.Services.csproj
+++ b/Microsoft.Toolkit.Uwp.Services/Microsoft.Toolkit.Uwp.Services.csproj
@@ -133,6 +133,7 @@
     <Compile Include="Services\Twitter\TwitterSearchResult.cs" />
     <Compile Include="Services\Twitter\Tweet.cs" />
     <Compile Include="Services\Twitter\TwitterError.cs" />
+    <Compile Include="Services\Twitter\TwitterStatus.cs" />
     <Compile Include="Services\Twitter\TwitterUser.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Microsoft.Toolkit.Uwp.Services/Services/Twitter/TwitterDataProvider.cs
+++ b/Microsoft.Toolkit.Uwp.Services/Services/Twitter/TwitterDataProvider.cs
@@ -321,6 +321,17 @@ namespace Microsoft.Toolkit.Uwp.Services.Twitter
         /// <returns>Success or failure.</returns>
         public async Task<bool> TweetStatusAsync(string tweet, params IRandomAccessStream[] pictures)
         {
+            return await TweetStatusAsync(new TwitterStatus { Message = tweet }, pictures);
+        }
+
+        /// <summary>
+        /// Tweets a status update.
+        /// </summary>
+        /// <param name="status">Tweet text.</param>
+        /// <param name="pictures">Pictures to attach to the tweet (up to 4).</param>
+        /// <returns>Success or failure.</returns>
+        public async Task<bool> TweetStatusAsync(TwitterStatus status, params IRandomAccessStream[] pictures)
+        {
             try
             {
                 var mediaIds = string.Empty;
@@ -336,7 +347,7 @@ namespace Microsoft.Toolkit.Uwp.Services.Twitter
                     mediaIds = "&media_ids=" + string.Join(",", ids);
                 }
 
-                var uri = new Uri($"{BaseUrl}/statuses/update.json?status={Uri.EscapeDataString(tweet)}{mediaIds}");
+                var uri = new Uri($"{BaseUrl}/statuses/update.json?{status.RequestParameters}{mediaIds}");
 
                 TwitterOAuthRequest request = new TwitterOAuthRequest();
                 await request.ExecutePostAsync(uri, _tokens);

--- a/Microsoft.Toolkit.Uwp.Services/Services/Twitter/TwitterService.cs
+++ b/Microsoft.Toolkit.Uwp.Services/Services/Twitter/TwitterService.cs
@@ -250,6 +250,17 @@ namespace Microsoft.Toolkit.Uwp.Services.Twitter
         /// <returns>Returns success or failure of post request.</returns>
         public async Task<bool> TweetStatusAsync(string message, params IRandomAccessStream[] pictures)
         {
+            return await TweetStatusAsync(new TwitterStatus { Message = message }, pictures);
+        }
+
+        /// <summary>
+        /// Post a Tweet with associated pictures.
+        /// </summary>
+        /// <param name="status">The tweet information.</param>
+        /// <param name="pictures">Pictures to attach to the tweet (up to 4).</param>
+        /// <returns>Returns success or failure of post request.</returns>
+        public async Task<bool> TweetStatusAsync(TwitterStatus status, params IRandomAccessStream[] pictures)
+        {
             if (pictures.Length > 4)
             {
                 throw new ArgumentOutOfRangeException(nameof(pictures));
@@ -257,13 +268,13 @@ namespace Microsoft.Toolkit.Uwp.Services.Twitter
 
             if (Provider.LoggedIn)
             {
-                return await Provider.TweetStatusAsync(message, pictures);
+                return await Provider.TweetStatusAsync(status, pictures);
             }
 
             var isLoggedIn = await LoginAsync();
             if (isLoggedIn)
             {
-                return await TweetStatusAsync(message, pictures);
+                return await TweetStatusAsync(status, pictures);
             }
 
             return false;

--- a/Microsoft.Toolkit.Uwp.Services/Services/Twitter/TwitterStatus.cs
+++ b/Microsoft.Toolkit.Uwp.Services/Services/Twitter/TwitterStatus.cs
@@ -1,0 +1,74 @@
+﻿// ******************************************************************
+// Copyright (c) Microsoft. All rights reserved.
+// This code is licensed under the MIT License (MIT).
+// THE CODE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH
+// THE CODE OR THE USE OR OTHER DEALINGS IN THE CODE.
+// ******************************************************************
+
+using System;
+
+namespace Microsoft.Toolkit.Uwp.Services.Twitter
+{
+    /// <summary>
+    /// A class for Twitter status other than the pictures
+    /// NOTE: Can be extended to handle the other pieces of the Twitter Status REST API.
+    /// https://dev.twitter.com/rest/reference/post/statuses/update
+    /// Validation COULD be added to the Lat/Long, but since Twitter ignores these if they are invalid then no big deal.
+    /// </summary>
+    public class TwitterStatus
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether the explicit latitude and longitude of the "tweet" message is displayed.
+        /// NOTE: Whether or not to put a pin on the exact coordinates a Tweet has been sent from.
+        /// </summary>
+        public bool DisplayCoordinates { get; set; }
+
+        /// <summary>
+        /// Gets or sets the latitude of the "tweet" message.
+        /// NOTE: This parameter will be ignored unless it is inside the range -90.0 to +90.0 (North is positive) inclusive.
+        /// It will also be ignored if there isn’t a corresponding long parameter.
+        /// </summary>
+        public decimal? Latitude { get; set; }
+
+        /// <summary>
+        /// Gets or sets the longitude of the "tweet" message.
+        /// NOTE: The valid ranges for longitude is -180.0 to +180.0 (East is positive) inclusive.
+        /// This parameter will be ignored if outside that range, if it is not a number, if geo_enabled is disabled,
+        /// or if there not a corresponding lat parameter.
+        /// </summary>
+        public decimal? Longitude { get; set; }
+
+        /// <summary>
+        /// Gets or sets the text of the "tweet" message.
+        /// </summary>
+        public string Message { get; set; }
+
+        /// <summary>
+        /// Gets a the Request parameters
+        /// </summary>
+        public string RequestParameters
+        {
+            get
+            {
+                string result = $"status={Uri.EscapeDataString(Message)}";
+
+                if (Latitude.HasValue && Longitude.HasValue)
+                {
+                    result = $"{result}&lat={Latitude.Value}&long={Longitude.Value}";
+                }
+
+                if (DisplayCoordinates)
+                {
+                    result = $"{result}&display_coordinates=true";
+                }
+
+                return result;
+            }
+        }
+    }
+}

--- a/Microsoft.Toolkit.Uwp.Services/Services/Twitter/TwitterStatus.cs
+++ b/Microsoft.Toolkit.Uwp.Services/Services/Twitter/TwitterStatus.cs
@@ -11,6 +11,7 @@
 // ******************************************************************
 
 using System;
+using System.Globalization;
 
 namespace Microsoft.Toolkit.Uwp.Services.Twitter
 {
@@ -38,7 +39,7 @@ namespace Microsoft.Toolkit.Uwp.Services.Twitter
         /// NOTE: This parameter will be ignored unless it is inside the range -90.0 to +90.0 (North is positive) inclusive.
         /// It will also be ignored if there isn’t a corresponding long parameter.
         /// </summary>
-        public decimal? Latitude { get; set; }
+        public double? Latitude { get; set; }
 
         /// <summary>
         /// Gets or sets the longitude of the "tweet" message.
@@ -46,7 +47,7 @@ namespace Microsoft.Toolkit.Uwp.Services.Twitter
         /// This parameter will be ignored if outside that range, if it is not a number, if geo_enabled is disabled,
         /// or if there not a corresponding lat parameter.
         /// </summary>
-        public decimal? Longitude { get; set; }
+        public double? Longitude { get; set; }
 
         /// <summary>
         /// Gets or sets the text of the Tweet message.
@@ -59,7 +60,7 @@ namespace Microsoft.Toolkit.Uwp.Services.Twitter
         public string PlaceId { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether the Tweet contains sensitive content (suchas nudity, etc.).
+        /// Gets or sets a value indicating whether the Tweet contains sensitive content (such as nudity, etc.).
         /// </summary>
         public bool PossiblySensitive { get; set; }
 
@@ -74,10 +75,10 @@ namespace Microsoft.Toolkit.Uwp.Services.Twitter
 
                 if (Latitude.HasValue && Longitude.HasValue)
                 {
-                    result = $"{result}&lat={Latitude.Value}&long={Longitude.Value}";
+                    result = $"{result}&lat={Latitude.Value.ToString(CultureInfo.InvariantCulture)}&long={Longitude.Value.ToString(CultureInfo.InvariantCulture)}";
+                    result = AddRequestParameter(result, "display_coordinates", DisplayCoordinates);
                 }
 
-                result = AddRequestParameter(result, "display_coordinates", DisplayCoordinates);
                 result = AddRequestParameter(result, "in_reply_to_status_id", InReplyToStatusId);
                 result = AddRequestParameter(result, "place_id", PlaceId);
                 result = AddRequestParameter(result, "possibly_sensitive", PossiblySensitive);
@@ -110,7 +111,7 @@ namespace Microsoft.Toolkit.Uwp.Services.Twitter
 
             if (!string.IsNullOrEmpty(value))
             {
-                result = $"{result}&{parameterName}={value}";
+                result = $"{result}&{parameterName}={Uri.EscapeDataString(value)}";
             }
 
             return result;

--- a/Microsoft.Toolkit.Uwp.Services/Services/Twitter/TwitterStatus.cs
+++ b/Microsoft.Toolkit.Uwp.Services/Services/Twitter/TwitterStatus.cs
@@ -29,6 +29,11 @@ namespace Microsoft.Toolkit.Uwp.Services.Twitter
         public bool DisplayCoordinates { get; set; }
 
         /// <summary>
+        /// Gets or sets the ID of the original tweet.
+        /// </summary>
+        public string InReplyToStatusId { get; set; }
+
+        /// <summary>
         /// Gets or sets the latitude of the "tweet" message.
         /// NOTE: This parameter will be ignored unless it is inside the range -90.0 to +90.0 (North is positive) inclusive.
         /// It will also be ignored if there isn’t a corresponding long parameter.
@@ -44,9 +49,19 @@ namespace Microsoft.Toolkit.Uwp.Services.Twitter
         public decimal? Longitude { get; set; }
 
         /// <summary>
-        /// Gets or sets the text of the "tweet" message.
+        /// Gets or sets the text of the Tweet message.
         /// </summary>
         public string Message { get; set; }
+
+        /// <summary>
+        /// Gets or sets the text of the Tweet message.
+        /// </summary>
+        public string PlaceId { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the Tweet contains sensitive content (suchas nudity, etc.).
+        /// </summary>
+        public bool PossiblySensitive { get; set; }
 
         /// <summary>
         /// Gets a the Request parameters
@@ -62,13 +77,43 @@ namespace Microsoft.Toolkit.Uwp.Services.Twitter
                     result = $"{result}&lat={Latitude.Value}&long={Longitude.Value}";
                 }
 
-                if (DisplayCoordinates)
-                {
-                    result = $"{result}&display_coordinates=true";
-                }
+                result = AddRequestParameter(result, "display_coordinates", DisplayCoordinates);
+                result = AddRequestParameter(result, "in_reply_to_status_id", InReplyToStatusId);
+                result = AddRequestParameter(result, "place_id", PlaceId);
+                result = AddRequestParameter(result, "possibly_sensitive", PossiblySensitive);
+                result = AddRequestParameter(result, "trim_user", TrimUser);
 
                 return result;
             }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the Tweet returned in a timeline will include a user object including only the status authors numerical ID.
+        /// </summary>
+        public bool TrimUser { get; set; }
+
+        private string AddRequestParameter(string request, string parameterName, bool value)
+        {
+            var result = request;
+
+            if (value)
+            {
+                result = $"{result}&{parameterName}=true";
+            }
+
+            return result;
+        }
+
+        private string AddRequestParameter(string request, string parameterName, string value)
+        {
+            var result = request;
+
+            if (!string.IsNullOrEmpty(value))
+            {
+                result = $"{result}&{parameterName}={value}";
+            }
+
+            return result;
         }
     }
 }

--- a/docs/services/Twitter.md
+++ b/docs/services/Twitter.md
@@ -52,7 +52,7 @@ var status = new TwitterStatus
 				Longitude = validLongitude,
 				PlaceId = "df51dec6f4ee2b2c",			// As defined by Twitter
 				PossiblySensitive = true,				// As defined by Twitter (nudity, violence, or medical procedures)
-				TrimUser = true,
+				TrimUser = true
 			}
 
 await TwitterService.Instance.TweetStatusAsync(status);

--- a/docs/services/Twitter.md
+++ b/docs/services/Twitter.md
@@ -50,8 +50,8 @@ var status = new TwitterStatus
 				InReplyToStatusId = "@ValidAccount",
 				Latitude = validLatitude,
 				Longitude = validLongitude,
-				PlaceId = "df51dec6f4ee2b2c",			// As defined by Twitter
-				PossiblySensitive = true,				// As defined by Twitter (nudity, violence, or medical procedures)
+				PlaceId = "df51dec6f4ee2b2c",	// As defined by Twitter
+				PossiblySensitive = true,		// As defined by Twitter (nudity, violence, or medical procedures)
 				TrimUser = true
 			}
 

--- a/docs/services/Twitter.md
+++ b/docs/services/Twitter.md
@@ -40,8 +40,27 @@ ListView.ItemsSource = await TwitterService.Instance.GetUserTimeLineAsync(user.S
 // Post a tweet
 await TwitterService.Instance.TweetStatusAsync(TweetText.Text);
 
+var status = new TwitterStatus
+			{
+				Message = TweetText.Text,
+
+				// Optional parameters defined by the Twitter "update" API (they may all be null or false)
+
+				DisplayCoordinates = true,
+				InReplyToStatusId = "@ValidAccount",
+				Latitude = validLatitude,
+				Longitude = validLongitude,
+				PlaceId = "df51dec6f4ee2b2c",			// As defined by Twitter
+				PossiblySensitive = true,				// As defined by Twitter (nudity, violence, or medical procedures)
+				TrimUser = true,
+			}
+
+await TwitterService.Instance.TweetStatusAsync(status);
+
 // Post a tweet with a picture
 await TwitterService.Instance.TweetStatusAsync(TweetText.Text, stream);
+
+await TwitterService.Instance.TweetStatusAsync(status, stream);
 
 // Search for a specific tag
 ListView.ItemsSource = await TwitterService.Instance.SearchAsync(TagText.Text, 50);


### PR DESCRIPTION
This is my first "official" PR so I HOPE I'm following the rules.  I REALLY would like the Lat/Long added to the status.  This looks like it's working through your test application.  I did not see any Unit Tests for Twitter otherwise I would have added some.  In the account that I tested with I only see "Colorado, USA" versus the lat/long (which I think used to be displayed last year or so).  That might be a setting on a per account basis.  As I was doing my research and testing, it didn't take much to add the REST of the UPDATE parameters through the mechanism I chose.  It also lends itself for extension as well without changing the provider.  I created a NEW method so I would not break the API, and then under the covers call the new API from the old API.  I hope this is all I need to do so I can continue with my UWP application that used to use TweetSharp in the old Windows Phone 8.1 world.  THANKS!!  I hope this helps!  Thank YOU for all of the other plumbing and reducing my work.  So I thought I would give back a few hours...