### PR TITLE
Add TranslatorServiceException and better documentation

### DIFF
--- a/Microsoft.Toolkit.Uwp.Services/Microsoft.Toolkit.Uwp.Services.csproj
+++ b/Microsoft.Toolkit.Uwp.Services/Microsoft.Toolkit.Uwp.Services.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -89,6 +89,8 @@
     <Compile Include="Services\Facebook\FacebookPhoto.cs" />
     <Compile Include="Services\Facebook\FacebookPictureData.cs" />
     <Compile Include="Services\Facebook\FacebookPlatformImageSource.cs" />
+    <Compile Include="Services\MicrosoftTranslator\ErrorResponse.cs" />
+    <Compile Include="Services\MicrosoftTranslator\TranslatorServiceException.cs" />
     <Compile Include="Services\OneDrive\DiscoverySettings.cs" />
     <Compile Include="Services\OneDrive\OneDriveAuthenticationHelper.cs" />
     <Compile Include="Services\OneDrive\OneDriveConflictItem.cs" />

--- a/Microsoft.Toolkit.Uwp.Services/Services/MicrosoftTranslator/AzureAuthToken.cs
+++ b/Microsoft.Toolkit.Uwp.Services/Services/MicrosoftTranslator/AzureAuthToken.cs
@@ -12,6 +12,7 @@
 
 using System;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
 using Windows.Web.Http;
 
 namespace Microsoft.Toolkit.Uwp.Services.MicrosoftTranslator
@@ -33,9 +34,9 @@ namespace Microsoft.Toolkit.Uwp.Services.MicrosoftTranslator
 
         /// <summary>
         /// After obtaining a valid token, this class will cache it for this duration.
-        /// Use a duration of 5 minutes, which is less than the actual token lifetime of 10 minutes.
+        /// Use a duration of 8 minutes, which is less than the actual token lifetime of 10 minutes.
         /// </summary>
-        private static readonly TimeSpan TokenCacheDuration = new TimeSpan(0, 5, 0);
+        private static readonly TimeSpan TokenCacheDuration = new TimeSpan(0, 8, 0);
 
         private string _storedTokenValue = string.Empty;
         private DateTime _storedTokenTime = DateTime.MinValue;
@@ -79,14 +80,14 @@ namespace Microsoft.Toolkit.Uwp.Services.MicrosoftTranslator
         /// This method uses a cache to limit the number of request to the token service.
         /// A fresh token can be re-used during its lifetime of 10 minutes. After a successful
         /// request to the token service, this method caches the access token. Subsequent
-        /// invocations of the method return the cached token for the next 5 minutes. After
-        /// 5 minutes, a new token is fetched from the token service and the cache is updated.
+        /// invocations of the method return the cached token for the next 8 minutes. After
+        /// 8 minutes, a new token is fetched from the token service and the cache is updated.
         /// </remarks>
         public async Task<string> GetAccessTokenAsync()
         {
-            if (string.IsNullOrEmpty(SubscriptionKey))
+            if (string.IsNullOrEmpty(_subscriptionKey))
             {
-                throw new ArgumentNullException(nameof(SubscriptionKey), "A subscription key is required");
+                throw new ArgumentNullException(nameof(SubscriptionKey), "A subscription key is required. Go to Azure Portal and sign up for Microsoft Translator: https://portal.azure.com/#create/Microsoft.CognitiveServices/apitype/TextTranslation");
             }
 
             // Re-use the cached token if there is one.
@@ -100,10 +101,16 @@ namespace Microsoft.Toolkit.Uwp.Services.MicrosoftTranslator
                 request.Headers.Add(OcpApimSubscriptionKeyHeader, SubscriptionKey);
 
                 var response = await HttpHelper.Instance.SendRequestAsync(request).ConfigureAwait(false);
-                var token = await response.GetTextResultAsync().ConfigureAwait(false);
+                var content = await response.GetTextResultAsync().ConfigureAwait(false);
+
+                if (!response.Success)
+                {
+                    var error = JsonConvert.DeserializeObject<ErrorResponse>(content);
+                    throw new TranslatorServiceException(error.Message);
+                }
 
                 _storedTokenTime = DateTime.Now;
-                _storedTokenValue = $"Bearer {token}";
+                _storedTokenValue = $"Bearer {content}";
 
                 return _storedTokenValue;
             }

--- a/Microsoft.Toolkit.Uwp.Services/Services/MicrosoftTranslator/ErrorResponse.cs
+++ b/Microsoft.Toolkit.Uwp.Services/Services/MicrosoftTranslator/ErrorResponse.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Toolkit.Uwp.Services.MicrosoftTranslator
+{
+    /// <summary>
+    /// Holds information about an error occurred while accessing Microsoft Translator Service.
+    /// </summary>
+    internal class ErrorResponse
+    {
+        /// <summary>
+        /// Gets or sets the error message.
+        /// </summary>
+        public string Message { get; set; }
+
+        /// <summary>
+        /// Gets or sets the HTTP status code.
+        /// </summary>
+        public int StatusCode { get; set; }
+    }
+}

--- a/Microsoft.Toolkit.Uwp.Services/Services/MicrosoftTranslator/ErrorResponse.cs
+++ b/Microsoft.Toolkit.Uwp.Services/Services/MicrosoftTranslator/ErrorResponse.cs
@@ -1,8 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿// ******************************************************************
+// Copyright (c) Microsoft. All rights reserved.
+// This code is licensed under the MIT License (MIT).
+// THE CODE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH
+// THE CODE OR THE USE OR OTHER DEALINGS IN THE CODE.
+// ******************************************************************
 
 namespace Microsoft.Toolkit.Uwp.Services.MicrosoftTranslator
 {

--- a/Microsoft.Toolkit.Uwp.Services/Services/MicrosoftTranslator/ITranslatorService.cs
+++ b/Microsoft.Toolkit.Uwp.Services/Services/MicrosoftTranslator/ITranslatorService.cs
@@ -31,9 +31,9 @@ namespace Microsoft.Toolkit.Uwp.Services.MicrosoftTranslator
         string SubscriptionKey { get; set; }
 
         /// <summary>
-        /// Gets or sets the string representing the supported language code to speak the text in.
+        /// Gets or sets the string representing the supported language code to translate the text in.
         /// </summary>
-        /// <value>The string representing the supported language code to speak the text in. The code must be present in the list of codes returned from the method <see cref="GetLanguagesAsync"/>.</value>
+        /// <value>The string representing the supported language code to translate the text in. The code must be present in the list of codes returned from the method <see cref="GetLanguagesAsync"/>.</value>
         /// <seealso cref="GetLanguagesAsync"/>
         string Language { get; set; }
 
@@ -42,14 +42,14 @@ namespace Microsoft.Toolkit.Uwp.Services.MicrosoftTranslator
         /// </summary>
         /// <param name="text">A string represeting the text whose language must be detected.</param>
         /// <returns>A string containing a two-character Language code for the given text.</returns>
-        /// <exception cref="ArgumentException">
+        /// <exception cref="ArgumentNullException">
         /// <list type="bullet">
         /// <term>The <see cref="SubscriptionKey"/> property hasn't been set.</term>
-        /// <term>The <paramref name="text"/> parameter is longer than 1000 characters.</term>
+        /// <term>The <paramref name="text"/> parameter is <strong>null</strong> (<strong>Nothing</strong> in Visual Basic) or empty.</term>
         /// </list>
         /// </exception>
-        /// <exception cref="ArgumentNullException">The <paramref name="text"/> parameter is <strong>null</strong> (<strong>Nothing</strong> in Visual Basic) or empty.</exception>
-        /// <remarks><para>This method perform a non-blocking request for language code.</para>
+        /// <exception cref="TranslatorServiceException">The provided <see cref="SubscriptionKey"/> isn't valid or has expired.</exception>
+        /// <remarks><para>This method performs a non-blocking request for language detection.</para>
         /// <para>For more information, go to http://msdn.microsoft.com/en-us/library/ff512427.aspx.
         /// </para></remarks>
         /// <seealso cref="GetLanguagesAsync"/>
@@ -57,11 +57,12 @@ namespace Microsoft.Toolkit.Uwp.Services.MicrosoftTranslator
         Task<string> DetectLanguageAsync(string text);
 
         /// <summary>
-        /// Retrieves the languages available for speech synthesis.
+        /// Retrieves the languages available for translation.
         /// </summary>
-        /// <returns>A string array containing the language codes supported for speech synthesis by <strong>Microsoft Translator Service</strong>.</returns>
-        /// <exception cref="ArgumentException">The <see cref="SubscriptionKey"/> property hasn't been set.</exception>
-        /// <remarks><para>This method performs a non-blocking request.</para>
+        /// <returns>A string array containing the language codes supported for translation by <strong>Microsoft Translator Service</strong>.</returns>
+        /// <exception cref="ArgumentNullException">The <see cref="SubscriptionKey"/> property hasn't been set.</exception>
+        /// <exception cref="TranslatorServiceException">The provided <see cref="SubscriptionKey"/> isn't valid or has expired.</exception>
+        /// <remarks><para>This method performs a non-blocking request for language codes.</para>
         /// <para>For more information, go to http://msdn.microsoft.com/en-us/library/ff512415.aspx.
         /// </para>
         /// </remarks>
@@ -71,6 +72,8 @@ namespace Microsoft.Toolkit.Uwp.Services.MicrosoftTranslator
         /// Initializes the <see cref="TranslatorService"/> class by getting an access token for the service.
         /// </summary>
         /// <returns>A <see cref="Task"/> that represents the initialize operation.</returns>
+        /// <exception cref="ArgumentNullException">The <see cref="SubscriptionKey"/> property hasn't been set.</exception>
+        /// <exception cref="TranslatorServiceException">The provided <see cref="SubscriptionKey"/> isn't valid or has expired.</exception>
         /// <remarks>Calling this method isn't mandatory, because the token is get/refreshed everytime is needed. However, it is called at startup, it can speed-up subsequest requests.</remarks>
         Task InitializeAsync();
 
@@ -81,14 +84,15 @@ namespace Microsoft.Toolkit.Uwp.Services.MicrosoftTranslator
         /// <param name="text">A string representing the text to translate.</param>
         /// <param name="from">A string representing the language code of the original text. The code must be present in the list of codes returned from the <see cref="GetLanguagesAsync"/> method. If the parameter is set to <strong>null</strong>, the language specified in the <seealso cref="Language"/> property will be used.</param>
         /// <param name="to">A string representing the language code to translate the text into. The code must be present in the list of codes returned from the <see cref="GetLanguagesAsync"/> method. If the parameter is set to <strong>null</strong>, the language specified in the <seealso cref="Language"/> property will be used.</param>
-        /// <exception cref="ArgumentException">
+        /// <exception cref="ArgumentNullException">
         /// <list type="bullet">
         /// <term>The <see cref="SubscriptionKey"/> property hasn't been set.</term>
-        /// <term>The <paramref name="text"/> parameter is longer than 1000 characters.</term>
+        /// <term>The <paramref name="text"/> parameter is <strong>null</strong> (<strong>Nothing</strong> in Visual Basic) or empty.</term>
         /// </list>
         /// </exception>
-        /// <exception cref="ArgumentNullException">The <paramref name="text"/> parameter is <strong>null</strong> (<strong>Nothing</strong> in Visual Basic) or empty.</exception>
-        /// <remarks><para>This method perform a non-blocking request for translation.</para>
+        /// <exception cref="ArgumentException">The <paramref name="text"/> parameter is longer than 1000 characters.</exception>
+        /// <exception cref="TranslatorServiceException">The provided <see cref="SubscriptionKey"/> isn't valid or has expired.</exception>
+        /// <remarks><para>This method perform a non-blocking request for text translation.</para>
         /// <para>For more information, go to http://msdn.microsoft.com/en-us/library/ff512421.aspx.
         /// </para>
         /// </remarks>
@@ -101,14 +105,15 @@ namespace Microsoft.Toolkit.Uwp.Services.MicrosoftTranslator
         /// <returns>A string representing the translated text.</returns>
         /// <param name="text">A string representing the text to translate.</param>
         /// <param name="to">A string representing the language code to translate the text into. The code must be present in the list of codes returned from the <see cref="GetLanguagesAsync"/> method. If the parameter is set to <strong>null</strong>, the language specified in the <seealso cref="Language"/> property will be used.</param>
-        /// <exception cref="ArgumentException">
+        /// <exception cref="ArgumentNullException">
         /// <list type="bullet">
         /// <term>The <see cref="SubscriptionKey"/> property hasn't been set.</term>
-        /// <term>The <paramref name="text"/> parameter is longer than 1000 characters.</term>
+        /// <term>The <paramref name="text"/> parameter is <strong>null</strong> (<strong>Nothing</strong> in Visual Basic) or empty.</term>
         /// </list>
         /// </exception>
-        /// <exception cref="ArgumentNullException">The <paramref name="text"/> parameter is <strong>null</strong> (<strong>Nothing</strong> in Visual Basic) or empty.</exception>
-        /// <remarks><para>This method perform a non-blocking request for translation.</para>
+        /// <exception cref="ArgumentException">The <paramref name="text"/> parameter is longer than 1000 characters.</exception>
+        /// <exception cref="TranslatorServiceException">The provided <see cref="SubscriptionKey"/> isn't valid or has expired.</exception>
+        /// <remarks><para>This method perform a non-blocking request for text translation.</para>
         /// <para>For more information, go to http://msdn.microsoft.com/en-us/library/ff512421.aspx.
         /// </para>
         /// </remarks>

--- a/Microsoft.Toolkit.Uwp.Services/Services/MicrosoftTranslator/TranslatorService.cs
+++ b/Microsoft.Toolkit.Uwp.Services/Services/MicrosoftTranslator/TranslatorService.cs
@@ -20,7 +20,7 @@ using System.Xml.Linq;
 namespace Microsoft.Toolkit.Uwp.Services.MicrosoftTranslator
 {
     /// <summary>
-    /// The <strong>TranslatorServiceClass</strong> class provides methods to translate text in various supported languages.
+    /// The <strong>TranslatorService</strong> class provides methods to translate text in various supported languages.
     /// </summary>
     /// <remarks>
     /// <para>To use this library, you must register Microsoft Translator on https://portal.azure.com/#create/Microsoft.CognitiveServices/apitype/TextTranslation to obtain the Subscription key.
@@ -80,18 +80,19 @@ namespace Microsoft.Toolkit.Uwp.Services.MicrosoftTranslator
         }
 
         /// <summary>
-        /// Gets or sets the string representing the supported language code to speak the text in.
+        /// Gets or sets the string representing the supported language code to translate the text in.
         /// </summary>
-        /// <value>The string representing the supported language code to speak the text in. The code must be present in the list of codes returned from the method <see cref="GetLanguagesAsync"/>.</value>
+        /// <value>The string representing the supported language code to translate the text in. The code must be present in the list of codes returned from the method <see cref="GetLanguagesAsync"/>.</value>
         /// <seealso cref="GetLanguagesAsync"/>
         public string Language { get; set; }
 
         /// <summary>
-        /// Retrieves the languages available for speech synthesis.
+        /// Retrieves the languages available for translation.
         /// </summary>
-        /// <returns>A string array containing the language codes supported for speech synthesis by <strong>Microsoft Translator Service</strong>.</returns>
-        /// <exception cref="ArgumentException">The <see cref="SubscriptionKey"/> property hasn't been set.</exception>
-        /// <remarks><para>This method performs a non-blocking request.</para>
+        /// <returns>A string array containing the language codes supported for translation by <strong>Microsoft Translator Service</strong>.</returns>
+        /// <exception cref="ArgumentNullException">The <see cref="SubscriptionKey"/> property hasn't been set.</exception>
+        /// <exception cref="TranslatorServiceException">The provided <see cref="SubscriptionKey"/> isn't valid or has expired.</exception>
+        /// <remarks><para>This method performs a non-blocking request for language codes.</para>
         /// <para>For more information, go to http://msdn.microsoft.com/en-us/library/ff512415.aspx.
         /// </para>
         /// </remarks>
@@ -120,14 +121,15 @@ namespace Microsoft.Toolkit.Uwp.Services.MicrosoftTranslator
         /// <param name="text">A string representing the text to translate.</param>
         /// <param name="from">A string representing the language code of the original text. The code must be present in the list of codes returned from the <see cref="GetLanguagesAsync"/> method. If the parameter is set to <strong>null</strong>, the language specified in the <seealso cref="Language"/> property will be used.</param>
         /// <param name="to">A string representing the language code to translate the text into. The code must be present in the list of codes returned from the <see cref="GetLanguagesAsync"/> method. If the parameter is set to <strong>null</strong>, the language specified in the <seealso cref="Language"/> property will be used.</param>
-        /// <exception cref="ArgumentException">
+        /// <exception cref="ArgumentNullException">
         /// <list type="bullet">
         /// <term>The <see cref="SubscriptionKey"/> property hasn't been set.</term>
-        /// <term>The <paramref name="text"/> parameter is longer than 1000 characters.</term>
+        /// <term>The <paramref name="text"/> parameter is <strong>null</strong> (<strong>Nothing</strong> in Visual Basic) or empty.</term>
         /// </list>
         /// </exception>
-        /// <exception cref="ArgumentNullException">The <paramref name="text"/> parameter is <strong>null</strong> (<strong>Nothing</strong> in Visual Basic) or empty.</exception>
-        /// <remarks><para>This method perform a non-blocking request for translation.</para>
+        /// <exception cref="ArgumentException">The <paramref name="text"/> parameter is longer than 1000 characters.</exception>
+        /// <exception cref="TranslatorServiceException">The provided <see cref="SubscriptionKey"/> isn't valid or has expired.</exception>
+        /// <remarks><para>This method perform a non-blocking request for text translation.</para>
         /// <para>For more information, go to http://msdn.microsoft.com/en-us/library/ff512421.aspx.
         /// </para>
         /// </remarks>
@@ -180,14 +182,15 @@ namespace Microsoft.Toolkit.Uwp.Services.MicrosoftTranslator
         /// <returns>A string representing the translated text.</returns>
         /// <param name="text">A string representing the text to translate.</param>
         /// <param name="to">A string representing the language code to translate the text into. The code must be present in the list of codes returned from the <see cref="GetLanguagesAsync"/> method. If the parameter is set to <strong>null</strong>, the language specified in the <seealso cref="Language"/> property will be used.</param>
-        /// <exception cref="ArgumentException">
+        /// <exception cref="ArgumentNullException">
         /// <list type="bullet">
         /// <term>The <see cref="SubscriptionKey"/> property hasn't been set.</term>
-        /// <term>The <paramref name="text"/> parameter is longer than 1000 characters.</term>
+        /// <term>The <paramref name="text"/> parameter is <strong>null</strong> (<strong>Nothing</strong> in Visual Basic) or empty.</term>
         /// </list>
         /// </exception>
-        /// <exception cref="ArgumentNullException">The <paramref name="text"/> parameter is <strong>null</strong> (<strong>Nothing</strong> in Visual Basic) or empty.</exception>
-        /// <remarks><para>This method perform a non-blocking request for translation.</para>
+        /// <exception cref="ArgumentException">The <paramref name="text"/> parameter is longer than 1000 characters.</exception>
+        /// <exception cref="TranslatorServiceException">The provided <see cref="SubscriptionKey"/> isn't valid or has expired.</exception>
+        /// <remarks><para>This method perform a non-blocking request for text translation.</para>
         /// <para>For more information, go to http://msdn.microsoft.com/en-us/library/ff512421.aspx.
         /// </para>
         /// </remarks>
@@ -199,18 +202,17 @@ namespace Microsoft.Toolkit.Uwp.Services.MicrosoftTranslator
         /// </summary>
         /// <param name="text">A string represeting the text whose language must be detected.</param>
         /// <returns>A string containing a two-character Language code for the given text.</returns>
-        /// <exception cref="ArgumentException">
+        /// <exception cref="ArgumentNullException">
         /// <list type="bullet">
         /// <term>The <see cref="SubscriptionKey"/> property hasn't been set.</term>
-        /// <term>The <paramref name="text"/> parameter is longer than 1000 characters.</term>
+        /// <term>The <paramref name="text"/> parameter is <strong>null</strong> (<strong>Nothing</strong> in Visual Basic) or empty.</term>
         /// </list>
         /// </exception>
-        /// <exception cref="ArgumentNullException">The <paramref name="text"/> parameter is <strong>null</strong> (<strong>Nothing</strong> in Visual Basic) or empty.</exception>
-        /// <remarks><para>This method perform a non-blocking request for language code.</para>
+        /// <exception cref="TranslatorServiceException">The provided <see cref="SubscriptionKey"/> isn't valid or has expired.</exception>
+        /// <remarks><para>This method performs a non-blocking request for language detection.</para>
         /// <para>For more information, go to http://msdn.microsoft.com/en-us/library/ff512427.aspx.
         /// </para></remarks>
         /// <seealso cref="GetLanguagesAsync"/>
-        /// <seealso cref="Language"/>
         public async Task<string> DetectLanguageAsync(string text)
         {
             if (string.IsNullOrWhiteSpace(text))
@@ -241,7 +243,12 @@ namespace Microsoft.Toolkit.Uwp.Services.MicrosoftTranslator
         /// Initializes the <see cref="TranslatorService"/> class by getting an access token for the service.
         /// </summary>
         /// <returns>A <see cref="Task"/> that represents the initialize operation.</returns>
-        /// <remarks>Calling this method isn't mandatory, because the token is get/refreshed everytime is needed. However, it is called at startup, it can speed-up subsequest requests.</remarks>
+        /// <exception cref="ArgumentNullException">The <see cref="SubscriptionKey"/> property hasn't been set.</exception>
+        /// <exception cref="TranslatorServiceException">The provided <see cref="SubscriptionKey"/> isn't valid or has expired.</exception>
+        /// <remarks>
+        /// <para>Calling this method isn't mandatory, because the token is get/refreshed everytime is needed. However, it is called at startup, it can speed-up subsequest requests.</para>
+        /// <para>You must register Microsoft Translator on https://portal.azure.com to obtain the Subscription key needed to use the service.</para>
+        /// </remarks>
         public Task InitializeAsync() => CheckUpdateTokenAsync();
 
         /// <summary>
@@ -250,39 +257,36 @@ namespace Microsoft.Toolkit.Uwp.Services.MicrosoftTranslator
         /// <param name="subscriptionKey">The subscription key for the Microsoft Translator Service on Azure.</param>
         /// <param name="language">A string representing the supported language code to speak the text in. The code must be present in the list of codes returned from the method <see cref="GetLanguagesAsync"/>.</param>
         /// <returns>A <see cref="Task"/> that represents the initialize operation.</returns>
+        /// <exception cref="ArgumentNullException">The <see cref="SubscriptionKey"/> property hasn't been set.</exception>
+        /// <exception cref="TranslatorServiceException">The provided <see cref="SubscriptionKey"/> isn't valid or has expired.</exception>
         /// <remarks>
+        /// <para>Calling this method isn't mandatory, because the token is get/refreshed everytime is needed. However, it is called at startup, it can speed-up subsequest requests.</para>
         /// <para>You must register Microsoft Translator on https://portal.azure.com to obtain the Subscription key needed to use the service.</para>
         /// </remarks>
         public Task InitializeAsync(string subscriptionKey, string language)
         {
             _authToken = new AzureAuthToken(subscriptionKey);
 
-            SubscriptionKey = subscriptionKey;
             Language = language;
 
             return InitializeAsync();
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="TranslatorService"/> class, using the specified Client ID and Client Secret and the current system language.
+        /// Initializes a new instance of the <see cref="TranslatorService"/> class by getting an access token for the service.
         /// </summary>
         /// <param name="subscriptionKey">The subscription key for the Microsoft Translator Service on Azure.</param>
         /// <returns>A <see cref="Task"/> that represents the initialize operation.</returns>
+        /// <exception cref="ArgumentNullException">The <see cref="SubscriptionKey"/> property hasn't been set.</exception>
+        /// <exception cref="TranslatorServiceException">The provided <see cref="SubscriptionKey"/> isn't valid or has expired.</exception>
         /// <remarks>
+        /// <para>Calling this method isn't mandatory, because the token is get/refreshed everytime is needed. However, it is called at startup, it can speed-up subsequest requests.</para>
         /// <para>You must register Microsoft Translator on https://portal.azure.com to obtain the Subscription key needed to use the service.</para>
         /// </remarks>
-        public Task InitializeAsync(string subscriptionKey = null)
-        {
-            return InitializeAsync(subscriptionKey, CultureInfo.CurrentCulture.Name.ToLower());
-        }
+        public Task InitializeAsync(string subscriptionKey) => InitializeAsync(subscriptionKey, CultureInfo.CurrentCulture.Name.ToLower());
 
         private async Task CheckUpdateTokenAsync()
         {
-            if (string.IsNullOrWhiteSpace(SubscriptionKey))
-            {
-                throw new ArgumentException("Invalid Subscription Key. Go to Azure Portal and sign up for Microsoft Translator: https://portal.azure.com/#create/Microsoft.CognitiveServices/apitype/TextTranslation");
-            }
-
             // If necessary, updates the access token.
             _authorizationHeaderValue = await _authToken.GetAccessTokenAsync().ConfigureAwait(false);
         }

--- a/Microsoft.Toolkit.Uwp.Services/Services/MicrosoftTranslator/TranslatorServiceException.cs
+++ b/Microsoft.Toolkit.Uwp.Services/Services/MicrosoftTranslator/TranslatorServiceException.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace Microsoft.Toolkit.Uwp.Services.MicrosoftTranslator
+{
+    /// <summary>
+    /// The <strong>TranslatorServiceException</strong> class holds information about Exception related to <see cref="TranslatorService"/>.
+    /// </summary>
+    /// <seealso cref="TranslatorService"/>
+    public class TranslatorServiceException : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TranslatorServiceException"/> class using the specified error message.
+        /// <param name="message">The message that describes the error.</param>
+        /// </summary>
+        public TranslatorServiceException(string message)
+            : base(message)
+        {
+        }
+    }
+}

--- a/Microsoft.Toolkit.Uwp.Services/Services/MicrosoftTranslator/TranslatorServiceException.cs
+++ b/Microsoft.Toolkit.Uwp.Services/Services/MicrosoftTranslator/TranslatorServiceException.cs
@@ -1,4 +1,16 @@
-﻿using System;
+﻿// ******************************************************************
+// Copyright (c) Microsoft. All rights reserved.
+// This code is licensed under the MIT License (MIT).
+// THE CODE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH
+// THE CODE OR THE USE OR OTHER DEALINGS IN THE CODE.
+// ******************************************************************
+
+using System;
 
 namespace Microsoft.Toolkit.Uwp.Services.MicrosoftTranslator
 {


### PR DESCRIPTION
TranslatorServiceException is thrown when an error occurs while obtaining the service access token. Its Message property contains the error reason retrieved from the service.
The documentation has been updated removing some typos and providing better explanation of exceptions.