### PR TITLE
Minor fix for displayed code IIncrementalSource

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Incremental Loading Collection/IncrementalLoadingCollectionCode.bind
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Incremental Loading Collection/IncrementalLoadingCollectionCode.bind
@@ -8,7 +8,7 @@ public class Person
 
 public class PeopleSource : IIncrementalSource<Person>
 {
-    private readonly List<Person> people;
+    private readonly List<Person> _people;
 
     public PeopleSource()
     {


### PR DESCRIPTION
The app displays code for copy/paste for developer. There is just a typo error for the "_people" list used in the IIncrementalSource