### PR TITLE
Handle keyboard input correctly in MasterViewDetail

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.Properties.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.Properties.cs
@@ -43,6 +43,16 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             new PropertyMetadata(null));
 
         /// <summary>
+        /// Identifies the <see cref="IsItemClickEnabled"/> dependency property.
+        /// </summary>
+        /// <returns>The identifier for the <see cref="IsItemClickEnabled"/> dependency property.</returns>
+        public static readonly DependencyProperty IsItemClickEnabledProperty = DependencyProperty.Register(
+            nameof(IsItemClickEnabled),
+            typeof(bool),
+            typeof(MasterDetailsView),
+            new PropertyMetadata(false));
+
+        /// <summary>
         /// Identifies the <see cref="MasterPaneBackground"/> dependency property.
         /// </summary>
         /// <returns>The identifier for the <see cref="MasterPaneBackground"/> dependency property.</returns>
@@ -129,6 +139,16 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         {
             get { return (DataTemplate)GetValue(DetailsTemplateProperty); }
             set { SetValue(DetailsTemplateProperty, value); }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether clicks are processed or not. If this is enabled, then <see cref="UpdateView(bool)"/>
+        /// must be called in a click handler for the master list, otherwise the details will not show in the narrow state
+        /// </summary>
+        public bool IsItemClickEnabled
+        {
+            get { return (bool)GetValue(IsItemClickEnabledProperty); }
+            set { SetValue(IsItemClickEnabledProperty, value); }
         }
 
         /// <summary>

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.cs
@@ -15,7 +15,6 @@ using Windows.ApplicationModel;
 using Windows.UI.Core;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Hosting;
 using Windows.UI.Xaml.Navigation;
 
 namespace Microsoft.Toolkit.Uwp.UI.Controls
@@ -27,6 +26,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
     [TemplatePart(Name = PartDetailsPanel, Type = typeof(FrameworkElement))]
     [TemplateVisualState(Name = NoSelectionNarrowState, GroupName = SelectionStates)]
     [TemplateVisualState(Name = NoSelectionWideState, GroupName = SelectionStates)]
+    [TemplateVisualState(Name = HasSelectionNarrowState, GroupName = SelectionStates)]
+    [TemplateVisualState(Name = HasSelectionWideState, GroupName = SelectionStates)]
     [TemplateVisualState(Name = NarrowState, GroupName = WidthStates)]
     [TemplateVisualState(Name = WideState, GroupName = WidthStates)]
     public partial class MasterDetailsView : ItemsControl
@@ -38,13 +39,12 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         private const string WideState = "WideState";
         private const string WidthStates = "WidthStates";
         private const string SelectionStates = "SelectionStates";
-        private const string HasSelectionState = "HasSelection";
+        private const string HasSelectionNarrowState = "HasSelectionNarrow";
+        private const string HasSelectionWideState = "HasSelectionWide";
         private const string NoSelectionNarrowState = "NoSelectionNarrow";
         private const string NoSelectionWideState = "NoSelectionWide";
-        private const string MasterPanel = "MasterPanel";
 
         private ContentPresenter _detailsPresenter;
-        private UIElement _masterPanel;
         private VisualStateGroup _stateGroup;
         private VisualState _narrowState;
         private Frame _frame;
@@ -70,7 +70,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             base.OnApplyTemplate();
 
             _detailsPresenter = (ContentPresenter)GetTemplateChild(PartDetailsPresenter);
-            _masterPanel = (UIElement)GetTemplateChild(MasterPanel);
 
             SetMasterHeaderVisibility();
         }
@@ -200,18 +199,25 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
         protected void UpdateView(bool useTransitions)
         {
-            string noSelectionState = _stateGroup.CurrentState == _narrowState
-               ? NoSelectionNarrowState
-               : NoSelectionWideState;
-            VisualStateManager.GoToState(this, SelectedItem == null ? noSelectionState : HasSelectionState, useTransitions);
+            VisualStateManager.GoToState(this, GetSelectionStateName(), useTransitions);
 
             UpdateViewState();
 
-            // Sets the ability for the Master list to handle focus on interaction. If the details view is the only
-            // view showing, we don't want it to be able to be focused
-            _masterPanel.Visibility = ViewState != MasterDetailsViewState.Details ? Visibility.Visible : Visibility.Collapsed;
-
             SetBackButtonVisibility(_stateGroup.CurrentState);
+        }
+
+        private string GetSelectionStateName()
+        {
+            var isNarrow = _stateGroup.CurrentState == _narrowState;
+
+            if (SelectedItem == null)
+            {
+                return isNarrow ? NoSelectionNarrowState : NoSelectionWideState;
+            }
+            else
+            {
+                return isNarrow ? HasSelectionNarrowState : HasSelectionWideState;
+            }
         }
 
         private void SetMasterHeaderVisibility()

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.cs
@@ -86,11 +86,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         private static void OnSelectedItemChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             var view = (MasterDetailsView)d;
-            string noSelectionState = view._stateGroup.CurrentState == view._narrowState
-                ? NoSelectionNarrowState
-                : NoSelectionWideState;
-            VisualStateManager.GoToState(view, view.SelectedItem == null ? noSelectionState : HasSelectionState, true);
-
+            view.UpdateView(true);
             view.OnSelectionChanged(new SelectionChangedEventArgs(new List<object> { e.OldValue }, new List<object> { e.NewValue }));
 
             // If there is no selection, do not remove the DetailsPresenter content but let it animate out.
@@ -140,11 +136,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
             _narrowState = GetTemplateChild(NarrowState) as VisualState;
 
-            string noSelectionState = _stateGroup.CurrentState == _narrowState
-                ? NoSelectionNarrowState
-                : NoSelectionWideState;
-            VisualStateManager.GoToState(this, this.SelectedItem == null ? noSelectionState : HasSelectionState, true);
-
+            UpdateView(true);
             UpdateViewState();
         }
 
@@ -174,10 +166,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             SetBackButtonVisibility(e.NewState);
 
             // When adaptive trigger changes state, switch between NoSelectionWide and NoSelectionNarrow.
-            string noSelectionState = e.NewState == _narrowState
-                ? NoSelectionNarrowState
-                : NoSelectionWideState;
-            VisualStateManager.GoToState(this, this.SelectedItem == null ? noSelectionState : HasSelectionState, false);
+            UpdateView(false);
         }
 
         /// <summary>
@@ -206,6 +195,14 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 SelectedItem = null;
                 args.Handled = true;
             }
+        }
+
+        private void UpdateView(bool useTransitions)
+        {
+            string noSelectionState = _stateGroup.CurrentState == _narrowState
+               ? NoSelectionNarrowState
+               : NoSelectionWideState;
+            VisualStateManager.GoToState(this, SelectedItem == null ? noSelectionState : HasSelectionState, useTransitions);
         }
 
         private void SetMasterHeaderVisibility()

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.xaml
@@ -61,13 +61,13 @@
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup x:Name="SelectionStates">
                                 <VisualStateGroup.Transitions>
-                                    <VisualTransition From="NoSelectionWide" To="HasSelection">
+                                    <VisualTransition From="NoSelectionWide" To="HasSelectionWide">
                                         <Storyboard>
                                             <DrillInThemeAnimation EntranceTargetName="DetailsPresenter"
                                                                    ExitTargetName="NoSelectionPresenter"/>
                                         </Storyboard>
                                     </VisualTransition>
-                                    <VisualTransition From="NoSelectionNarrow" To="HasSelection">
+                                    <VisualTransition From="NoSelectionNarrow" To="HasSelectionWide">
                                         <Storyboard>
                                             <DoubleAnimation Storyboard.TargetName="DetailsPresenterTransform"
                                                              Storyboard.TargetProperty="X"
@@ -87,13 +87,33 @@
                                             </DoubleAnimation>
                                         </Storyboard>
                                     </VisualTransition>
-                                    <VisualTransition From="HasSelection" To="NoSelectionWide">
+                                    <VisualTransition From="NoSelectionNarrow" To="HasSelectionNarrow">
+                                        <Storyboard>
+                                            <DoubleAnimation Storyboard.TargetName="DetailsPresenterTransform"
+                                                             Storyboard.TargetProperty="X"
+                                                             BeginTime="0:0:0" Duration="0:0:0.25"
+                                                             From="200" To="0">
+                                                <DoubleAnimation.EasingFunction>
+                                                    <QuarticEase EasingMode="EaseOut"/>
+                                                </DoubleAnimation.EasingFunction>
+                                            </DoubleAnimation>
+                                            <DoubleAnimation Storyboard.TargetName="DetailsPresenter"
+                                                             Storyboard.TargetProperty="Opacity"
+                                                             BeginTime="0:0:0" Duration="0:0:0.25"
+                                                             From="0" To="1">
+                                                <DoubleAnimation.EasingFunction>
+                                                    <QuarticEase EasingMode="EaseOut"/>
+                                                </DoubleAnimation.EasingFunction>
+                                            </DoubleAnimation>
+                                        </Storyboard>
+                                    </VisualTransition>
+                                    <VisualTransition From="HasSelectionWide" To="NoSelectionWide">
                                         <Storyboard>
                                             <DrillOutThemeAnimation ExitTargetName="DetailsPresenter"
                                                                     EntranceTargetName="NoSelectionPresenter"/>
                                         </Storyboard>
                                     </VisualTransition>
-                                    <VisualTransition From="HasSelection" To="NoSelectionNarrow">
+                                    <VisualTransition From="HasSelectionNarrow" To="NoSelectionNarrow">
                                         <Storyboard>
                                             <DoubleAnimation Storyboard.TargetName="DetailsPresenterTransform"
                                                              Storyboard.TargetProperty="X"
@@ -114,17 +134,26 @@
                                 <VisualState x:Name="NoSelectionWide">
                                     <VisualState.Setters>
                                         <Setter Target="DetailsPresenter.Visibility" Value="Collapsed" />
+                                        <Setter Target="MasterPanel.Visibility" Value="Visible" />
                                     </VisualState.Setters>
                                 </VisualState>
-                                <VisualState x:Name="HasSelection">
+                                <VisualState x:Name="HasSelectionWide">
                                     <VisualState.Setters>
                                         <Setter Target="NoSelectionPresenter.Visibility" Value="Collapsed" />
+                                        <Setter Target="MasterPanel.Visibility" Value="Visible" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                                <VisualState x:Name="HasSelectionNarrow">
+                                    <VisualState.Setters>
+                                        <Setter Target="NoSelectionPresenter.Visibility" Value="Collapsed" />
+                                        <Setter Target="MasterPanel.Visibility" Value="Collapsed" />
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="NoSelectionNarrow">
                                     <VisualState.Setters>
                                         <Setter Target="NoSelectionPresenter.Visibility" Value="Collapsed" />
                                         <Setter Target="DetailsPresenter.Visibility" Value="Collapsed" />
+                                        <Setter Target="MasterPanel.Visibility" Value="Visible" />
                                     </VisualState.Setters>
                                 </VisualState>
                             </VisualStateGroup>


### PR DESCRIPTION
This uses the `ItemClick` event instead of the bound `SelectedItem` property to set the view state. In this way, only when an item is clicked or selected with enter via keyboard, will it end up in the details view in a narrow state.

Fixes #791 