### PR TITLE
Fixed #905

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp/Shell.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/Shell.xaml.cs
@@ -47,8 +47,7 @@ namespace Microsoft.Toolkit.Uwp.SampleApp
 
         public void ShowInfoArea()
         {
-            InfoAreaGrid.Visibility = Visibility.Visible;
-            UpdateRootGridMinWidth();
+            InfoAreaGrid.Visibility = Visibility.Visible;           
             RootGrid.ColumnDefinitions[0].Width = new GridLength(2, GridUnitType.Star);
             RootGrid.ColumnDefinitions[1].Width = new GridLength(1, GridUnitType.Star);
             RootGrid.RowDefinitions[1].Height = new GridLength(32);
@@ -222,8 +221,6 @@ namespace Microsoft.Toolkit.Uwp.SampleApp
                     InfoAreaPivot.Items.Add(JavaScriptPivotItem);
                 }
 
-                UpdateRootGridMinWidth();
-
                 if (!string.IsNullOrEmpty(sample.CodeUrl))
                 {
                     GitHub.NavigateUri = new Uri(sample.CodeUrl);
@@ -244,20 +241,6 @@ namespace Microsoft.Toolkit.Uwp.SampleApp
                 {
                     HideInfoArea();
                 }
-            }
-        }
-
-        private void UpdateRootGridMinWidth()
-        {
-            if (ActualWidth > 2 * RootGridColumnsMinWidth)
-            {
-                RootGrid.ColumnDefinitions[0].MinWidth = RootGridColumnsMinWidth;
-                RootGrid.ColumnDefinitions[1].MinWidth = RootGridColumnsMinWidth;
-            }
-            else
-            {
-                RootGrid.ColumnDefinitions[0].MinWidth = 0;
-                RootGrid.ColumnDefinitions[1].MinWidth = 0;
             }
         }
 
@@ -434,8 +417,6 @@ namespace Microsoft.Toolkit.Uwp.SampleApp
             {
                 return;
             }
-
-            UpdateRootGridMinWidth();
         }
 
         private void GitHub_OnClick(object sender, RoutedEventArgs e)

--- a/Microsoft.Toolkit.Uwp.SampleApp/Shell.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/Shell.xaml.cs
@@ -25,9 +25,6 @@ namespace Microsoft.Toolkit.Uwp.SampleApp
 {
     public sealed partial class Shell
     {
-        private const int RootGridColumnsMinWidth = 300;
-        private const int RootGridColumnsDefaultMinWidth = 0;
-
         public static Shell Current { get; private set; }
 
         private bool _isPaneOpen;
@@ -62,8 +59,6 @@ namespace Microsoft.Toolkit.Uwp.SampleApp
             _currentSample = null;
             CommandArea.Children.Clear();
             Splitter.Visibility = Visibility.Collapsed;
-            RootGrid.ColumnDefinitions[0].MinWidth = RootGridColumnsDefaultMinWidth;
-            RootGrid.ColumnDefinitions[1].MinWidth = RootGridColumnsDefaultMinWidth;
         }
 
         public void ShowOnlyHeader(string title)


### PR DESCRIPTION
Removed the UpdateRootGridMinWidth method from Shell.xaml.cs. This minimum width calculation for the RootGrid columns was messing things up, not only for the AdaptiveGridView page. It was causing a "cropping" effect on the left side of every page in smaller width screen resolutions, by setting minimum width for the Grid larger than the actual width. Removed it because the adaptive triggers on XAML page are doing the job. 