### PR TITLE
Corrects scroll behavior for HamburgerMenu (#954)

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/HamburgerMenu/HamburgerMenu.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/HamburgerMenu/HamburgerMenu.xaml
@@ -25,60 +25,63 @@
                                    PaneBackground="{TemplateBinding PaneBackground}"
                                    PanePlacement="{TemplateBinding PanePlacement}">
                             <SplitView.Pane>
-                                <Grid x:Name="PaneGrid">
+                                <Grid x:Name="PaneGrid"
+                                      FlowDirection="LeftToRight">
                                     <Grid.RowDefinitions>
                                         <RowDefinition Height="Auto" />
                                         <RowDefinition />
-                                        <RowDefinition Height="Auto" />
                                     </Grid.RowDefinitions>
                                     <Grid Grid.Row="0"
                                           Height="{TemplateBinding HamburgerHeight}" />
-                                    <ListView Name="ButtonsListView"
-                                              Grid.Row="1"
-                                              Width="{TemplateBinding OpenPaneLength}"
-                                              AutomationProperties.Name="Menu items"
-                                              IsItemClickEnabled="True"
-                                              ItemTemplate="{TemplateBinding ItemTemplate}"
-                                              ItemTemplateSelector="{TemplateBinding ItemTemplateSelector}"
-                                              ItemsSource="{TemplateBinding ItemsSource}"
-                                              SelectedIndex="{Binding SelectedIndex, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay}"
-                                              SelectedItem="{Binding SelectedItem, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay}"
-                                              SelectionMode="Single"
-                                              TabIndex="1">
-                                        <ListView.ItemContainerStyle>
-                                            <Style TargetType="ListViewItem">
-                                                <Setter Property="Padding" Value="0" />
-                                            </Style>
-                                        </ListView.ItemContainerStyle>
-                                    </ListView>
-
-                                    <Grid Grid.Row="2"
-                                          Visibility="{TemplateBinding OptionsVisibility}">
-                                        <Grid.RowDefinitions>
-                                            <RowDefinition Height="Auto" />
-                                            <RowDefinition />
-                                        </Grid.RowDefinitions>
-
-                                        <ListView Name="OptionsListView"
-                                                  Grid.Row="1"
-                                                  Width="{TemplateBinding OpenPaneLength}"
-                                                  VerticalAlignment="Bottom"
-                                                  AutomationProperties.Name="Option items"
-                                                  IsItemClickEnabled="True"
-                                                  ItemTemplate="{TemplateBinding OptionsItemTemplate}"
-                                                  ItemTemplateSelector="{TemplateBinding OptionsItemTemplateSelector}"
-                                                  ItemsSource="{TemplateBinding OptionsItemsSource}"
-                                                  SelectedIndex="{Binding SelectedOptionsIndex, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay}"
-                                                  SelectedItem="{Binding SelectedOptionsItem, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay}"
-                                                  TabIndex="2">
-                                            <ListView.ItemContainerStyle>
-                                                <Style TargetType="ListViewItem">
-                                                    <Setter Property="Padding" Value="0" />
-                                                </Style>
-                                            </ListView.ItemContainerStyle>
-                                        </ListView>
-                                    </Grid>
-
+                                    <ScrollViewer Grid.Row="1"
+                                                  HorizontalAlignment="Stretch"
+                                                  VerticalAlignment="Stretch"
+                                                  FlowDirection="RightToLeft"
+                                                  VerticalScrollBarVisibility="Auto">
+                                        <Grid FlowDirection="LeftToRight">
+                                            <Grid.RowDefinitions>
+                                                <RowDefinition Height="Auto" />
+                                                <RowDefinition />
+                                                <RowDefinition Height="Auto " />
+                                            </Grid.RowDefinitions>
+                                            <ListView Name="ButtonsListView"
+                                                      Grid.Row="0"
+                                                      Width="{TemplateBinding OpenPaneLength}"
+                                                      AutomationProperties.Name="Menu items"
+                                                      IsItemClickEnabled="True"
+                                                      ItemTemplate="{TemplateBinding ItemTemplate}"
+                                                      ItemTemplateSelector="{TemplateBinding ItemTemplateSelector}"
+                                                      ItemsSource="{TemplateBinding ItemsSource}"
+                                                      SelectedIndex="{Binding SelectedIndex, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay}"
+                                                      SelectedItem="{Binding SelectedItem, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay}"
+                                                      SelectionMode="Single"
+                                                      TabIndex="1">
+                                                <ListView.ItemContainerStyle>
+                                                    <Style TargetType="ListViewItem">
+                                                        <Setter Property="Padding" Value="0" />
+                                                    </Style>
+                                                </ListView.ItemContainerStyle>
+                                            </ListView>
+                                            <ListView Name="OptionsListView"
+                                                      Grid.Row="2"
+                                                      Width="{TemplateBinding OpenPaneLength}"
+                                                      VerticalAlignment="Bottom"
+                                                      AutomationProperties.Name="Option items"
+                                                      IsItemClickEnabled="True"
+                                                      ItemTemplate="{TemplateBinding OptionsItemTemplate}"
+                                                      ItemTemplateSelector="{TemplateBinding OptionsItemTemplateSelector}"
+                                                      ItemsSource="{TemplateBinding OptionsItemsSource}"
+                                                      SelectedIndex="{Binding SelectedOptionsIndex, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay}"
+                                                      SelectedItem="{Binding SelectedOptionsItem, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay}"
+                                                      TabIndex="2">
+                                                <ListView.ItemContainerStyle>
+                                                    <Style TargetType="ListViewItem">
+                                                        <Setter Property="Padding" Value="0" />
+                                                    </Style>
+                                                </ListView.ItemContainerStyle>
+                                            </ListView>
+                                        </Grid>
+                                    </ScrollViewer>
                                 </Grid>
                             </SplitView.Pane>
                             <ContentPresenter x:Name="ContentPart"


### PR DESCRIPTION
This pull request corrects the behavior outlined in #954 where `OptionsListView` overlaps `ButtonsListView` when the view becomes too small to house both.  Additionally, it moves the scroll bar for the HamburgerMenu `PaneGrid` to the left side to ensure visibility when the menu is in its compact state.  `VerticalScrollBarVisibility` has also been set to `Auto` to only allow it to be visible when needed and to avoid cluttering the view unnecessarily.