### PR TITLE
Fixing issues with the normal map not being found via Nuget

### DIFF
--- a/build/Microsoft.Toolkit.Uwp.UI.Animations.nuspec
+++ b/build/Microsoft.Toolkit.Uwp.UI.Animations.nuspec
@@ -26,5 +26,6 @@
     <file src="$binaries$\Microsoft.Toolkit.Uwp.UI.Animations\Microsoft.Toolkit.Uwp.UI.Animations.pdb" target="lib\uap10.0" />
     <file src="$binaries$\Microsoft.Toolkit.Uwp.UI.Animations\Microsoft.Toolkit.Uwp.UI.Animations.pri" target="lib\uap10.0" />
     <file src="$binaries$\Microsoft.Toolkit.Uwp.UI.Animations\Microsoft.Toolkit.Uwp.UI.Animations.xml" target="lib\uap10.0" />
+    <file src="$binaries$\Microsoft.Toolkit.Uwp.UI.Animations\Microsoft.Toolkit.Uwp.UI.Animations\Assets\SphericalWithMask.png" target="lib\uap10.0\Microsoft.Toolkit.Uwp.UI.Animations\Assets" />
   </files>
 </package>


### PR DESCRIPTION
The normal map asset wasn't getting added to the nuget package. I've updated the nuspec to pull the file from the binary folder and place it in the expected location for it to compile and work.