### PR TITLE
Use XML syntax highlighting for XAML code blocks

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp/Models/Sample.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/Models/Sample.cs
@@ -113,7 +113,7 @@ namespace Microsoft.Toolkit.Uwp.SampleApp
 
                         // Need to do some cleaning
                         // Rework code tags
-                        var regex = new Regex("```(xaml|csharp)(?<code>.+?)```", RegexOptions.Singleline);
+                        var regex = new Regex("```(xaml|xml|csharp)(?<code>.+?)```", RegexOptions.Singleline);
 
                         foreach (Match match in regex.Matches(result))
                         {

--- a/docs/animations/Blur.md
+++ b/docs/animations/Blur.md
@@ -9,7 +9,7 @@ Sometimes you want an element to appear slightly out of focus, but to be familia
 
 You can either use the blur behavior from your XAML code:
 
-```xaml
+```xml
 
     <interactivity:Interaction.Behaviors>
     <behaviors:Blur x:Name="BlurBehavior" 

--- a/docs/animations/Fade.md
+++ b/docs/animations/Fade.md
@@ -4,7 +4,7 @@ The **Fade animation behavior** fades objects, in and out, over time.
 
 ## Syntax
 
-```xaml
+```xml
 
     <behaviors:Fade x:Name="FadeBehavior>" 
                 Value="0.5" 

--- a/docs/animations/FadeHeader.md
+++ b/docs/animations/FadeHeader.md
@@ -10,7 +10,7 @@ The **FadeHeader Behavior** fades a ListView or GridView Header UIElement when t
 
 Automatically detects the Header element by finding the ListViewBase (note: GridView uses ListViewBase)
 
-```xaml
+```xml
 
     <interactivity:Interaction.Behaviors>
         <behaviors:FadeHeaderBehavior />
@@ -23,7 +23,7 @@ Automatically detects the Header element by finding the ListViewBase (note: Grid
 
 Set the ElementName property using the UIElement of the Header manually
 
-```xaml
+```xml
 
     <interactivity:Interaction.Behaviors>
         <behaviors:FadeHeaderBehavior HeaderElement="{Binding ElementName=MyHeaderGrid}" />
@@ -52,7 +52,7 @@ Explicit usage:
 
 ## Example ##
 
-```xaml
+```xml
 
     <ListView x:Name="MyListView">
     <interactivity:Interaction.Behaviors>

--- a/docs/animations/Light.md
+++ b/docs/animations/Light.md
@@ -11,7 +11,7 @@ The further away from the light source the more the light will spread over the U
 
 You can either use the light behavior from your XAML code:
 
-```xaml
+```xml
 
     <interactivity:Interaction.Behaviors>
     <behaviors:Light x:Name="LightBehavior" 

--- a/docs/animations/Offset.md
+++ b/docs/animations/Offset.md
@@ -4,7 +4,7 @@ The **Offset animation behavior** gets the number of pixels, from the origin of 
 
 ## Syntax
 
-```xaml
+```xml
 
 <behaviors:Offset x:Name="OffsetBehavior" 
 	OffsetX="25.0" 

--- a/docs/animations/ParallaxService.md
+++ b/docs/animations/ParallaxService.md
@@ -4,7 +4,7 @@ The **ParallaxService** class allows to create a parralax effect for items conta
 
 ## Syntax
 
-```xaml
+```xml
 
 <Image Source="ms-appx:///Assets/Photos/BigFourSummerHeat.png"
        ParallaxService.VerticalMultiplier="2.5/>

--- a/docs/animations/ReorderGrid.md
+++ b/docs/animations/ReorderGrid.md
@@ -4,7 +4,7 @@ The **ReorderGridAnimation** class allows your GridView controls to animate item
 
 ## Syntax
 
-```xaml
+```xml
 
 <GridView x:Name="GridItems"
           animations:ReorderGridAnimation.Duration="250"/>

--- a/docs/animations/Rotate.md
+++ b/docs/animations/Rotate.md
@@ -4,7 +4,7 @@ The **Rotate animation behavior** allows users to modify and animate the control
 
 ## Syntax
 
-```xaml
+```xml
 
    <behaviors:Rotate x:Name="RotateBehavior" 
 				Value="180"

--- a/docs/animations/Scale.md
+++ b/docs/animations/Scale.md
@@ -4,7 +4,7 @@ The **Scale animation behavior** allows you to change a control's scale by incre
 
 ## Syntax
 
-```xaml
+```xml
 
 <interactivity:Interaction.Behaviors>
     <behaviors:Scale x:Name="Scale" 

--- a/docs/controls/AdaptiveGridView.md
+++ b/docs/controls/AdaptiveGridView.md
@@ -6,7 +6,7 @@ If there are not enough items to fill one row, the control will stretch the item
 
 ## Syntax
 
-```xaml
+```xml
 
 <controls:AdaptiveGridView  Name="AdaptiveGridViewControl"
           ItemHeight="200"

--- a/docs/controls/BladeView.md
+++ b/docs/controls/BladeView.md
@@ -4,7 +4,7 @@ The BladeView provides a container to host blades as extra detail pages in, for 
 
 ## Syntax
 
-```xaml
+```xml
 
 <controls:BladeView>
     <controls:BladeItem IsOpen="True"
@@ -55,7 +55,7 @@ public enum BladeMode
 
 Here is an example of a BladeView where the `BladeMode` property is binded to a value in the code-behind.
 
-```xaml
+```xml
 
 <controls:BladeView x:Name="BladeView"
                     Padding="0"

--- a/docs/controls/DropShadowPanel.md
+++ b/docs/controls/DropShadowPanel.md
@@ -7,7 +7,7 @@ You can control the following property of the drop shadow effect : Offset, Color
 
 ## Syntax
 
-```xaml
+```xml
 
 <controls:DropShadowPanel BlurRadius="4.0"
                           ShadowOpacity="0.70"

--- a/docs/controls/GridSplitter.md
+++ b/docs/controls/GridSplitter.md
@@ -10,7 +10,7 @@ Developers can use the control to resize fixed and star (*) width/height columns
 
 ## Syntax
 
-```xaml
+```xml
 
 <controls:GridSplitter 
             Grid.Column="1"
@@ -46,7 +46,7 @@ Developers can use the control to resize fixed and star (*) width/height columns
 
 The following sample demonstrates how to add Grid Splitter Control.
 
-```xaml
+```xml
 
 <Page
     x:Class="Microsoft.Toolkit.Uwp.SampleApp.SamplePages.GridSplitterPage"

--- a/docs/controls/HamburgerMenu.md
+++ b/docs/controls/HamburgerMenu.md
@@ -10,7 +10,7 @@ Developers can place menu specific content, navigation, images, text or custom c
 
 ## Syntax
 
-```xaml
+```xml
 
 <controls:HamburgerMenu PaneBackground="@[PaneBackground:Brush:Black]" x:Name="HamburgerMenuControl"
 	Foreground="White"
@@ -42,7 +42,7 @@ You can also create HamburgerMenuGlyphItem (or HamburgerMenuImageItem) directly 
 
 The next sample demonstrates how to add custom menu items to the HamburgerMenu control.
 
-```xaml
+```xml
 
 <Page
     x:Class="HamburgerSample.MainPage"

--- a/docs/controls/HeaderedTextBlock.md
+++ b/docs/controls/HeaderedTextBlock.md
@@ -4,7 +4,7 @@ The **HeaderedTextBlock Control** provides a header for read-only text. This con
 
 ## Syntax
 
-```xaml
+```xml
 
 <controls:HeaderedTextBlock Header="HeaderedTextBlockControl" 
            Text="UWP Community Toolkit" 

--- a/docs/controls/ImageEx.md
+++ b/docs/controls/ImageEx.md
@@ -5,7 +5,7 @@ You can also use a placeholder image that will be displayed will loading the mai
  
 ## Syntax
 
-```xaml
+```xml
 
 <controls:ImageEx Name="ImageExControl"
 	IsCacheEnabled="True"

--- a/docs/controls/Loading.md
+++ b/docs/controls/Loading.md
@@ -6,7 +6,7 @@ The loading control is for showing an animation with some content when the user 
 
 An example of how we can build the loading control.
 
-```xaml
+```xml
 <controls:Loading x:Name="LoadingControl" IsLoading="{Binding IsBusy}">
     <ContentControl x:Name="LoadingContentControl"/>
 </controls:Loading>
@@ -15,7 +15,7 @@ An example of how we can build the loading control.
 - Use the **LoadingControl** to show specialized content.
 - You can also use **BorderBrush** and **BorderThickness** to change the **LoadingControl**.
 
-```xaml
+```xml
 <controls:Loading x:Name="LoadingControl" IsLoading="{Binding IsBusy}"  >
     <StackPanel Orientation="Horizontal" Padding="12">
         <Grid Margin="0,0,8,0">

--- a/docs/controls/MarkdownTextBlock.md
+++ b/docs/controls/MarkdownTextBlock.md
@@ -6,7 +6,7 @@ Under the hood, the control uses XAML sub elements to build the visual rendering
 
 ## Syntax
 
-```xaml
+```xml
 
  <controls:MarkdownTextBlock
     Text="**This is *Markdown*!"

--- a/docs/controls/MasterDetailsView.md
+++ b/docs/controls/MasterDetailsView.md
@@ -4,7 +4,7 @@ The **MasterDetailsView Control** presents items in a master/details pattern. It
 
 ## Syntax
 
-```xaml
+```xml
 
 <controls:MasterDetailsView
           ItemsSource="{Binding Items}"

--- a/docs/controls/PullToRefreshListview.md
+++ b/docs/controls/PullToRefreshListview.md
@@ -12,7 +12,7 @@ The *RefreshIndicatorContent* can be used with the *PullProgressChanged* event t
 
 ## Syntax
 
-```xaml
+```xml
 
 <controls:PullToRefreshListView Name="PullToRefreshListViewControl"
 	ItemsSource="{x:Bind _items}"	

--- a/docs/controls/RadialGauge.md
+++ b/docs/controls/RadialGauge.md
@@ -9,7 +9,7 @@ The Radial Gauge supports animated transitions between configuration states. The
 
 ## Syntax
 
-```xaml
+```xml
 
 <controls:RadialGauge x:Name="RadialGaugeControl"
 	Column="1"

--- a/docs/controls/RangeSelector.md
+++ b/docs/controls/RangeSelector.md
@@ -4,7 +4,7 @@ The **RangeSelector Control** is a *Double Slider* control that allows the user 
 
 Please note that if you are using a RangeSelector within a ScrollViewer you'll need to add the following code:
 
-```xaml
+```xml
 
 <controls:RangeSelector x:Name="Selector" ThumbDragStarted="Selector_OnDragStarted" ThumbDragCompleted="Selector_OnDragCompleted"></controls:RangeSelector>
 
@@ -31,7 +31,7 @@ This is because by default, the ScrollViewer will block the thumbs of the RangeS
 
 ## Syntax
 
-```xaml
+```xml
 
 <controls:RangeSelector x:Name="RangeSelectorControl" 
 	Minimum="10" 

--- a/docs/controls/RotatorTile.md
+++ b/docs/controls/RotatorTile.md
@@ -4,7 +4,7 @@ The **Rotator Tile Control** is an ItemsControl that rotates through a set of it
 
 ## Syntax
 
-```xaml
+```xml
 
 <controls:RotatorTile x:Name="Tile1"
 	Background="LightGray"

--- a/docs/controls/ScrollHeader.md
+++ b/docs/controls/ScrollHeader.md
@@ -4,7 +4,7 @@ The **ScrollHeader Control** provides a header for ListViews or GridViews that a
 
 ## Syntax
 
-```xaml
+```xml
 
 <ListView Name="listView" ItemsSource="{x:Bind _items, Mode=OneWay}">
 	<ListView.Header>

--- a/docs/controls/SlidableListItem.md
+++ b/docs/controls/SlidableListItem.md
@@ -54,7 +54,7 @@ If you use **SlidableListItem** in a **ListView** with the **ItemClick** event, 
 
 ## Syntax
 
-```xaml
+```xml
 
 <controls:SlidableListItem
 	LeftIcon="Favorite" 

--- a/docs/controls/SurfaceDialTextboxHelper.md
+++ b/docs/controls/SurfaceDialTextboxHelper.md
@@ -23,7 +23,7 @@ Enables you to click the Surface Dial Control to move to the next focus item in 
 
 ## Syntax
 
-```xaml
+```xml
 
 <TextBox Width="106"
           HorizontalAlignment="Left"

--- a/docs/controls/TextBoxMask.md
+++ b/docs/controls/TextBoxMask.md
@@ -25,7 +25,7 @@ In case you want to add a custom variable character you can use property TextBox
 
 ## Syntax
 
-```xaml
+```xml
 
             <TextBox controls:TextBoxMasks.Mask="9a9a-a9a*"
                      Header="Text box with Mask 9a9a-a9a* (9 allows from 0 to 9, a allow from a to Z and * allows both a and 9)"
@@ -56,7 +56,7 @@ In case you want to add a custom variable character you can use property TextBox
 
 The following sample demonstrates how to add TextBoxMask property.
 
-```xaml
+```xml
 
 <Page x:Class="Microsoft.Toolkit.Uwp.SampleApp.SamplePages.TextBoxMaskPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"

--- a/docs/controls/TextBoxRegex.md
+++ b/docs/controls/TextBoxRegex.md
@@ -17,7 +17,7 @@ Main Attached Properties:
 
 ## Syntax
 
-```xaml
+```xml
 
             <TextBox controls:TextBoxRegex.Regex="^\s*\+?\s*([0-9][\s-]*){9,}$" />
 
@@ -43,7 +43,7 @@ Main Attached Properties:
 
 The following sample demonstrates how to add TextBoxRegex property.
 
-```xaml
+```xml
 
 <Page x:Class="Microsoft.Toolkit.Uwp.SampleApp.SamplePages.TextBoxRegexPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"

--- a/docs/controls/TileControl.md
+++ b/docs/controls/TileControl.md
@@ -4,7 +4,7 @@ The **Tile Control** is a control that repeat an image many times. It enables yo
 
 ## Syntax
 
-```xaml
+```xml
 
 <controls:TileControl x:Name="Tile1"
 	OffsetX="-10" 

--- a/docs/controls/WrapPanel.md
+++ b/docs/controls/WrapPanel.md
@@ -8,7 +8,7 @@ The WrapPanel position child controls based on orientation, horizontal orientati
 
 ## Syntax
 
-```xaml
+```xml
 
 <wrapPanel:WrapPanel Name="VerticalWrapPanel"
                                  Grid.Row="1"
@@ -28,7 +28,7 @@ The WrapPanel position child controls based on orientation, horizontal orientati
 
 The following sample demonstrates how to add WrapPanel Control.
 
-```xaml
+```xml
 
 <Page x:Class="Microsoft.Toolkit.Uwp.SampleApp.SamplePages.WrapPanelPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"

--- a/docs/helpers/BindableValueHolder.md
+++ b/docs/helpers/BindableValueHolder.md
@@ -6,7 +6,7 @@ The **BindableValueHolder** lets users change several objects' states at a time.
 
 You can use it to switch several object states by declaring it as a Resource (either in a page or control):
 
-```xaml
+```xml
 
 <helpers:BindableValueHolder x:Name="HighlightBrushHolder" Value="{StaticResource BlackBrush}" />
 
@@ -14,7 +14,7 @@ You can use it to switch several object states by declaring it as a Resource (ei
 
 and using it like that:
 
-```xaml
+```xml
 
 <TextBlock x:Name="Label" Foreground="{Binding Value, ElementName=HighlightBrushHolder}" />
 
@@ -24,7 +24,7 @@ and using it like that:
 
 and switching it like that:
 
-```xaml
+```xml
 
 <VisualStateGroup x:Name="HighlightStates">
     <VisualState x:Name="Normal" />

--- a/docs/helpers/Converters.md
+++ b/docs/helpers/Converters.md
@@ -16,7 +16,7 @@ Commonly used **converters** that allow the data to be modified as it passes thr
 `BoolToObjectConverter` can be used to generalize the behavior of `BoolToVisibilityConverter` by allowing to pass the two values it can return.
 You can use it to switch Visibility by declaring it :
 
-```xaml
+```xml
 
 <converters:BoolToObjectConverter x:Key="BoolToVisibilityConverter" TrueValue="Visible" FalseValue="Collapsed"/>
 
@@ -24,7 +24,7 @@ You can use it to switch Visibility by declaring it :
 
 and using it like that :
 
-```xaml
+```xml
 
 <Image Visibility="{x:Bind Path=MyBoolValue, Converter={StaticResource BoolToVisibilityConverter}}" />
 
@@ -34,7 +34,7 @@ It can also be used to switch between two values of brush.
 
 Note : you can use a resource for the brush or pass the color string and have it converted to a brush automatically.
 
-```xaml
+```xml
 
 <converters:BoolToObjectConverter x:Key="BoolToBrushConverter" TrueValue="Green" FalseValue="{StaticResource NopeBrush}" />
 
@@ -42,7 +42,7 @@ Note : you can use a resource for the brush or pass the color string and have it
 
 and using it like that :
 
-```xaml
+```xml
 
 <Border Background="{x:Bind Path=MyBoolValue, Converter={StaticResource BoolToBrushConverter}}" />
 
@@ -50,7 +50,7 @@ and using it like that :
 
 An other example is to switch between two images by specifying their source :
 
-```xaml
+```xml
 
 <converters:BoolToObjectConverter x:Key="BoolToImageConverter" TrueValue="ms-appx:///Assets/Yes.png" FalseValue="ms-appx:///Assets/No.png" />
 
@@ -58,7 +58,7 @@ An other example is to switch between two images by specifying their source :
 
 and using it like that :
 
-```xaml
+```xml
 
 <Image Source="{x:Bind Path=MyBoolValue, Converter={StaticResource BoolToImageConverter}}" />
 

--- a/docs/helpers/HyperlinkExtensions.md
+++ b/docs/helpers/HyperlinkExtensions.md
@@ -4,7 +4,7 @@ The **HyperlinkExtensions** allows for a Hyperlink element to invoke the execute
 
 ## Example
 
-```xaml
+```xml
 	// Use Hyperlink in a wrapped TextBlock with text either side and ensure it executes a command when
 	// clicked passing the current data context as the command parameter.
 	<TextBlock>

--- a/docs/helpers/ListViewBaseExtensions.md
+++ b/docs/helpers/ListViewBaseExtensions.md
@@ -7,7 +7,7 @@ ListViewBase [IsItemClickEnabled](https://msdn.microsoft.com/en-us/library/windo
 
 ## Example
 
-```xaml
+```xml
     // Attach the command declared in MainViewModel to ListView declared in XAML
     // IsItemClickEnabled is set to true as shown below
     <ListView

--- a/docs/helpers/WebViewExtensions.md
+++ b/docs/helpers/WebViewExtensions.md
@@ -4,7 +4,7 @@ The **WebViewExtensions** allows attaching HTML content to WebView.
 
 ## Example
 
-```xaml
+```xml
 	// Attach HTML content directly to WebView.
 	<WebView xaml:WebViewExtensions.Content="{Binding HtmlContent}" />
 


### PR DESCRIPTION
As Github doesn't provide XAML syntax highlighting, I've changed all files in docs to use XML instead (which XAML is in essence!)