### PR TITLE
Added background download creation.

### DIFF
--- a/Microsoft.Toolkit.Uwp.Services/Services/OneDrive/OneDriveService.cs
+++ b/Microsoft.Toolkit.Uwp.Services/Services/OneDrive/OneDriveService.cs
@@ -16,6 +16,10 @@ using Microsoft.Graph;
 using Microsoft.OneDrive.Sdk;
 using Microsoft.OneDrive.Sdk.Authentication;
 using static Microsoft.Toolkit.Uwp.Services.OneDrive.OneDriveEnums;
+using Windows.Networking.BackgroundTransfer;
+using Windows.Storage;
+using System.Linq;
+using System.Threading;
 
 namespace Microsoft.Toolkit.Uwp.Services.OneDrive
 {
@@ -326,5 +330,47 @@ namespace Microsoft.Toolkit.Uwp.Services.OneDrive
             var oneDriveRootItem = await _oneDriveProvider.Drive.Special.Photos.Request().GetAsync();
             return new OneDriveStorageFolder(_oneDriveProvider, _oneDriveProvider.Drive.Special.Photos, oneDriveRootItem);
         }
+
+        /// <summary>
+        /// Creates a background download for given OneDriveId
+        /// </summary>
+        /// <param name="oneDriveId">OneDrive item's Id</param>
+        /// <param name="destinationFile">A <see cref="StorageFile"/> to which content will be downloaded</param>
+        /// <param name="completionGroup">The <see cref="BackgroundTransferCompletionGroup"/> to which should <see cref="BackgroundDownloader"/> reffer to</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request</param>
+        /// <returns>The created <see cref="DownloadOperation"/></returns>
+        public async Task<DownloadOperation> CreateBackgroundDownloadForItemAsync(string oneDriveId, StorageFile destinationFile, BackgroundTransferCompletionGroup completionGroup = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (string.IsNullOrWhiteSpace(oneDriveId))
+            {
+                throw new ArgumentNullException(nameof(oneDriveId));
+            }
+
+            if (destinationFile == null)
+            {
+                throw new ArgumentNullException(nameof(destinationFile));
+            }
+
+            // log the user silently with a Microsoft Account associate to Windows
+            if (_isConnected == false)
+            {
+                OneDriveService.Instance.Initialize();
+                if (!await OneDriveService.Instance.LoginAsync())
+                {
+                    throw new Exception("Unable to sign in");
+                }
+            }
+
+            var requestMessage = Provider.Drive.Items[oneDriveId].Content.Request().GetHttpRequestMessage();
+            await Provider.AuthenticationProvider.AuthenticateRequestAsync(requestMessage).AsAsyncAction().AsTask(cancellationToken);
+            var downloader = completionGroup == null ? new BackgroundDownloader() : new BackgroundDownloader(completionGroup);
+            foreach (var item in requestMessage.Headers)
+            {
+                downloader.SetRequestHeader(item.Key, item.Value.First());
+            }
+
+            return await Task.Run(() => downloader.CreateDownload(requestMessage.RequestUri, destinationFile), cancellationToken);
+        }
+
     }
 }

--- a/Microsoft.Toolkit.Uwp.Services/Services/OneDrive/OneDriveService.cs
+++ b/Microsoft.Toolkit.Uwp.Services/Services/OneDrive/OneDriveService.cs
@@ -361,15 +361,18 @@ namespace Microsoft.Toolkit.Uwp.Services.OneDrive
                 }
             }
 
-            var requestMessage = Provider.Drive.Items[oneDriveId].Content.Request().GetHttpRequestMessage();
-            await Provider.AuthenticationProvider.AuthenticateRequestAsync(requestMessage).AsAsyncAction().AsTask(cancellationToken);
-            var downloader = completionGroup == null ? new BackgroundDownloader() : new BackgroundDownloader(completionGroup);
-            foreach (var item in requestMessage.Headers)
-            {
-                downloader.SetRequestHeader(item.Key, item.Value.First());
-            }
-
-            return await Task.Run(() => downloader.CreateDownload(requestMessage.RequestUri, destinationFile), cancellationToken);
+            return await Task.Run(
+                async () =>
+                {
+                    var requestMessage = Provider.Drive.Items[oneDriveId].Content.Request().GetHttpRequestMessage();
+                    await Provider.AuthenticationProvider.AuthenticateRequestAsync(requestMessage).AsAsyncAction().AsTask(cancellationToken);
+                    var downloader = completionGroup == null ? new BackgroundDownloader() : new BackgroundDownloader(completionGroup);
+                    foreach (var item in requestMessage.Headers)
+                    {
+                        downloader.SetRequestHeader(item.Key, item.Value.First());
+                    }
+                    return downloader.CreateDownload(requestMessage.RequestUri, destinationFile);
+                }, cancellationToken);
         }
 
     }

--- a/Microsoft.Toolkit.Uwp.Services/Services/OneDrive/OneDriveStorageFile.cs
+++ b/Microsoft.Toolkit.Uwp.Services/Services/OneDrive/OneDriveStorageFile.cs
@@ -19,6 +19,9 @@ using Microsoft.OneDrive.Sdk;
 using Windows.Foundation;
 using Windows.Storage.FileProperties;
 using Windows.Storage.Streams;
+using Windows.Networking.BackgroundTransfer;
+using Windows.Storage;
+using System.Linq;
 
 namespace Microsoft.Toolkit.Uwp.Services.OneDrive
 {
@@ -82,6 +85,31 @@ namespace Microsoft.Toolkit.Uwp.Services.OneDrive
         {
             var renameItem = await base.RenameAsync(desiredName, cancellationToken);
             return InitializeOneDriveStorageFile(renameItem.OneDriveItem);
+        }
+
+        /// <summary>
+        /// Creates a background download for the current file
+        /// </summary>
+        /// <param name="destinationFile">A <see cref="StorageFile"/> to which content will be downloaded</param>
+        /// <param name="completionGroup">The <see cref="BackgroundTransferCompletionGroup"/> to which should <see cref="BackgroundDownloader"/> reffer to</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request</param>
+        /// <returns>The created <see cref="DownloadOperation"/></returns>
+        public async Task<DownloadOperation> CreateBackgroundDownloadAsync(StorageFile destinationFile, BackgroundTransferCompletionGroup completionGroup = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (destinationFile == null)
+            {
+                throw new ArgumentNullException(nameof(destinationFile));
+            }
+
+            var requestMessage = Provider.Drive.Items[OneDriveItem.Id].Content.Request().GetHttpRequestMessage();
+            await Provider.AuthenticationProvider.AuthenticateRequestAsync(requestMessage).AsAsyncAction().AsTask(cancellationToken);
+            var downloader = completionGroup == null ? new BackgroundDownloader() : new BackgroundDownloader(completionGroup);
+            foreach (var item in requestMessage.Headers)
+            {
+                downloader.SetRequestHeader(item.Key, item.Value.First());
+            }
+
+            return await Task.Run(() => downloader.CreateDownload(requestMessage.RequestUri, destinationFile), cancellationToken);
         }
 
         /// <summary>

--- a/Microsoft.Toolkit.Uwp.Services/Services/OneDrive/OneDriveStorageFile.cs
+++ b/Microsoft.Toolkit.Uwp.Services/Services/OneDrive/OneDriveStorageFile.cs
@@ -101,15 +101,18 @@ namespace Microsoft.Toolkit.Uwp.Services.OneDrive
                 throw new ArgumentNullException(nameof(destinationFile));
             }
 
-            var requestMessage = Provider.Drive.Items[OneDriveItem.Id].Content.Request().GetHttpRequestMessage();
-            await Provider.AuthenticationProvider.AuthenticateRequestAsync(requestMessage).AsAsyncAction().AsTask(cancellationToken);
-            var downloader = completionGroup == null ? new BackgroundDownloader() : new BackgroundDownloader(completionGroup);
-            foreach (var item in requestMessage.Headers)
-            {
-                downloader.SetRequestHeader(item.Key, item.Value.First());
-            }
-
-            return await Task.Run(() => downloader.CreateDownload(requestMessage.RequestUri, destinationFile), cancellationToken);
+            return await Task.Run(
+                async () =>
+                {
+                    var requestMessage = Provider.Drive.Items[OneDriveItem.Id].Content.Request().GetHttpRequestMessage();
+                    await Provider.AuthenticationProvider.AuthenticateRequestAsync(requestMessage).AsAsyncAction().AsTask(cancellationToken);
+                    var downloader = completionGroup == null ? new BackgroundDownloader() : new BackgroundDownloader(completionGroup);
+                    foreach (var item in requestMessage.Headers)
+                    {
+                        downloader.SetRequestHeader(item.Key, item.Value.First());
+                    }
+                    return downloader.CreateDownload(requestMessage.RequestUri, destinationFile);
+                }, cancellationToken);
         }
 
         /// <summary>

--- a/Microsoft.Toolkit.Uwp.Services/Services/OneDrive/OneDriveStorageFolder.cs
+++ b/Microsoft.Toolkit.Uwp.Services/Services/OneDrive/OneDriveStorageFolder.cs
@@ -265,8 +265,9 @@ namespace Microsoft.Toolkit.Uwp.Services.OneDrive
         /// </summary>
         /// <param name="startIndex">The zero-based index of the first item in the range to get</param>
         /// <param name="maxItemsToRetrieve">The maximum number of items to get</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>When this method completes successfully, it returns a list of the subfolders and files in the current folder.</returns>
-        public async Task<OneDriveStorageItemsCollection> GetItemsAsync(uint startIndex, uint maxItemsToRetrieve)
+        public async Task<OneDriveStorageItemsCollection> GetItemsAsync(uint startIndex, uint maxItemsToRetrieve, CancellationToken cancellationToken = default(CancellationToken))
         {
             IItemChildrenCollectionRequest oneDriveitemsRequest = null;
             var request = RequestBuilder.Children.Request();
@@ -275,7 +276,7 @@ namespace Microsoft.Toolkit.Uwp.Services.OneDrive
             // oneDriveitemsRequest = request.Top((int)maxItemsToRetrieve).Skip((int)startIndex);
             int maxToRetrieve = (int)(maxItemsToRetrieve + startIndex);
             oneDriveitemsRequest = request.Top(maxToRetrieve);
-            var tempo = await oneDriveitemsRequest.GetAsync().ConfigureAwait(false);
+            var tempo = await oneDriveitemsRequest.GetAsync(cancellationToken).ConfigureAwait(false);
 
             List<OneDriveStorageItem> items = new List<OneDriveStorageItem>();
 


### PR DESCRIPTION
#883 - I've added two methods creating background download - one in *OneDriveStorageFile* and one in *OneDriveService*. I've also added cancellation in method responsible for getting items.

@EricVernie The *GetItemsAsync(...)* method of *OneDriveStorageFolder* allows to download up to 1000 items, due to SDK limit, otherwise it will throw exception. Another problem is that the request doesn't accept *Skip()*. In that case if you start with index 2 and want to download 1000 items - it will also throw exception. Do you have any ideas for that?