### PR TITLE
Only show back button when changing from collapsed details view

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.cs
@@ -102,7 +102,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
             if (view._stateGroup != null)
             {
-                view.SetBackButtonVisibility(view._stateGroup.CurrentState);
+                view.SetBackButtonVisibility();
             }
         }
 
@@ -143,7 +143,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             _narrowState = GetTemplateChild(NarrowState) as VisualState;
 
             SetVisualState(_stateGroup.CurrentState, true);
-            SetBackButtonVisibility(_stateGroup.CurrentState);
+            SetBackButtonVisibility();
 
             UpdateViewState();
         }
@@ -171,7 +171,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// </remarks>
         private void OnVisualStateChanged(object sender, VisualStateChangedEventArgs e)
         {
-            SetBackButtonVisibility(e.NewState);
+            SetBackButtonVisibility();
 
             // When adaptive trigger changes state, switch between NoSelectionWide and NoSelectionNarrow.
             SetVisualState(e.NewState, false);
@@ -219,7 +219,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// <summary>
         /// Sets the back button visibility based on the current visual state and selected item
         /// </summary>
-        private void SetBackButtonVisibility(VisualState currentState)
+        private void SetBackButtonVisibility()
         {
             UpdateViewState();
             if (DesignMode.DesignModeEnabled)

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.cs
@@ -45,6 +45,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         private const string NoSelectionNarrowState = "NoSelectionNarrow";
         private const string NoSelectionWideState = "NoSelectionWide";
 
+        private AppViewBackButtonVisibility _previousBackButtonVisibility;
         private ContentPresenter _detailsPresenter;
         private VisualStateGroup _stateGroup;
         private VisualState _narrowState;
@@ -74,6 +75,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             SetDetailsContent();
 
             SetMasterHeaderVisibility();
+
+            if (DesignMode.DesignModeEnabled == false)
+            {
+                _previousBackButtonVisibility = SystemNavigationManager.GetForCurrentView().AppViewBackButtonVisibility;
+            }
         }
 
         /// <summary>
@@ -232,11 +238,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             else if (previousState == MasterDetailsViewState.Details)
             {
                 // Make sure we show the back button if the stack can navigate back
-                var frame = GetFrame();
-                SystemNavigationManager.GetForCurrentView().AppViewBackButtonVisibility =
-                    ((frame != null) && frame.CanGoBack)
-                        ? AppViewBackButtonVisibility.Visible
-                        : AppViewBackButtonVisibility.Collapsed;
+                SystemNavigationManager.GetForCurrentView().AppViewBackButtonVisibility = _previousBackButtonVisibility;
             }
         }
 

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.cs
@@ -205,8 +205,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
         private void UpdateView(bool animate)
         {
+            var currentState = ViewState;
             UpdateViewState();
-            SetBackButtonVisibility();
+            SetBackButtonVisibility(currentState);
             if (_stateGroup != null)
             {
                 SetVisualState(_stateGroup.CurrentState, animate);
@@ -216,7 +217,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// <summary>
         /// Sets the back button visibility based on the current visual state and selected item
         /// </summary>
-        private void SetBackButtonVisibility()
+        private void SetBackButtonVisibility(MasterDetailsViewState previousState)
         {
             if (DesignMode.DesignModeEnabled)
             {
@@ -228,7 +229,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 SystemNavigationManager.GetForCurrentView().AppViewBackButtonVisibility =
                     AppViewBackButtonVisibility.Visible;
             }
-            else
+            else if (previousState == MasterDetailsViewState.Details)
             {
                 // Make sure we show the back button if the stack can navigate back
                 var frame = GetFrame();

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.cs
@@ -87,22 +87,15 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         private static void OnSelectedItemChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             var view = (MasterDetailsView)d;
-            if (view._stateGroup != null)
-            {
-                view.SetVisualState(view._stateGroup.CurrentState, true);
-            }
 
             view.OnSelectionChanged(new SelectionChangedEventArgs(new List<object> { e.OldValue }, new List<object> { e.NewValue }));
+
+            view.UpdateView(true);
 
             // If there is no selection, do not remove the DetailsPresenter content but let it animate out.
             if (view.SelectedItem != null)
             {
                 view.SetDetailsContent();
-            }
-
-            if (view._stateGroup != null)
-            {
-                view.SetBackButtonVisibility();
             }
         }
 
@@ -142,10 +135,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
             _narrowState = GetTemplateChild(NarrowState) as VisualState;
 
-            SetVisualState(_stateGroup.CurrentState, true);
-            SetBackButtonVisibility();
-
-            UpdateViewState();
+            UpdateView(true);
         }
 
         private void OnUnloaded(object sender, RoutedEventArgs e)
@@ -171,10 +161,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// </remarks>
         private void OnVisualStateChanged(object sender, VisualStateChangedEventArgs e)
         {
-            SetBackButtonVisibility();
-
-            // When adaptive trigger changes state, switch between NoSelectionWide and NoSelectionNarrow.
-            SetVisualState(e.NewState, false);
+            UpdateView(false);
         }
 
         /// <summary>
@@ -216,12 +203,21 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             }
         }
 
+        private void UpdateView(bool animate)
+        {
+            UpdateViewState();
+            SetBackButtonVisibility();
+            if (_stateGroup != null)
+            {
+                SetVisualState(_stateGroup.CurrentState, animate);
+            }
+        }
+
         /// <summary>
         /// Sets the back button visibility based on the current visual state and selected item
         /// </summary>
         private void SetBackButtonVisibility()
         {
-            UpdateViewState();
             if (DesignMode.DesignModeEnabled)
             {
                 return;
@@ -250,6 +246,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
         private void UpdateViewState()
         {
+            if (_stateGroup == null)
+            {
+                return;
+            }
+
             var before = ViewState;
 
             if (_stateGroup.CurrentState == _narrowState || _stateGroup.CurrentState == null)

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.cs
@@ -75,11 +75,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             SetDetailsContent();
 
             SetMasterHeaderVisibility();
-
-            if (DesignMode.DesignModeEnabled == false)
-            {
-                _previousBackButtonVisibility = SystemNavigationManager.GetForCurrentView().AppViewBackButtonVisibility;
-            }
         }
 
         /// <summary>
@@ -232,8 +227,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
             if (ViewState == MasterDetailsViewState.Details)
             {
-                SystemNavigationManager.GetForCurrentView().AppViewBackButtonVisibility =
-                    AppViewBackButtonVisibility.Visible;
+                var navigationManager = SystemNavigationManager.GetForCurrentView();
+                _previousBackButtonVisibility = navigationManager.AppViewBackButtonVisibility;
+
+                navigationManager.AppViewBackButtonVisibility = AppViewBackButtonVisibility.Visible;
             }
             else if (previousState == MasterDetailsViewState.Details)
             {


### PR DESCRIPTION
Changes to when the MasterDetailsView updates the back button visibility. It will now only update the visibility if in the ViewState is MasterDetailsViewState.Details, or if it is changing from MasterDetailsViewState.Details. 
The control also will keep track if the back button was visible before it changes it when going into the Details state. If the MasterDetailsView is going from MasterDetailsViewState.Details, it will set the back button visibility to whatever is was previously. 

Fixes ##939 and possibly #906. Tested #906 after fixing this and I cannot reproduce
