### PR TITLE
Adds missing documentation to public items

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/BladeView/Blade.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/BladeView/Blade.cs
@@ -15,6 +15,9 @@ using Windows.UI.Xaml;
 
 namespace Microsoft.Toolkit.Uwp.UI.Controls
 {
+    /// <summary>
+    /// The Blade is used as a child in the BladeView
+    /// </summary>
     [Deprecated("The Blade class has been replaced with the BladeItem class. Please use that going forward", DeprecationType.Deprecate, 1)]
     public class Blade : BladeItem
     {

--- a/Microsoft.Toolkit.Uwp.UI.Controls/BladeView/BladeMode.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/BladeView/BladeMode.cs
@@ -10,14 +10,11 @@
 // THE CODE OR THE USE OR OTHER DEALINGS IN THE CODE.
 // ******************************************************************
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Microsoft.Toolkit.Uwp.UI.Controls
 {
+    /// <summary>
+    /// The blade mode.
+    /// </summary>
     public enum BladeMode
     {
         /// <summary>

--- a/Microsoft.Toolkit.Uwp.UI.Controls/DropShadowPanel/DropShadowPanel.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/DropShadowPanel/DropShadowPanel.cs
@@ -77,6 +77,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             ElementCompositionPreview.SetElementChildVisual(ShadowElement, _shadowVisual);
         }
 
+        /// <summary>
+        /// Gets or sets the casting element.
+        /// </summary>
         public FrameworkElement CastingElement
         {
             get

--- a/Microsoft.Toolkit.Uwp.UI.Controls/ImageEx/ImageExFailedEventArgs.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/ImageEx/ImageExFailedEventArgs.cs
@@ -14,6 +14,11 @@ using System;
 
 namespace Microsoft.Toolkit.Uwp.UI.Controls
 {
+    /// <summary>
+    /// A delegate for <see cref="ImageEx"/> failed.
+    /// </summary>
+    /// <param name="sender">The sender.</param>
+    /// <param name="e">The event arguments.</param>
     public delegate void ImageExFailedEventHandler(object sender, ImageExFailedEventArgs e);
 
     /// <summary>

--- a/Microsoft.Toolkit.Uwp.UI.Controls/ImageEx/ImageExOpenedEventArgs.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/ImageEx/ImageExOpenedEventArgs.cs
@@ -14,6 +14,11 @@ using System;
 
 namespace Microsoft.Toolkit.Uwp.UI.Controls
 {
+    /// <summary>
+    /// A delegate for <see cref="ImageEx"/> opened.
+    /// </summary>
+    /// <param name="sender">The sender.</param>
+    /// <param name="e">The event arguments.</param>
     public delegate void ImageExOpenedEventHandler(object sender, ImageExOpenedEventArgs e);
 
     /// <summary>

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsViewState.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsViewState.cs
@@ -12,6 +12,9 @@
 
 namespace Microsoft.Toolkit.Uwp.UI.Controls
 {
+    /// <summary>
+    /// The <see cref="MasterDetailsView"/> state.
+    /// </summary>
     public enum MasterDetailsViewState
     {
         /// <summary>

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MosaicControl/MosaicControl.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MosaicControl/MosaicControl.cs
@@ -53,6 +53,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         Both
     }
 
+    /// <summary>
+    /// Image alignment
+    /// </summary>
     public enum ImageAlignment
     {
         /// <summary>
@@ -87,47 +90,69 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
     /// </summary>
     public sealed class MosaicControl : ContentControl
     {
-        // Using a DependencyProperty as the backing store for ScrollViewer.  This enables animation, styling, binding, etc...
+        /// <summary>
+        /// Identifies the <see cref="ScrollViewerContainer"/> property.
+        /// </summary>
         public static readonly DependencyProperty ScrollViewerContainerProperty =
             DependencyProperty.Register(nameof(ScrollViewerContainer), typeof(FrameworkElement), typeof(MosaicControl), new PropertyMetadata(null, OnScrollViewerContainerChange));
 
-        // Using a DependencyProperty as the backing store for ImageAlignment.  This enables animation, styling, binding, etc...
+        /// <summary>
+        /// Identifies the <see cref="ImageAlignment"/> property.
+        /// </summary>
         public static readonly DependencyProperty ImageAlignmentProperty =
             DependencyProperty.Register(nameof(ImageAlignment), typeof(ImageAlignment), typeof(MosaicControl), new PropertyMetadata(ImageAlignment.None, OnAlignmentChange));
 
-        // Using a DependencyProperty as the backing store for ImageSource.  This enables animation, styling, binding, etc...
+        /// <summary>
+        /// Identifies the <see cref="ImageSource"/> property.
+        /// </summary>
         public static readonly DependencyProperty ImageSourceProperty =
             DependencyProperty.Register(nameof(ImageSource), typeof(Uri), typeof(MosaicControl), new PropertyMetadata(null, OnImageSourceChanged));
 
-        // Using a DependencyProperty as the backing store for Orientation.  This enables animation, styling, binding, etc...
+        /// <summary>
+        /// Identifies the <see cref="ScrollOrientation"/> property.
+        /// </summary>
         public static readonly DependencyProperty ScrollOrientationProperty =
             DependencyProperty.Register(nameof(ScrollOrientation), typeof(ScrollOrientation), typeof(MosaicControl), new PropertyMetadata(ScrollOrientation.Both, OnOrientationChanged));
 
-        // Using a DependencyProperty as the backing store for OffsetX.  This enables animation, styling, binding, etc...
+        /// <summary>
+        /// Identifies the <see cref="OffsetX"/> property.
+        /// </summary>
         public static readonly DependencyProperty OffsetXProperty =
             DependencyProperty.Register(nameof(OffsetX), typeof(double), typeof(MosaicControl), new PropertyMetadata(0.0, OnOffsetChange));
 
-        // Using a DependencyProperty as the backing store for OffsetY.  This enables animation, styling, binding, etc...
+        /// <summary>
+        /// Identifies the <see cref="OffsetY"/> property.
+        /// </summary>
         public static readonly DependencyProperty OffsetYProperty =
             DependencyProperty.Register(nameof(OffsetY), typeof(double), typeof(MosaicControl), new PropertyMetadata(0.0, OnOffsetChange));
 
-        // Using a DependencyProperty as the backing store for ScrollSpeedRatio.  This enables animation, styling, binding, etc...
+        /// <summary>
+        /// Identifies the <see cref="ParallaxSpeedRatio"/> property.
+        /// </summary>
         public static readonly DependencyProperty ParallaxSpeedRatioProperty =
             DependencyProperty.Register(nameof(ParallaxSpeedRatio), typeof(double), typeof(MosaicControl), new PropertyMetadata(1.0, OnScrollSpeedRatioChange));
 
-        // Using a DependencyProperty as the backing store for IsAnimated.  This enables animation, styling, binding, etc...
+        /// <summary>
+        /// Identifies the <see cref="IsAnimated"/> property.
+        /// </summary>
         public static readonly DependencyProperty IsAnimatedProperty =
             DependencyProperty.Register(nameof(IsAnimated), typeof(bool), typeof(MosaicControl), new PropertyMetadata(false, OnIsAnimatedChange));
 
-        // Using a DependencyProperty as the backing store for AnimationStepX.  This enables animation, styling, binding, etc...
+        /// <summary>
+        /// Identifies the <see cref="AnimationStepX"/> property.
+        /// </summary>
         public static readonly DependencyProperty AnimationStepXProperty =
             DependencyProperty.Register(nameof(AnimationStepX), typeof(double), typeof(MosaicControl), new PropertyMetadata(1.0));
 
-        // Using a DependencyProperty as the backing store for AnimationStepY.  This enables animation, styling, binding, etc...
+        /// <summary>
+        /// Identifies the <see cref="AnimationStepY"/> property.
+        /// </summary>
         public static readonly DependencyProperty AnimationStepYProperty =
             DependencyProperty.Register(nameof(AnimationStepY), typeof(double), typeof(MosaicControl), new PropertyMetadata(1.0));
 
-        // Using a DependencyProperty as the backing store for AnimationDuration.  This enables animation, styling, binding, etc...
+        /// <summary>
+        /// Identifies the <see cref="AnimationDuration"/> property.
+        /// </summary>
         public static readonly DependencyProperty AnimationDurationProperty =
             DependencyProperty.Register(nameof(AnimationDuration), typeof(double), typeof(MosaicControl), new PropertyMetadata(30.0, OnAnimationDuration));
 
@@ -181,6 +206,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             Composition
         }
 
+        /// <summary>
+        /// The image loaded event.
+        /// </summary>
         public event EventHandler ImageLoaded = null;
 
         /// <summary>

--- a/Microsoft.Toolkit.Uwp.UI.Controls/RadialGauge/RadialGauge.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/RadialGauge/RadialGauge.cs
@@ -53,7 +53,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         public static readonly DependencyProperty StepSizeProperty =
             DependencyProperty.Register(nameof(StepSize), typeof(double), typeof(RadialGauge), new PropertyMetadata(0.0));
 
-        // Identifies the IsInteractive dependency property.
+        /// <summary>
+        /// Identifies the <see cref="IsInteractive"/> property.
+        /// </summary>
         public static readonly DependencyProperty IsInteractiveProperty =
             DependencyProperty.Register(nameof(IsInteractive), typeof(bool), typeof(RadialGauge), new PropertyMetadata(false, OnInteractivityChanged));
 

--- a/Microsoft.Toolkit.Uwp.UI.Controls/ScrollHeader/ScrollHeader.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/ScrollHeader/ScrollHeader.cs
@@ -23,6 +23,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
     /// </summary>
     public class ScrollHeader : ContentControl
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ScrollHeader"/> class.
+        /// </summary>
         public ScrollHeader()
         {
             DefaultStyleKey = typeof(ScrollHeader);
@@ -111,6 +114,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             }
         }
 
+        /// <summary>
+        /// Invoked whenever application code or internal processes (such as a rebuilding layout pass) call <see cref="Control.ApplyTemplate"/>.
+        /// </summary>
         protected override void OnApplyTemplate()
         {
             if (TargetListViewBase != null)


### PR DESCRIPTION
CS1591 rule has been disabled for this project, which means we are not validating if all public types and members have xmldoc in them.

Unfortunately at the moment we can't enable this rule as it will break the build given that some compiler generated types don't have proper xmldoc (thanks a lot Microsoft... not!)

I've enabled the rule temporarily and noticed that these are the types with missing documentation, so I'm now adding them back.