### PR TITLE
Add foreground for markdown textblock header 1 through 6

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/MarkdownTextBlock/MarkdownTextBlockPage.xaml
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/MarkdownTextBlock/MarkdownTextBlockPage.xaml
@@ -38,6 +38,7 @@
                       VerticalScrollBarVisibility="Visible">
             <controls:MarkdownTextBlock x:Name="UiMarkdownText"
                                         Margin="6"
+                                        Header1Foreground="{ThemeResource SystemControlForegroundAccentBrush}"
                                         Foreground="Black"
                                         LinkForeground="BlueViolet"
                                         LinkClicked="MarkdownText_LinkClicked"

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/Display/XamlRenderer.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/Display/XamlRenderer.cs
@@ -156,6 +156,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls.Markdown.Display
         public Thickness Header1Margin { get; set; }
 
         /// <summary>
+        /// Gets or sets the foreground brush for level 1 headers.
+        /// </summary>
+        public Brush Header1Foreground { get; set; }
+
+        /// <summary>
         /// Gets or sets the font weight to use for level 2 headers.
         /// </summary>
         public FontWeight Header2FontWeight { get; set; }
@@ -169,6 +174,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls.Markdown.Display
         /// Gets or sets the margin for level 2 headers.
         /// </summary>
         public Thickness Header2Margin { get; set; }
+
+        /// <summary>
+        /// Gets or sets the foreground brush for level 2 headers.
+        /// </summary>
+        public Brush Header2Foreground { get; set; }
 
         /// <summary>
         /// Gets or sets the font weight to use for level 3 headers.
@@ -186,6 +196,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls.Markdown.Display
         public Thickness Header3Margin { get; set; }
 
         /// <summary>
+        /// Gets or sets the foreground brush for level 3 headers.
+        /// </summary>
+        public Brush Header3Foreground { get; set; }
+
+        /// <summary>
         /// Gets or sets the font weight to use for level 4 headers.
         /// </summary>
         public FontWeight Header4FontWeight { get; set; }
@@ -199,6 +214,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls.Markdown.Display
         /// Gets or sets the margin for level 4 headers.
         /// </summary>
         public Thickness Header4Margin { get; set; }
+        
+        /// <summary>
+        /// Gets or sets the foreground brush for level 4 headers.
+        /// </summary>
+        public Brush Header4Foreground { get; set; }
 
         /// <summary>
         /// Gets or sets the font weight to use for level 5 headers.
@@ -216,6 +236,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls.Markdown.Display
         public Thickness Header5Margin { get; set; }
 
         /// <summary>
+        /// Gets or sets the foreground brush for level 5 headers.
+        /// </summary>
+        public Brush Header5Foreground { get; set; }
+
+        /// <summary>
         /// Gets or sets the font weight to use for level 6 headers.
         /// </summary>
         public FontWeight Header6FontWeight { get; set; }
@@ -229,6 +254,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls.Markdown.Display
         /// Gets or sets the margin for level 6 headers.
         /// </summary>
         public Thickness Header6Margin { get; set; }
+
+        /// <summary>
+        /// Gets or sets the foreground brush for level 6 headers.
+        /// </summary>
+        public Brush Header6Foreground { get; set; }
 
         /// <summary>
         /// Gets or sets the brush used to render a horizontal rule.  If this is <c>null</c>, then
@@ -472,31 +502,37 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls.Markdown.Display
                     paragraph.Margin = Header1Margin;
                     paragraph.FontSize = Header1FontSize;
                     paragraph.FontWeight = Header1FontWeight;
+                    paragraph.Foreground = Header1Foreground;
                     break;
                 case 2:
                     paragraph.Margin = Header2Margin;
                     paragraph.FontSize = Header2FontSize;
                     paragraph.FontWeight = Header2FontWeight;
+                    paragraph.Foreground = Header2Foreground;
                     break;
                 case 3:
                     paragraph.Margin = Header3Margin;
                     paragraph.FontSize = Header3FontSize;
                     paragraph.FontWeight = Header3FontWeight;
+                    paragraph.Foreground = Header3Foreground;
                     break;
                 case 4:
                     paragraph.Margin = Header4Margin;
                     paragraph.FontSize = Header4FontSize;
                     paragraph.FontWeight = Header4FontWeight;
+                    paragraph.Foreground = Header4Foreground;
                     break;
                 case 5:
                     paragraph.Margin = Header5Margin;
                     paragraph.FontSize = Header5FontSize;
                     paragraph.FontWeight = Header5FontWeight;
+                    paragraph.Foreground = Header5Foreground;
                     break;
                 case 6:
                     paragraph.Margin = Header6Margin;
                     paragraph.FontSize = Header6FontSize;
                     paragraph.FontWeight = Header6FontWeight;
+                    paragraph.Foreground = Header6Foreground;
 
                     var underline = new Underline();
                     childInlines = underline.Inlines;

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/MarkdownTextBlock.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/MarkdownTextBlock.cs
@@ -287,6 +287,24 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             new PropertyMetadata(null, OnPropertyChangedStatic));
 
         /// <summary>
+        /// Gets or sets the foreground brush for level 1 headers.
+        /// </summary>
+        public Brush Header1Foreground
+        {
+            get { return (Brush) GetValue(Header1ForegroundProperty); }
+            set { SetValue(Header1ForegroundProperty, value); }
+        }
+
+        /// <summary>
+        /// Gets the dependency property for <see cref="Header1Foreground"/>.
+        /// </summary>
+        public static readonly DependencyProperty Header1ForegroundProperty = DependencyProperty.Register(
+            nameof(Header1Foreground),
+            typeof(Brush),
+            typeof(MarkdownTextBlock),
+            new PropertyMetadata(null, OnPropertyChangedStatic));
+
+        /// <summary>
         /// Gets or sets the font weight to use for level 2 headers.
         /// </summary>
         public FontWeight Header2FontWeight
@@ -337,6 +355,24 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         public static readonly DependencyProperty Header2MarginProperty = DependencyProperty.Register(
             nameof(Header2Margin),
             typeof(Thickness),
+            typeof(MarkdownTextBlock),
+            new PropertyMetadata(null, OnPropertyChangedStatic));
+
+        /// <summary>
+        /// Gets or sets the foreground brush for level 2 headers.
+        /// </summary>
+        public Brush Header2Foreground
+        {
+            get { return (Brush)GetValue(Header2ForegroundProperty); }
+            set { SetValue(Header2ForegroundProperty, value); }
+        }
+
+        /// <summary>
+        /// Gets the dependency property for <see cref="Header2Foreground"/>.
+        /// </summary>
+        public static readonly DependencyProperty Header2ForegroundProperty = DependencyProperty.Register(
+            nameof(Header2Foreground),
+            typeof(Brush),
             typeof(MarkdownTextBlock),
             new PropertyMetadata(null, OnPropertyChangedStatic));
 
@@ -395,6 +431,24 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             new PropertyMetadata(null, OnPropertyChangedStatic));
 
         /// <summary>
+        /// Gets or sets the foreground brush for level 3 headers.
+        /// </summary>
+        public Brush Header3Foreground
+        {
+            get { return (Brush)GetValue(Header3ForegroundProperty); }
+            set { SetValue(Header3ForegroundProperty, value); }
+        }
+
+        /// <summary>
+        /// Gets the dependency property for <see cref="Header3Foreground"/>.
+        /// </summary>
+        public static readonly DependencyProperty Header3ForegroundProperty = DependencyProperty.Register(
+            nameof(Header3Foreground),
+            typeof(Brush),
+            typeof(MarkdownTextBlock),
+            new PropertyMetadata(null, OnPropertyChangedStatic));
+
+        /// <summary>
         /// Gets or sets the font weight to use for level 4 headers.
         /// </summary>
         public FontWeight Header4FontWeight
@@ -445,6 +499,24 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         public static readonly DependencyProperty Header4MarginProperty = DependencyProperty.Register(
             nameof(Header4Margin),
             typeof(Thickness),
+            typeof(MarkdownTextBlock),
+            new PropertyMetadata(null, OnPropertyChangedStatic));
+
+        /// <summary>
+        /// Gets or sets the foreground brush for level 4 headers.
+        /// </summary>
+        public Brush Header4Foreground
+        {
+            get { return (Brush)GetValue(Header4ForegroundProperty); }
+            set { SetValue(Header4ForegroundProperty, value); }
+        }
+
+        /// <summary>
+        /// Gets the dependency property for <see cref="Header4Foreground"/>.
+        /// </summary>
+        public static readonly DependencyProperty Header4ForegroundProperty = DependencyProperty.Register(
+            nameof(Header4Foreground),
+            typeof(Brush),
             typeof(MarkdownTextBlock),
             new PropertyMetadata(null, OnPropertyChangedStatic));
 
@@ -503,6 +575,24 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             new PropertyMetadata(null, OnPropertyChangedStatic));
 
         /// <summary>
+        /// Gets or sets the foreground brush for level 5 headers.
+        /// </summary>
+        public Brush Header5Foreground
+        {
+            get { return (Brush)GetValue(Header5ForegroundProperty); }
+            set { SetValue(Header5ForegroundProperty, value); }
+        }
+
+        /// <summary>
+        /// Gets the dependency property for <see cref="Header5Foreground"/>.
+        /// </summary>
+        public static readonly DependencyProperty Header5ForegroundProperty = DependencyProperty.Register(
+            nameof(Header5Foreground),
+            typeof(Brush),
+            typeof(MarkdownTextBlock),
+            new PropertyMetadata(null, OnPropertyChangedStatic));
+
+        /// <summary>
         /// Gets or sets the font weight to use for level 6 headers.
         /// </summary>
         public FontWeight Header6FontWeight
@@ -553,6 +643,24 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         public static readonly DependencyProperty Header6MarginProperty = DependencyProperty.Register(
             nameof(Header6Margin),
             typeof(Thickness),
+            typeof(MarkdownTextBlock),
+            new PropertyMetadata(null, OnPropertyChangedStatic));
+
+        /// <summary>
+        /// Gets or sets the foreground brush for level 6 headers.
+        /// </summary>
+        public Brush Header6Foreground
+        {
+            get { return (Brush)GetValue(Header6ForegroundProperty); }
+            set { SetValue(Header6ForegroundProperty, value); }
+        }
+
+        /// <summary>
+        /// Gets the dependency property for <see cref="Header6Foreground"/>.
+        /// </summary>
+        public static readonly DependencyProperty Header6ForegroundProperty = DependencyProperty.Register(
+            nameof(Header6Foreground),
+            typeof(Brush),
             typeof(MarkdownTextBlock),
             new PropertyMetadata(null, OnPropertyChangedStatic));
 
@@ -988,21 +1096,27 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                     Header1FontSize = Header1FontSize,
                     Header1FontWeight = Header1FontWeight,
                     Header1Margin = Header1Margin,
+                    Header1Foreground = Header1Foreground,
                     Header2FontSize = Header2FontSize,
                     Header2FontWeight = Header2FontWeight,
                     Header2Margin = Header2Margin,
+                    Header2Foreground = Header2Foreground,
                     Header3FontSize = Header3FontSize,
                     Header3FontWeight = Header3FontWeight,
                     Header3Margin = Header3Margin,
+                    Header3Foreground = Header3Foreground,
                     Header4FontSize = Header4FontSize,
                     Header4FontWeight = Header4FontWeight,
                     Header4Margin = Header4Margin,
+                    Header4Foreground = Header4Foreground,
                     Header5FontSize = Header5FontSize,
                     Header5FontWeight = Header5FontWeight,
                     Header5Margin = Header5Margin,
+                    Header5Foreground = Header5Foreground,
                     Header6FontSize = Header6FontSize,
                     Header6FontWeight = Header6FontWeight,
                     Header6Margin = Header6Margin,
+                    Header6Foreground = Header6Foreground,
                     HorizontalRuleBrush = HorizontalRuleBrush,
                     HorizontalRuleMargin = HorizontalRuleMargin,
                     HorizontalRuleThickness = HorizontalRuleThickness,

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/MarkdownTextBlock.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/MarkdownTextBlock.xaml
@@ -31,21 +31,27 @@
         <Setter Property="Header1FontWeight" Value="Bold" />
         <Setter Property="Header1FontSize" Value="20" />
         <Setter Property="Header1Margin" Value="0, 15, 0, 15" />
+        <Setter Property="Header1Foreground" Value="{ThemeResource DefaultTextForegroundThemeBrush}" />
         <Setter Property="Header2FontWeight" Value="Normal" />
         <Setter Property="Header2FontSize" Value="20" />
         <Setter Property="Header2Margin" Value="0, 15, 0, 15" />
+        <Setter Property="Header2Foreground" Value="{ThemeResource DefaultTextForegroundThemeBrush}" />
         <Setter Property="Header3FontWeight" Value="Bold" />
         <Setter Property="Header3FontSize" Value="17" />
         <Setter Property="Header3Margin" Value="0, 10, 0, 10" />
+        <Setter Property="Header3Foreground" Value="{ThemeResource DefaultTextForegroundThemeBrush}" />
         <Setter Property="Header4FontWeight" Value="Normal" />
         <Setter Property="Header4FontSize" Value="17" />
         <Setter Property="Header4Margin" Value="0, 10, 0, 10" />
+        <Setter Property="Header4Foreground" Value="{ThemeResource DefaultTextForegroundThemeBrush}" />
         <Setter Property="Header5FontWeight" Value="Bold" />
         <Setter Property="Header5FontSize" Value="15" />
         <Setter Property="Header5Margin" Value="0, 10, 0, 5" />
+        <Setter Property="Header5Foreground" Value="{ThemeResource DefaultTextForegroundThemeBrush}" />
         <Setter Property="Header6FontWeight" Value="Normal" />
         <Setter Property="Header6FontSize" Value="15" />
         <Setter Property="Header6Margin" Value="0, 10, 0, 0" />
+        <Setter Property="Header6Foreground" Value="{ThemeResource DefaultTextForegroundThemeBrush}" />
         <Setter Property="HorizontalRuleBrush" Value="{ThemeResource MarkdownBorderBrush}" />
         <Setter Property="HorizontalRuleMargin" Value="0, 7, 0, 7" />
         <Setter Property="HorizontalRuleThickness" Value="2" />


### PR DESCRIPTION
I thought it would be cool to allow changing the foreground brush for the headers inside the markdown textblock.
