### PR TITLE
for Onedrive consumer, support OrderBy descending size, and ascending…

### DIFF
--- a/Microsoft.Toolkit.Uwp.Services/Services/OneDrive/OneDriveEnums.cs
+++ b/Microsoft.Toolkit.Uwp.Services/Services/OneDrive/OneDriveEnums.cs
@@ -49,14 +49,49 @@ namespace Microsoft.Toolkit.Uwp.Services.OneDrive
             None,
 
             /// <summary>
-            /// Use the name to order the items
+            /// Use the name to order the items with "A" first
             /// </summary>
             Name,
 
             /// <summary>
-            /// Use the size to order the items
+            /// Use the name to order the items, with "A" first, new form
+            /// </summary>
+            NameAsc = Name,
+
+            /// <summary>
+            /// Use the name to order the items, with "Z" first
+            /// </summary>
+            NameDesc,
+
+            /// <summary>
+            /// Use the size to order the items, with the smallest first
             /// </summary>
             Size,
+
+            /// <summary>
+            /// Use the size to order the items, with the smallest first, new form
+            /// </summary>
+            SizeAsc = Size,
+
+            /// <summary>
+            /// Use the size to order the items, with the largest first
+            /// </summary>
+            SizeDesc,
+
+            /// <summary>
+            /// Use the date to order the items, with the oldest first
+            /// </summary>
+            Date,
+
+            /// <summary>
+            /// Use the date to order the items, with the oldest first, new form
+            /// </summary>
+            DateAsc = Date,
+
+            /// <summary>
+            /// Use the date to order the items, with the newest first
+            /// </summary>
+            DateDesc
         }
 
         /// <summary>

--- a/Microsoft.Toolkit.Uwp.Services/Services/OneDrive/OneDriveHelper.cs
+++ b/Microsoft.Toolkit.Uwp.Services/Services/OneDrive/OneDriveHelper.cs
@@ -11,6 +11,7 @@
 // ******************************************************************
 
 using System.Text;
+using static Microsoft.Toolkit.Uwp.Services.OneDrive.OneDriveEnums;
 
 namespace Microsoft.Toolkit.Uwp.Services.OneDrive
 {
@@ -73,6 +74,32 @@ namespace Microsoft.Toolkit.Uwp.Services.OneDrive
             }
 
             return sb.ToString().Split(',');
+        }
+
+        /// <summary>
+        /// Transform Orderby enum into the orderby string
+        /// </summary>
+        /// <param name="order">orderby enum</param>
+        /// <returns>a string array containing the OneDrive Order by string</returns>
+        public static string TransformOrderByToODataString(OrderBy order)
+        {
+            switch (order)
+            {
+                case OrderBy.Name:
+                    return "name asc";
+                case OrderBy.NameDesc:
+                    return "name desc";
+                case OrderBy.Size:
+                    return "size asc";
+                case OrderBy.SizeDesc:
+                    return "size desc";
+                case OrderBy.Date:
+                    return "lastModifiedDateTime asc";
+                case OrderBy.DateDesc:
+                    return "lastModifiedDateTime desc";
+            }
+
+            return string.Empty;
         }
     }
 }

--- a/Microsoft.Toolkit.Uwp.Services/Services/OneDrive/OneDriveItemExtension.cs
+++ b/Microsoft.Toolkit.Uwp.Services/Services/OneDrive/OneDriveItemExtension.cs
@@ -165,7 +165,7 @@ namespace Microsoft.Toolkit.Uwp.Services.OneDrive
                 return requestBuilder.Children.Request().Top(top).Filter(filter);
             }
 
-            string order = $"{orderBy} asc".ToLower();
+            string order = OneDriveHelper.TransformOrderByToODataString(orderBy);
 
             if (string.IsNullOrEmpty(filter))
             {


### PR DESCRIPTION
I noted that the toolkit was missing functionality that is pretty basic when comparing a raft of files, and doing the cleanup app I was building.

for Onedrive consumer, support OrderBy descending size, and ascending…
… and descending date....els

Note that this won't work for OneDrive for Bus, but neither will size, so this would seem to be a useful change.

Suggested here: https://dev.onedrive.com/odata/optional-query-parameters.htm