### PR TITLE
Allow AdvancedCollectionView to sort on object itself and custom comparers

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI/AdvancedCollectionView/AdvancedCollectionView.cs
+++ b/Microsoft.Toolkit.Uwp.UI/AdvancedCollectionView/AdvancedCollectionView.cs
@@ -394,8 +394,7 @@ namespace Microsoft.Toolkit.Uwp.UI
 
                 try
                 {
-                    var comparer = sd.Comparer ?? ComparerAdapter.Instance;
-                    var cmp = comparer.Compare(cx, cy);
+                    var cmp = sd.Comparer.Compare(cx, cy);
 
                     if (cmp != 0)
                     {
@@ -603,24 +602,6 @@ namespace Microsoft.Toolkit.Uwp.UI
             _index = i;
             OnCurrentChanged(null);
             return true;
-        }
-
-        private class ComparerAdapter : IComparer
-        {
-            public static readonly IComparer Instance = new ComparerAdapter();
-
-            private ComparerAdapter()
-            {
-            }
-
-            public int Compare(object x, object y)
-            {
-                var cx = x as IComparable;
-                var cy = y as IComparable;
-
-                // ReSharper disable once PossibleUnintendedReferenceComparison
-                return cx == cy ? 0 : cx == null ? -1 : cy == null ? +1 : cx.CompareTo(cy);
-            }
         }
     }
 }

--- a/Microsoft.Toolkit.Uwp.UI/AdvancedCollectionView/AdvancedCollectionView.cs
+++ b/Microsoft.Toolkit.Uwp.UI/AdvancedCollectionView/AdvancedCollectionView.cs
@@ -392,18 +392,11 @@ namespace Microsoft.Toolkit.Uwp.UI
                     cy = pi.GetValue(y);
                 }
 
-                try
-                {
-                    var cmp = sd.Comparer.Compare(cx, cy);
+                var cmp = sd.Comparer.Compare(cx, cy);
 
-                    if (cmp != 0)
-                    {
-                        return sd.Direction == SortDirection.Ascending ? +cmp : -cmp;
-                    }
-                }
-                catch
+                if (cmp != 0)
                 {
-                    // fail silently
+                    return sd.Direction == SortDirection.Ascending ? +cmp : -cmp;
                 }
             }
 

--- a/Microsoft.Toolkit.Uwp.UI/AdvancedCollectionView/AdvancedCollectionView.cs
+++ b/Microsoft.Toolkit.Uwp.UI/AdvancedCollectionView/AdvancedCollectionView.cs
@@ -377,24 +377,26 @@ namespace Microsoft.Toolkit.Uwp.UI
 
             foreach (var sd in _sortDescriptions)
             {
-                IComparable cx, cy;
+                object cx, cy;
 
                 if (string.IsNullOrEmpty(sd.PropertyName))
                 {
-                    cx = x as IComparable;
-                    cy = y as IComparable;
+                    cx = x;
+                    cy = y;
                 }
                 else
                 {
                     var pi = _sortProperties[sd.PropertyName];
-                    cx = pi.GetValue(x) as IComparable;
-                    cy = pi.GetValue(y) as IComparable;
+
+                    cx = pi.GetValue(x);
+                    cy = pi.GetValue(y);
                 }
 
                 try
                 {
-                    // ReSharper disable once PossibleUnintendedReferenceComparison
-                    var cmp = cx == cy ? 0 : cx == null ? -1 : cy == null ? +1 : cx.CompareTo(cy);
+                    var comparer = sd.Comparer ?? ComparerAdapter.Instance;
+                    var cmp = comparer.Compare(cx, cy);
+
                     if (cmp != 0)
                     {
                         return sd.Direction == SortDirection.Ascending ? +cmp : -cmp;
@@ -601,6 +603,24 @@ namespace Microsoft.Toolkit.Uwp.UI
             _index = i;
             OnCurrentChanged(null);
             return true;
+        }
+
+        private class ComparerAdapter : IComparer
+        {
+            public static readonly IComparer Instance = new ComparerAdapter();
+
+            private ComparerAdapter()
+            {
+            }
+
+            public int Compare(object x, object y)
+            {
+                var cx = x as IComparable;
+                var cy = y as IComparable;
+
+                // ReSharper disable once PossibleUnintendedReferenceComparison
+                return cx == cy ? 0 : cx == null ? -1 : cy == null ? +1 : cx.CompareTo(cy);
+            }
         }
     }
 }

--- a/Microsoft.Toolkit.Uwp.UI/AdvancedCollectionView/AdvancedCollectionView.cs
+++ b/Microsoft.Toolkit.Uwp.UI/AdvancedCollectionView/AdvancedCollectionView.cs
@@ -368,15 +368,29 @@ namespace Microsoft.Toolkit.Uwp.UI
                 var typeInfo = x.GetType().GetTypeInfo();
                 foreach (var sd in _sortDescriptions)
                 {
-                    _sortProperties[sd.PropertyName] = typeInfo.GetDeclaredProperty(sd.PropertyName);
+                    if (!string.IsNullOrEmpty(sd.PropertyName))
+                    {
+                        _sortProperties[sd.PropertyName] = typeInfo.GetDeclaredProperty(sd.PropertyName);
+                    }
                 }
             }
 
             foreach (var sd in _sortDescriptions)
             {
-                var pi = _sortProperties[sd.PropertyName];
-                var cx = pi.GetValue(x) as IComparable;
-                var cy = pi.GetValue(y) as IComparable;
+                IComparable cx, cy;
+
+                if (string.IsNullOrEmpty(sd.PropertyName))
+                {
+                    cx = x as IComparable;
+                    cy = y as IComparable;
+                }
+                else
+                {
+                    var pi = _sortProperties[sd.PropertyName];
+                    cx = pi.GetValue(x) as IComparable;
+                    cy = pi.GetValue(y) as IComparable;
+                }
+
                 try
                 {
                     // ReSharper disable once PossibleUnintendedReferenceComparison

--- a/Microsoft.Toolkit.Uwp.UI/AdvancedCollectionView/SortDescription.cs
+++ b/Microsoft.Toolkit.Uwp.UI/AdvancedCollectionView/SortDescription.cs
@@ -10,6 +10,8 @@
 // THE CODE OR THE USE OR OTHER DEALINGS IN THE CODE.
 // ******************************************************************
 
+using System.Collections;
+
 namespace Microsoft.Toolkit.Uwp.UI
 {
     /// <summary>
@@ -28,6 +30,11 @@ namespace Microsoft.Toolkit.Uwp.UI
         public SortDirection Direction { get; }
 
         /// <summary>
+        /// Gets the comparer
+        /// </summary>
+        public IComparer Comparer { get; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="SortDescription"/> class that describes
         /// a sort on the object itself
         /// </summary>
@@ -35,6 +42,18 @@ namespace Microsoft.Toolkit.Uwp.UI
         public SortDescription(SortDirection direction)
         {
             Direction = direction;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SortDescription"/> class that describes
+        /// a sort on the object itself
+        /// </summary>
+        /// <param name="direction">directio of sort</param>
+        /// <param name="comparer">comparer to use</param>
+        public SortDescription(SortDirection direction, IComparer comparer)
+        {
+            Direction = direction;
+            Comparer = comparer;
         }
 
         /// <summary>
@@ -46,6 +65,19 @@ namespace Microsoft.Toolkit.Uwp.UI
         {
             PropertyName = propertyName;
             Direction = direction;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SortDescription"/> class.
+        /// </summary>
+        /// <param name="propertyName">name of property to sort on</param>
+        /// <param name="direction">direction of sort</param>
+        /// <param name="comparer">comparer to use</param>
+        public SortDescription(string propertyName, SortDirection direction, IComparer comparer)
+        {
+            PropertyName = propertyName;
+            Direction = direction;
+            Comparer = comparer;
         }
     }
 }

--- a/Microsoft.Toolkit.Uwp.UI/AdvancedCollectionView/SortDescription.cs
+++ b/Microsoft.Toolkit.Uwp.UI/AdvancedCollectionView/SortDescription.cs
@@ -20,12 +20,22 @@ namespace Microsoft.Toolkit.Uwp.UI
         /// <summary>
         /// Gets the name of property to sort on
         /// </summary>
-        public string PropertyName { get; private set; }
+        public string PropertyName { get; }
 
         /// <summary>
         /// Gets the direction of sort
         /// </summary>
-        public SortDirection Direction { get; private set; }
+        public SortDirection Direction { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SortDescription"/> class that describes
+        /// a sort on the object itself
+        /// </summary>
+        /// <param name="direction">direction of sort</param>
+        public SortDescription(SortDirection direction)
+        {
+            Direction = direction;
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SortDescription"/> class.

--- a/Microsoft.Toolkit.Uwp.UI/AdvancedCollectionView/SortDescription.cs
+++ b/Microsoft.Toolkit.Uwp.UI/AdvancedCollectionView/SortDescription.cs
@@ -10,6 +10,7 @@
 // THE CODE OR THE USE OR OTHER DEALINGS IN THE CODE.
 // ******************************************************************
 
+using System;
 using System.Collections;
 
 namespace Microsoft.Toolkit.Uwp.UI
@@ -40,8 +41,8 @@ namespace Microsoft.Toolkit.Uwp.UI
         /// </summary>
         /// <param name="direction">direction of sort</param>
         public SortDescription(SortDirection direction)
+            : this(null, direction, ObjectComparer.Instance)
         {
-            Direction = direction;
         }
 
         /// <summary>
@@ -51,9 +52,8 @@ namespace Microsoft.Toolkit.Uwp.UI
         /// <param name="direction">directio of sort</param>
         /// <param name="comparer">comparer to use</param>
         public SortDescription(SortDirection direction, IComparer comparer)
+            : this(null, direction, comparer)
         {
-            Direction = direction;
-            Comparer = comparer;
         }
 
         /// <summary>
@@ -62,9 +62,8 @@ namespace Microsoft.Toolkit.Uwp.UI
         /// <param name="propertyName">name of property to sort on</param>
         /// <param name="direction">direction of sort</param>
         public SortDescription(string propertyName, SortDirection direction)
+            : this(propertyName, direction, ObjectComparer.Instance)
         {
-            PropertyName = propertyName;
-            Direction = direction;
         }
 
         /// <summary>
@@ -78,6 +77,24 @@ namespace Microsoft.Toolkit.Uwp.UI
             PropertyName = propertyName;
             Direction = direction;
             Comparer = comparer;
+        }
+
+        private class ObjectComparer : IComparer
+        {
+            public static readonly IComparer Instance = new ObjectComparer();
+
+            private ObjectComparer()
+            {
+            }
+
+            public int Compare(object x, object y)
+            {
+                var cx = x as IComparable;
+                var cy = y as IComparable;
+
+                // ReSharper disable once PossibleUnintendedReferenceComparison
+                return cx == cy ? 0 : cx == null ? -1 : cy == null ? +1 : cx.CompareTo(cy);
+            }
         }
     }
 }

--- a/Microsoft.Toolkit.Uwp.UI/AdvancedCollectionView/SortDescription.cs
+++ b/Microsoft.Toolkit.Uwp.UI/AdvancedCollectionView/SortDescription.cs
@@ -39,19 +39,9 @@ namespace Microsoft.Toolkit.Uwp.UI
         /// Initializes a new instance of the <see cref="SortDescription"/> class that describes
         /// a sort on the object itself
         /// </summary>
-        /// <param name="direction">direction of sort</param>
-        public SortDescription(SortDirection direction)
-            : this(null, direction, ObjectComparer.Instance)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="SortDescription"/> class that describes
-        /// a sort on the object itself
-        /// </summary>
-        /// <param name="direction">directio of sort</param>
-        /// <param name="comparer">comparer to use</param>
-        public SortDescription(SortDirection direction, IComparer comparer)
+        /// <param name="direction">Direction of sort</param>
+        /// <param name="comparer">Comparer to use. If null, will use default comparer</param>
+        public SortDescription(SortDirection direction, IComparer comparer = null)
             : this(null, direction, comparer)
         {
         }
@@ -59,24 +49,14 @@ namespace Microsoft.Toolkit.Uwp.UI
         /// <summary>
         /// Initializes a new instance of the <see cref="SortDescription"/> class.
         /// </summary>
-        /// <param name="propertyName">name of property to sort on</param>
-        /// <param name="direction">direction of sort</param>
-        public SortDescription(string propertyName, SortDirection direction)
-            : this(propertyName, direction, ObjectComparer.Instance)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="SortDescription"/> class.
-        /// </summary>
-        /// <param name="propertyName">name of property to sort on</param>
-        /// <param name="direction">direction of sort</param>
-        /// <param name="comparer">comparer to use</param>
-        public SortDescription(string propertyName, SortDirection direction, IComparer comparer)
+        /// <param name="propertyName">Name of property to sort on</param>
+        /// <param name="direction">Direction of sort</param>
+        /// <param name="comparer">Comparer to use. If null, will use default comparer</param>
+        public SortDescription(string propertyName, SortDirection direction, IComparer comparer = null)
         {
             PropertyName = propertyName;
             Direction = direction;
-            Comparer = comparer;
+            Comparer = comparer ?? ObjectComparer.Instance;
         }
 
         private class ObjectComparer : IComparer

--- a/UnitTests/UI/Person.cs
+++ b/UnitTests/UI/Person.cs
@@ -10,15 +10,29 @@
 // THE CODE OR THE USE OR OTHER DEALINGS IN THE CODE.
 // ******************************************************************
 
+using System;
+
 namespace UnitTests.UI
 {
     /// <summary>
     /// Sample class to test AdvancedCollectionViewSource functionality
     /// </summary>
-    internal class Person
+    internal class Person : IComparable
     {
         public string Name { get; set; }
 
         public int Age { get; set; }
+
+        public int CompareTo(object obj)
+        {
+            var other = obj as Person;
+
+            if (other == null)
+            {
+                return -1;
+            }
+
+            return Age.CompareTo(other.Age);
+        }
     }
 }

--- a/UnitTests/UI/Test_AdvancedCollectionView.cs
+++ b/UnitTests/UI/Test_AdvancedCollectionView.cs
@@ -10,12 +10,15 @@
 // THE CODE OR THE USE OR OTHER DEALINGS IN THE CODE.
 // ******************************************************************
 
+using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using Microsoft.Toolkit.Uwp.UI;
 using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
 using Microsoft.VisualStudio.TestPlatform.UnitTestFramework.AppContainer;
+
 using Assert = Microsoft.VisualStudio.TestPlatform.UnitTestFramework.Assert;
 
 namespace UnitTests.UI
@@ -228,6 +231,116 @@ namespace UnitTests.UI
             };
 
             Assert.AreEqual(((Person)a.First()).Age, 42);
+        }
+
+        [TestCategory("AdvancedCollectionView")]
+        [UITestMethod]
+        public void Test_AdvancedCollectionView_Sorting_OnSelf_CustomComparable()
+        {
+            var l = new ObservableCollection<Person>
+            {
+                new Person()
+                {
+                    Name = "lorem",
+                    Age = 4
+                },
+                new Person()
+                {
+                    Name = "imsum",
+                    Age = 8
+                },
+                new Person()
+                {
+                    Name = "dolor",
+                    Age = 15
+                },
+                new Person()
+                {
+                    Name = "sit",
+                    Age = 16
+                },
+                new Person()
+                {
+                    Name = "amet",
+                    Age = 23
+                },
+                new Person()
+                {
+                    Name = "consectetur",
+                    Age = 42
+                },
+            };
+
+            var a = new AdvancedCollectionView(l)
+            {
+                SortDescriptions =
+                {
+                    new SortDescription(SortDirection.Ascending, new DelegateComparable((x, y) => -((Person)x).Age.CompareTo(((Person)y).Age)))
+                }
+            };
+
+            Assert.AreEqual(((Person)a.First()).Age, 42);
+        }
+
+        [TestCategory("AdvancedCollectionView")]
+        [UITestMethod]
+        public void Test_AdvancedCollectionView_Sorting_CustomComparable()
+        {
+            var l = new ObservableCollection<Person>
+            {
+                new Person()
+                {
+                    Name = "lorem",
+                    Age = 4
+                },
+                new Person()
+                {
+                    Name = "imsum",
+                    Age = 8
+                },
+                new Person()
+                {
+                    Name = "dolor",
+                    Age = 15
+                },
+                new Person()
+                {
+                    Name = "sit",
+                    Age = 16
+                },
+                new Person()
+                {
+                    Name = "amet",
+                    Age = 23
+                },
+                new Person()
+                {
+                    Name = "consectetur",
+                    Age = 42
+                },
+            };
+
+            var a = new AdvancedCollectionView(l)
+            {
+                SortDescriptions =
+                {
+                    new SortDescription(nameof(Person.Age), SortDirection.Ascending, new DelegateComparable((x, y) => -((int)x).CompareTo((int)y)))
+                }
+            };
+
+            Assert.AreEqual(((Person)a.First()).Age, 42);
+        }
+
+        private class DelegateComparable : IComparer
+        {
+            private Func<object, object, int> _func;
+
+            public DelegateComparable(Func<object, object, int> func)
+            {
+                _func = func;
+            }
+
+            public int Compare(object x, object y) => _func(x, y);
         }
     }
 }

--- a/UnitTests/UI/Test_AdvancedCollectionView.cs
+++ b/UnitTests/UI/Test_AdvancedCollectionView.cs
@@ -180,5 +180,54 @@ namespace UnitTests.UI
             Assert.AreEqual(((Person)a.First()).Age, 42);
             Assert.AreEqual(a.Count, 2);
         }
+
+        [TestCategory("AdvancedCollectionView")]
+        [UITestMethod]
+        public void Test_AdvancedCollectionView_Sorting_OnSelf()
+        {
+            var l = new ObservableCollection<Person>
+            {
+                new Person()
+                {
+                    Name = "lorem",
+                    Age = 4
+                },
+                new Person()
+                {
+                    Name = "imsum",
+                    Age = 8
+                },
+                new Person()
+                {
+                    Name = "dolor",
+                    Age = 15
+                },
+                new Person()
+                {
+                    Name = "sit",
+                    Age = 16
+                },
+                new Person()
+                {
+                    Name = "amet",
+                    Age = 23
+                },
+                new Person()
+                {
+                    Name = "consectetur",
+                    Age = 42
+                },
+            };
+
+            var a = new AdvancedCollectionView(l)
+            {
+                SortDescriptions =
+                {
+                    new SortDescription(SortDirection.Descending)
+                }
+            };
+
+            Assert.AreEqual(((Person)a.First()).Age, 42);
+        }
     }
 }


### PR DESCRIPTION
This adds support to AdvancedCollectionView to sort on the object itself and also provides a way to add customer comparers if desired. This is done by adding three new overloads to `SortDescription`

- `SortDescription(SortDirection)` will use the IComparable that the object itself defines (if available)
- `SortDescription(SortDirection, IComparer)` provides a custom comparer for the object itself
- `SortDescription(string propertyName, SortDirection, IComparer)` provides a custom comparer for the property indicated

*Edit*

If this goes in 1.3, we can just use an optional parameter (if it were to go in 1.4, that's a breaking binary change), and have two overloads for the constructor:

- `SortDescription(SortDirection, IComparer = null)` will sort on the object itself
- `SortDescription(string propertyName, SortDirection, IComparer = null)` sorts on the property with the given name

Fixes #881 