### PR TITLE
Added Latitude and Longitude to a returning Tweet if available.

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Twitter Service/TwitterPage.xaml
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Twitter Service/TwitterPage.xaml
@@ -3,8 +3,6 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-      xmlns:core="using:Microsoft.Xaml.Interactions.Core"
-      xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
       xmlns:twitter="using:Microsoft.Toolkit.Uwp.Services.Twitter"
       mc:Ignorable="d">
     <Page.Resources>

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Twitter Service/TwitterPage.xaml
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Twitter Service/TwitterPage.xaml
@@ -3,6 +3,8 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:core="using:Microsoft.Xaml.Interactions.Core"
+      xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
       xmlns:twitter="using:Microsoft.Toolkit.Uwp.Services.Twitter"
       mc:Ignorable="d">
     <Page.Resources>
@@ -58,10 +60,16 @@
                                Text="{x:Bind Text}"
                                TextTrimming="CharacterEllipsis"
                                TextWrapping="WrapWholeWords" />
-                    <TextBlock Grid.Row="2"
-                               HorizontalAlignment="Right"
-                               FontWeight="ExtraLight"
-                               Text="{x:Bind CreationDate}" />
+                    <StackPanel Grid.Row="2"
+                                HorizontalAlignment="Right"
+                                Orientation="Horizontal">
+                        <TextBlock FontWeight="ExtraLight"
+                                   Text="{x:Bind CreationDate}" />
+                        <TextBlock FontWeight="ExtraLight"
+                                   Margin="4,0,0,0"
+                                   Text="{x:Bind GeoData.DisplayCoordinates}">
+                        </TextBlock>
+                    </StackPanel>
                 </Grid>
             </Border>
         </DataTemplate>

--- a/Microsoft.Toolkit.Uwp.Services/Microsoft.Toolkit.Uwp.Services.csproj
+++ b/Microsoft.Toolkit.Uwp.Services/Microsoft.Toolkit.Uwp.Services.csproj
@@ -89,6 +89,7 @@
     <Compile Include="Services\Facebook\FacebookPlatformImageSource.cs" />
     <Compile Include="Services\Twitter\TwitterErrors.cs" />
     <Compile Include="Services\Twitter\TwitterException.cs" />
+    <Compile Include="Services\Twitter\TwitterGeoData.cs" />
     <Compile Include="Services\Twitter\TwitterOAuthTokenType.cs" />
     <Compile Include="Services\Facebook\FacebookPermissions.cs" />
     <Compile Include="Services\Facebook\FacebookDataHost.cs" />

--- a/Microsoft.Toolkit.Uwp.Services/Services/Twitter/Tweet.cs
+++ b/Microsoft.Toolkit.Uwp.Services/Services/Twitter/Tweet.cs
@@ -28,6 +28,12 @@ namespace Microsoft.Toolkit.Uwp.Services.Twitter
         public string CreatedAt { get; set; }
 
         /// <summary>
+        /// Gets or sets the geographic data (latitude and longitude)
+        /// </summary>
+        [JsonProperty("geo")]
+        public TwitterGeoData GeoData { get; set; }
+
+        /// <summary>
         /// Gets or sets item Id.
         /// </summary>
         [JsonProperty("id_str")]

--- a/Microsoft.Toolkit.Uwp.Services/Services/Twitter/TwitterGeoData.cs
+++ b/Microsoft.Toolkit.Uwp.Services/Services/Twitter/TwitterGeoData.cs
@@ -1,0 +1,95 @@
+﻿// ******************************************************************
+// Copyright (c) Microsoft. All rights reserved.
+// This code is licensed under the MIT License (MIT).
+// THE CODE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH
+// THE CODE OR THE USE OR OTHER DEALINGS IN THE CODE.
+// ******************************************************************
+
+using System.Globalization;
+using Newtonsoft.Json;
+
+namespace Microsoft.Toolkit.Uwp.Services.Twitter
+{
+    /// <summary>
+    /// A class to contain the latitude and longitude of a tweet.
+    /// </summary>
+    public class TwitterGeoData
+    {
+        private const int LatitudeIndex = 0;
+        private const int LongitudeIndex = 1;
+        private const string PointType = "Point";
+
+        /// <summary>
+        /// Gets or sets the type of data
+        /// </summary>
+        [JsonProperty("type")]
+        public string DataType { get; set; }
+
+        /// <summary>
+        /// Gets the latitude and longitude in a coordinate format.
+        /// </summary>
+        public string DisplayCoordinates
+        {
+            get
+            {
+                string result = null;
+
+                if (Coordinates != null)
+                {
+                    result = $"({Coordinates[LatitudeIndex]}, {Coordinates[LongitudeIndex]})";
+                }
+
+                return result;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the coordinates of the geographic data
+        /// </summary>
+        [JsonProperty("coordinates")]
+        public string[] Coordinates { get; set; }
+
+        /// <summary>
+        /// Gets the numeric latitude (null if the value could not be converted)
+        /// </summary>
+        public double? Latitude
+        {
+            get
+            {
+                return ParseCoordinate(LatitudeIndex);
+            }
+        }
+
+        /// <summary>
+        /// Gets the numeric longitude (null if the value could not be converted)
+        /// </summary>
+        public double? Longitude
+        {
+            get
+            {
+                return ParseCoordinate(LongitudeIndex);
+            }
+        }
+
+        private double? ParseCoordinate(int index)
+        {
+            double? result = null;
+            double parsed;
+
+            if (DataType == PointType
+            && Coordinates != null
+            && !string.IsNullOrEmpty(Coordinates[index])
+            && double.TryParse(Coordinates[index], NumberStyles.AllowDecimalPoint | NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture, out parsed))
+            {
+                result = parsed;
+            }
+
+            return result;
+        }
+    }
+}

--- a/Microsoft.Toolkit.Uwp.Services/Services/Twitter/TwitterStatus.cs
+++ b/Microsoft.Toolkit.Uwp.Services/Services/Twitter/TwitterStatus.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Toolkit.Uwp.Services.Twitter
         public bool PossiblySensitive { get; set; }
 
         /// <summary>
-        /// Gets a the Request parameters
+        /// Gets the request parameters
         /// </summary>
         public string RequestParameters
         {

--- a/docs/services/Twitter.md
+++ b/docs/services/Twitter.md
@@ -17,6 +17,13 @@ Copy this from the *Keys and Access Tokens* tab on your application page.
 **Callback URI** Enter a unique URI for your application.  This must match the *Callback URL* field on the *Application Details* tab in Twitter.
 *Example*: http://myapp.company.com - (this does not have to be a working URL)
 
+## Overview
+
+In the code section below the GetUserTimeLineAsync method returns some Tweet objects.  The Tweet class returns some basic information along with the tweet text itself.
+
+o CreatedAt	(string) – The date and time of the Tweet formatted by Twitter
+o Text		(string) – The text of the status
+
 ## Syntax
 
 ```csharp
@@ -34,7 +41,7 @@ if (!await TwitterService.Instance.LoginAsync())
 var user = await TwitterService.Instance.GetUserAsync();
 ProfileImage.DataContext = user;
 
-// Get user timeline
+// Get user time line
 ListView.ItemsSource = await TwitterService.Instance.GetUserTimeLineAsync(user.ScreenName, 50);
 
 // Post a tweet

--- a/docs/services/Twitter.md
+++ b/docs/services/Twitter.md
@@ -21,8 +21,11 @@ Copy this from the *Keys and Access Tokens* tab on your application page.
 
 In the code section below the GetUserTimeLineAsync method returns some Tweet objects.  The Tweet class returns some basic information along with the tweet text itself.
 
-o CreatedAt	(string) – The date and time of the Tweet formatted by Twitter
-o Text		(string) – The text of the status
+- **CreatedAt**	(string)         – The date and time of the Tweet formatted by Twitter
+- **Text**		(string)         – The text of the Tweet
+- **Id**		(string)         – The Twitter status identifier
+- **GeoData**   (TwitterGeoData) - A class containing the latitude and longitude of the Tweet
+- **User**      (TwitterUser)    - A class containing the user ID, Name, ScreenName, and ProfileImageUrl
 
 ## Syntax
 


### PR DESCRIPTION
The TwitterGeoData is deserialized if the "geo" element is populated on the response JSON.  I added the DisplayCoordinates to the TwitterGeoData since I didn't see a TwitterModel for the UI.  After I put in the double conversion I felt that it wasn't really needed, but I was just following the pattern for the CreationDate.  The TwitterGeoData could just expose the string data.