### PR TITLE
Update to CompositionSurfaceFactory 0.7.1 and fix SurfaceFactory usag…

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/TileControl/TileControl.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/TileControl/TileControl.cs
@@ -441,16 +441,15 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 if (strategy == UIStrategy.Composition)
                 {
                     var compositor = _containerVisual.Compositor;
+                    
+                    var surfaceFactory = SurfaceFactory.GetSharedSurfaceFactoryForCompositor(compositor);
 
-                    using (var surfaceFactory = SurfaceFactory.GetSharedSurfaceFactoryForCompositor(compositor))
-                    {
-                        var surfaceUri = await surfaceFactory.CreateUriSurfaceAsync(uri);
+                    var surfaceUri = await surfaceFactory.CreateUriSurfaceAsync(uri);
 
-                        _uriSurface = surfaceUri;
-                        _brushVisual = compositor.CreateSurfaceBrush(surfaceUri.Surface);
+                    _uriSurface = surfaceUri;
+                    _brushVisual = compositor.CreateSurfaceBrush(surfaceUri.Surface);
 
-                        _imageSize = surfaceUri.Size;
-                    }
+                    _imageSize = surfaceUri.Size;
                 }
                 else
                 {

--- a/Microsoft.Toolkit.Uwp.UI.Controls/project.json
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/project.json
@@ -1,7 +1,7 @@
 ﻿{
   "dependencies": {
     "Microsoft.NETCore.UniversalWindowsPlatform": "5.1.0",
-    "Robmikh.CompositionSurfaceFactory": "0.7.0-alpha",
+    "Robmikh.CompositionSurfaceFactory": "0.7.1",
     "StyleCop.Analyzers": "1.0.0"
   },
   "frameworks": {


### PR DESCRIPTION
This was submitted as discussed with @deltakosh.

The dependency on CompositionSurfaceFactory is updated to 0.7.1 from the prerelease version. Additionally, TileControl was fixed to properly consume SurfaceFactory. 

The issue is that the SurfaceFactory object needs to be alive in order to regenerate surfaces it creates. Otherwise there is no one to observe when the graphics device is lost, which would leave all Composition surfaces empty. Also, because the SurfaceFactory was shared, it shouldn't be disposed by anyone other than the application author, or consumers of the toolkit might find their surfaces suddenly parent-less and empty in the event of losing the graphics device.