### PR TITLE
Allow SelectedItem to be set before control is loaded

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.cs
@@ -143,6 +143,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             _narrowState = GetTemplateChild(NarrowState) as VisualState;
 
             SetVisualState(_stateGroup.CurrentState, true);
+            SetBackButtonVisibility(_stateGroup.CurrentState);
 
             UpdateViewState();
         }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.cs
@@ -86,10 +86,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         private static void OnSelectedItemChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             var view = (MasterDetailsView)d;
-            string noSelectionState = view._stateGroup.CurrentState == view._narrowState
-                ? NoSelectionNarrowState
-                : NoSelectionWideState;
-            VisualStateManager.GoToState(view, view.SelectedItem == null ? noSelectionState : HasSelectionState, true);
+            view.SetVisualState(view._stateGroup.CurrentState, true);
 
             view.OnSelectionChanged(new SelectionChangedEventArgs(new List<object> { e.OldValue }, new List<object> { e.NewValue }));
 
@@ -140,10 +137,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
             _narrowState = GetTemplateChild(NarrowState) as VisualState;
 
-            string noSelectionState = _stateGroup.CurrentState == _narrowState
-                ? NoSelectionNarrowState
-                : NoSelectionWideState;
-            VisualStateManager.GoToState(this, this.SelectedItem == null ? noSelectionState : HasSelectionState, true);
+            SetVisualState(_stateGroup.CurrentState, true);
 
             UpdateViewState();
         }
@@ -174,10 +168,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             SetBackButtonVisibility(e.NewState);
 
             // When adaptive trigger changes state, switch between NoSelectionWide and NoSelectionNarrow.
-            string noSelectionState = e.NewState == _narrowState
-                ? NoSelectionNarrowState
-                : NoSelectionWideState;
-            VisualStateManager.GoToState(this, this.SelectedItem == null ? noSelectionState : HasSelectionState, false);
+            SetVisualState(e.NewState, false);
         }
 
         /// <summary>
@@ -270,6 +261,14 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             {
                 ViewStateChanged?.Invoke(this, after);
             }
+        }
+
+        private void SetVisualState(VisualState state, bool animate)
+        {
+            string noSelectionState = state == _narrowState
+                ? NoSelectionNarrowState
+                : NoSelectionWideState;
+            VisualStateManager.GoToState(this, SelectedItem == null ? noSelectionState : HasSelectionState, animate);
         }
     }
 }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.cs
@@ -71,6 +71,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             base.OnApplyTemplate();
 
             _detailsPresenter = (ContentPresenter)GetTemplateChild(PartDetailsPresenter);
+            SetDetailsContent();
 
             SetMasterHeaderVisibility();
         }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.cs
@@ -96,9 +96,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             // If there is no selection, do not remove the DetailsPresenter content but let it animate out.
             if (view.SelectedItem != null)
             {
-                view._detailsPresenter.Content = view.MapDetails == null
-                    ? view.SelectedItem
-                    : view.MapDetails(view.SelectedItem);
+                view.SetDetailsContent();
             }
 
             if (view._stateGroup != null)
@@ -275,6 +273,16 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 ? NoSelectionNarrowState
                 : NoSelectionWideState;
             VisualStateManager.GoToState(this, SelectedItem == null ? noSelectionState : HasSelectionState, animate);
+        }
+
+        private void SetDetailsContent()
+        {
+            if ((SelectedItem != null) && (_detailsPresenter != null))
+            {
+                _detailsPresenter.Content = MapDetails == null
+                    ? SelectedItem
+                    : MapDetails(SelectedItem);
+            }
         }
     }
 }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.cs
@@ -86,7 +86,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         private static void OnSelectedItemChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             var view = (MasterDetailsView)d;
-            view.SetVisualState(view._stateGroup.CurrentState, true);
+            if (view._stateGroup != null)
+            {
+                view.SetVisualState(view._stateGroup.CurrentState, true);
+            }
 
             view.OnSelectionChanged(new SelectionChangedEventArgs(new List<object> { e.OldValue }, new List<object> { e.NewValue }));
 
@@ -98,7 +101,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                     : view.MapDetails(view.SelectedItem);
             }
 
-            view.SetBackButtonVisibility(view._stateGroup.CurrentState);
+            if (view._stateGroup != null)
+            {
+                view.SetBackButtonVisibility(view._stateGroup.CurrentState);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #877 by allowing the SelectedItem property to be set before the control has been loaded.