### PR TITLE
ux improvement for range selector

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/RangeSelector/RangeSelectorPage.xaml
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/RangeSelector/RangeSelectorPage.xaml
@@ -26,6 +26,7 @@
                        Text="{Binding RangeMin, ElementName=RangeSelectorControl, Converter={StaticResource StringFormatConverter}, ConverterParameter='{}{0:0.##}'}" />
             <controls:RangeSelector x:Name="RangeSelectorControl"
                                     Grid.Column="1"
+                                    IsTouchOptimized="True"
                                     Maximum="{Binding Maximum.Value, Mode=TwoWay}"
                                     Minimum="{Binding Minimum.Value, Mode=TwoWay}" />
             <TextBlock Grid.Column="2"

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/RangeSelector/RangeSelectorPage.xaml
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/RangeSelector/RangeSelectorPage.xaml
@@ -21,6 +21,7 @@
             </Grid.ColumnDefinitions>
             <TextBlock Grid.Column="0"
                        HorizontalAlignment="Left"
+                       VerticalAlignment="Center"
                        Foreground="Black"
                        Text="{Binding RangeMin, ElementName=RangeSelectorControl, Converter={StaticResource StringFormatConverter}, ConverterParameter='{}{0:0.##}'}" />
             <controls:RangeSelector x:Name="RangeSelectorControl"
@@ -29,6 +30,7 @@
                                     Minimum="{Binding Minimum.Value, Mode=TwoWay}" />
             <TextBlock Grid.Column="2"
                        HorizontalAlignment="Right"
+                       VerticalAlignment="Center"
                        Foreground="Black"
                        Text="{Binding RangeMax, ElementName=RangeSelectorControl, Converter={StaticResource StringFormatConverter}, ConverterParameter='{}{0:0.##}'}" />
         </Grid>

--- a/Microsoft.Toolkit.Uwp.UI.Controls/RangeSelector/RangeSelector.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/RangeSelector/RangeSelector.cs
@@ -54,6 +54,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// </summary>
         public static readonly DependencyProperty RangeMaxProperty = DependencyProperty.Register(nameof(RangeMax), typeof(double), typeof(RangeSelector), new PropertyMetadata(1.0, RangeMaxChangedCallback));
 
+        /// <summary>
+        /// Identifies the IsTouchOptimized dependency property.
+        /// </summary>
+        public static readonly DependencyProperty IsTouchOptimizedProperty = DependencyProperty.Register(nameof(IsTouchOptimized), typeof(bool), typeof(RangeSelector), new PropertyMetadata(false, IsTouchOptimizedChangedCallback));
+
         private const double Epsilon = 0.01;
 
         private Border _outOfRangeContentContainer;
@@ -173,6 +178,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             VisualStateManager.GoToState(this, IsEnabled ? "Normal" : "Disabled", false);
 
             IsEnabledChanged += RangeSelector_IsEnabledChanged;
+
+            ArrangeForTouch();
 
             base.OnApplyTemplate();
         }
@@ -562,6 +569,57 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             }
         }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether the control is optimized for touch use.
+        /// </summary>
+        /// <value>
+        /// The value for touch optimization.
+        /// </value>
+        public bool IsTouchOptimized
+        {
+            get
+            {
+                return (bool)GetValue(IsTouchOptimizedProperty);
+            }
+
+            set
+            {
+                SetValue(IsTouchOptimizedProperty, value);
+            }
+        }
+
+        private static void IsTouchOptimizedChangedCallback(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            var rangeSelector = d as RangeSelector;
+            if (rangeSelector == null)
+            {
+                return;
+            }
+
+            rangeSelector.ArrangeForTouch();
+        }
+
+        private void ArrangeForTouch()
+        {
+            if (_containerCanvas == null)
+            {
+                return;
+            }
+
+            if (IsTouchOptimized)
+            {
+                _outOfRangeContentContainer.Height = _minThumb.Height = _maxThumb.Height = 44;
+                _minThumb.Width = _maxThumb.Width = 44;
+                _minThumb.Margin = _maxThumb.Margin = new Thickness(-20, 0, 0, 0);
+            }
+            else
+            {
+                _outOfRangeContentContainer.Height = _minThumb.Height = _maxThumb.Height = 24;
+                _minThumb.Width = _maxThumb.Width = 8;
+                _minThumb.Margin = _maxThumb.Margin = new Thickness(-8, 0, 0, 0);
+            }
+        }
+
         private void SyncThumbs()
         {
             if (_containerCanvas == null)
@@ -574,6 +632,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
             Canvas.SetLeft(_minThumb, relativeLeft);
             Canvas.SetLeft(_activeRectangle, relativeLeft);
+            Canvas.SetTop(_activeRectangle, (_containerCanvas.ActualHeight - _activeRectangle.ActualHeight) / 2);
 
             Canvas.SetLeft(_maxThumb, relativeRight);
 

--- a/Microsoft.Toolkit.Uwp.UI.Controls/RangeSelector/RangeSelector.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/RangeSelector/RangeSelector.cs
@@ -608,15 +608,43 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
             if (IsTouchOptimized)
             {
-                _outOfRangeContentContainer.Height = _minThumb.Height = _maxThumb.Height = 44;
-                _minThumb.Width = _maxThumb.Width = 44;
-                _minThumb.Margin = _maxThumb.Margin = new Thickness(-20, 0, 0, 0);
+                if (_outOfRangeContentContainer != null)
+                {
+                    _outOfRangeContentContainer.Height = 44;
+                }
+
+                if (_minThumb != null)
+                {
+                    _minThumb.Width = _minThumb.Height = 44;
+                    _minThumb.Margin = new Thickness(-20, 0, 0, 0);
+                }
+
+                if (_maxThumb != null)
+                {
+                    _maxThumb.Width = _maxThumb.Height = 44;
+                    _maxThumb.Margin = new Thickness(-20, 0, 0, 0);
+                }
             }
             else
             {
-                _outOfRangeContentContainer.Height = _minThumb.Height = _maxThumb.Height = 24;
-                _minThumb.Width = _maxThumb.Width = 8;
-                _minThumb.Margin = _maxThumb.Margin = new Thickness(-8, 0, 0, 0);
+                if (_outOfRangeContentContainer != null)
+                {
+                    _outOfRangeContentContainer.Height = 24;
+                }
+
+                if (_minThumb != null)
+                {
+                    _minThumb.Width = 8;
+                    _minThumb.Height = 24;
+                    _minThumb.Margin = new Thickness(-8, 0, 0, 0);
+                }
+
+                if (_maxThumb != null)
+                {
+                    _maxThumb.Width = 8;
+                    _maxThumb.Height = 24;
+                    _maxThumb.Margin = new Thickness(-8, 0, 0, 0);
+                }
             }
         }
 

--- a/Microsoft.Toolkit.Uwp.UI.Controls/RangeSelector/RangeSelector.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/RangeSelector/RangeSelector.xaml
@@ -8,7 +8,7 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="controls:RangeSelector">
-                    <Grid Height="24">
+                    <Grid Height="40">
                         <Grid.Resources>
                             <Style x:Key="SliderThumbStyle"
                                    TargetType="Thumb">
@@ -17,27 +17,29 @@
                                 <Setter Property="Background" Value="{ThemeResource SystemControlForegroundAccentBrush}" />
                                 <Setter Property="RenderTransform">
                                     <Setter.Value>
-                                        <TranslateTransform X="-8" />
+                                        <TranslateTransform X="-20" />
                                     </Setter.Value>
                                 </Setter>
                                 <Setter Property="Template">
                                     <Setter.Value>
                                         <ControlTemplate TargetType="Thumb">
-                                            <Border Width="8"
-                                                    Height="24"
+                                            <Grid Width="40" Height="40" Background="Transparent">
+                                                <Border Width="8"
+                                                    Height="24"                                                    
                                                     HorizontalAlignment="Center"
                                                     Background="{TemplateBinding Background}"
                                                     BorderBrush="{TemplateBinding BorderBrush}"
                                                     BorderThickness="{TemplateBinding BorderThickness}"
                                                     CornerRadius="4" />
+                                            </Grid>
                                         </ControlTemplate>
                                     </Setter.Value>
                                 </Setter>
                             </Style>
                         </Grid.Resources>
 
-                        <Border x:Name="OutOfRangeContentContainer"
-                                Height="24"
+                        <Border x:Name="OutOfRangeContentContainer" 
+                                Height="40"
                                 Margin="12,0"
                                 Background="Transparent">
                             <Rectangle x:Name="BackgroundElement"
@@ -48,13 +50,13 @@
                                 Margin="12,0"
                                 Background="Transparent">
                             <Rectangle x:Name="ActiveRectangle"
-                                       Canvas.Top="11"
+                                       Canvas.Top="19"                                       
                                        Height="2"
                                        Fill="{TemplateBinding Foreground}" />
                             <Thumb x:Name="MinThumb"
                                    AutomationProperties.Name="Min thumb"
                                    Background="{TemplateBinding Foreground}"
-                                   IsTabStop="True"
+                                   IsTabStop="True"                                  
                                    Style="{StaticResource SliderThumbStyle}"
                                    TabIndex="0" />
                             <Thumb x:Name="MaxThumb"

--- a/Microsoft.Toolkit.Uwp.UI.Controls/RangeSelector/RangeSelector.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/RangeSelector/RangeSelector.xaml
@@ -8,22 +8,19 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="controls:RangeSelector">
-                    <Grid Height="40">
+                    <Grid x:Name="ControlGrid" Height="{TemplateBinding Height}">
                         <Grid.Resources>
                             <Style x:Key="SliderThumbStyle"
                                    TargetType="Thumb">
                                 <Setter Property="UseSystemFocusVisuals" Value="True" />
                                 <Setter Property="BorderThickness" Value="0" />
-                                <Setter Property="Background" Value="{ThemeResource SystemControlForegroundAccentBrush}" />
-                                <Setter Property="RenderTransform">
-                                    <Setter.Value>
-                                        <TranslateTransform X="-20" />
-                                    </Setter.Value>
-                                </Setter>
+                                <Setter Property="Background" Value="{ThemeResource SystemControlForegroundAccentBrush}" />                              
                                 <Setter Property="Template">
                                     <Setter.Value>
                                         <ControlTemplate TargetType="Thumb">
-                                            <Grid Width="40" Height="40" Background="Transparent">
+                                            <Grid Width="{TemplateBinding Width}" 
+                                                  Height="{TemplateBinding Height}" 
+                                                  Background="Transparent">
                                                 <Border Width="8"
                                                     Height="24"                                                    
                                                     HorizontalAlignment="Center"
@@ -38,8 +35,7 @@
                             </Style>
                         </Grid.Resources>
 
-                        <Border x:Name="OutOfRangeContentContainer" 
-                                Height="40"
+                        <Border x:Name="OutOfRangeContentContainer"                                 
                                 Margin="12,0"
                                 Background="Transparent">
                             <Rectangle x:Name="BackgroundElement"
@@ -49,14 +45,13 @@
                         <Canvas x:Name="ContainerCanvas"
                                 Margin="12,0"
                                 Background="Transparent">
-                            <Rectangle x:Name="ActiveRectangle"
-                                       Canvas.Top="19"                                       
+                            <Rectangle x:Name="ActiveRectangle"                                                                     
                                        Height="2"
                                        Fill="{TemplateBinding Foreground}" />
                             <Thumb x:Name="MinThumb"
                                    AutomationProperties.Name="Min thumb"
                                    Background="{TemplateBinding Foreground}"
-                                   IsTabStop="True"                                  
+                                   IsTabStop="True" 
                                    Style="{StaticResource SliderThumbStyle}"
                                    TabIndex="0" />
                             <Thumb x:Name="MaxThumb"


### PR DESCRIPTION
The RangeSlider on a touchscreen (mobile/tablet) was extremely difficult to use, because you had to drag the two thumbs who were very small for touch. I added a grid containing the thumb border in the thumb template, a bit bigger with a transparent background. Now it is a lot easier to manipulate the thumbs using touch. 
Also I modified the slider's sample page a bit because now the control requires more height and I had to adjust the alignment of the min/max indicators.