### PR TITLE
Update HamburgerMenu docs

### DIFF
--- a/docs/controls/HamburgerMenu.md
+++ b/docs/controls/HamburgerMenu.md
@@ -75,7 +75,7 @@ The next sample demonstrates how to add custom menu items to the HamburgerMenu c
                                 ItemClick="OnMenuItemClick"
                                 OptionsItemTemplate="{StaticResource DefaultTemplate}"
                                 OptionsItemClick="OnMenuItemClick">
-            <Frame x:Name="contentFrame"/>
+            <Frame x:Name="contentFrame" Foreground="Black"/>
         </controls:HamburgerMenu>
     </Grid>
 </Page>


### PR DESCRIPTION
If you don't explicitly set a different foreground color for the children of HamburgerMenu, they'll inherit from their parent, which in this example is "white." If this can be confusing in basic cases (like a page that displays a text box) because if the page background is *also* white (which by default, it is) it'll seem like the children aren't rendering. 
Setting "foreground" fixes this.