### PR TITLE
Fix ColorHelper HSL and HSV calculations

### DIFF
--- a/Microsoft.Toolkit.Uwp/Helpers/ColorHelper.cs
+++ b/Microsoft.Toolkit.Uwp/Helpers/ColorHelper.cs
@@ -171,7 +171,9 @@ namespace Microsoft.Toolkit.Uwp
             }
             else if (max == r)
             {
-                h1 = ((g - b) / chroma) % 6;
+                // The % operator doesn't do proper modulo on negative
+                // numbers, so we'll add 6 before using it
+                h1 = (((g - b) / chroma) + 6) % 6;
             }
             else if (max == g)
             {

--- a/Microsoft.Toolkit.Uwp/Helpers/ColorHelper.cs
+++ b/Microsoft.Toolkit.Uwp/Helpers/ColorHelper.cs
@@ -216,7 +216,9 @@ namespace Microsoft.Toolkit.Uwp
             }
             else if (max == r)
             {
-                h1 = ((g - b) / chroma) % 6;
+                // The % operator doesn't do proper modulo on negative
+                // numbers, so we'll add 6 before using it
+                h1 = (((g - b) / chroma) + 6) % 6;
             }
             else if (max == g)
             {

--- a/Microsoft.Toolkit.Uwp/Helpers/ColorHelper.cs
+++ b/Microsoft.Toolkit.Uwp/Helpers/ColorHelper.cs
@@ -182,7 +182,7 @@ namespace Microsoft.Toolkit.Uwp
                 h1 = 4 + ((r - g) / chroma);
             }
 
-            double lightness = 0.5 * (max - min);
+            double lightness = 0.5 * (max + min);
             double saturation = chroma == 0 ? 0 : chroma / (1 - Math.Abs((2 * lightness) - 1));
             HslColor ret;
             ret.H = 60 * h1;
@@ -225,8 +225,7 @@ namespace Microsoft.Toolkit.Uwp
                 h1 = 4 + ((r - g) / chroma);
             }
 
-            double lightness = 0.5 * (max - min);
-            double saturation = chroma == 0 ? 0 : chroma / (1 - Math.Abs((2 * lightness) - 1));
+            double saturation = chroma == 0 ? 0 : chroma / max;
             HsvColor ret;
             ret.H = 60 * h1;
             ret.S = saturation;

--- a/UnitTests/Helpers/Test_ColorHelper.cs
+++ b/UnitTests/Helpers/Test_ColorHelper.cs
@@ -143,6 +143,28 @@ namespace UnitTests.Helpers
 
         [TestCategory("Helpers")]
         [TestMethod]
+        public void Test_ColorHelper_ToHsv_MaxR()
+        {
+            HsvColor hsvColor;
+            hsvColor.A = 1.0;        // Alpha
+            hsvColor.H = 330;        // Hue
+            hsvColor.S = 0.58823529; // Saturation
+            hsvColor.V = 1;          // Value
+
+            // Use a test color with non-zero/non-max values for both RGB and HSV
+            var color = Windows.UI.Color.FromArgb(255, 255, 105, 180).ToHsv();
+
+            // These still may not come out exactly even, so define a delta so that
+            // if the two are almost equal, the test still passes.
+            const double delta = 0.000001d;
+            Assert.AreEqual(color.H, hsvColor.H, delta);
+            Assert.AreEqual(color.S, hsvColor.S, delta);
+            Assert.AreEqual(color.V, hsvColor.V, delta);
+            Assert.AreEqual(color.A, hsvColor.A, delta);
+        }
+
+        [TestCategory("Helpers")]
+        [TestMethod]
         public void Test_ColorHelper_FromHsl()
         {
             Assert.AreEqual(ColorHelper.FromHsl(0.0, 1.0, 0.5), Windows.UI.Colors.Red);

--- a/UnitTests/Helpers/Test_ColorHelper.cs
+++ b/UnitTests/Helpers/Test_ColorHelper.cs
@@ -89,15 +89,37 @@ namespace UnitTests.Helpers
 
         [TestCategory("Helpers")]
         [TestMethod]
+        public void Test_ColorHelper_ToHsl_White()
+        {
+            HslColor hslWhite;
+            hslWhite.A = 1.0;  // Alpha
+            hslWhite.H = 0.0;  // Hue
+            hslWhite.S = 0.0;  // Saturation
+            hslWhite.L = 1.0;  // Lightness
+
+            Assert.AreEqual(Windows.UI.Colors.White.ToHsl(), hslWhite);
+        }
+
+        [TestCategory("Helpers")]
+        [TestMethod]
         public void Test_ColorHelper_ToHsv()
         {
-            HsvColor hsvRed;
-            hsvRed.A = 1.0;  // Alpha
-            hsvRed.H = 0.0;  // Hue
-            hsvRed.S = 1.0;  // Saturation
-            hsvRed.V = 1.0;  // Value
+            HsvColor hsvColor;
+            hsvColor.A = 1.0;   // Alpha
+            hsvColor.H = 100;   // Hue
+            hsvColor.S = 0.25;  // Saturation
+            hsvColor.V = 0.80;  // Value
 
-            Assert.AreEqual(Windows.UI.Colors.Red.ToHsv(), hsvRed);
+            // Use a test color with non-zero/non-max values for both RGB and HSV
+            var color = Windows.UI.Color.FromArgb(255, 170, 204, 153).ToHsv();
+
+            // These still may not come out exactly even, so define a delta so that
+            // if the two are almost equal, the test still passes.
+            const double delta = 0.000001d;
+            Assert.AreEqual(color.H, hsvColor.H, delta);
+            Assert.AreEqual(color.S, hsvColor.S, delta);
+            Assert.AreEqual(color.V, hsvColor.V, delta);
+            Assert.AreEqual(color.A, hsvColor.A, delta);
         }
 
         [TestCategory("Helpers")]

--- a/UnitTests/Helpers/Test_ColorHelper.cs
+++ b/UnitTests/Helpers/Test_ColorHelper.cs
@@ -102,6 +102,25 @@ namespace UnitTests.Helpers
 
         [TestCategory("Helpers")]
         [TestMethod]
+        public void Test_ColorHelper_ToHsl_MaxR()
+        {
+            // Test when given an RGB value where R is the max value.
+            HslColor hslColor;
+            hslColor.A = 1.0;        // Alpha
+            hslColor.H = 330.0;      // Hue
+            hslColor.S = 1.0;        // Saturation
+            hslColor.L = 0.7058823;  // Lightness
+
+            const double delta = 0.000001d;
+            var color = Windows.UI.Color.FromArgb(255, 255, 105, 180).ToHsl();
+            Assert.AreEqual(color.H, hslColor.H, delta);
+            Assert.AreEqual(color.S, hslColor.S, delta);
+            Assert.AreEqual(color.L, hslColor.L, delta);
+            Assert.AreEqual(color.A, hslColor.A, delta);
+        }
+
+        [TestCategory("Helpers")]
+        [TestMethod]
         public void Test_ColorHelper_ToHsv()
         {
             HsvColor hsvColor;


### PR DESCRIPTION
When using `ColorHelper` to convert colors to HSL, I noticed that the lightness value returned wasn't exactly right. I read through the conversion code and found a small error in the lightness calculation. Since I was close, I took a glance at the HSV conversion code and noticed that the saturation was calculated using the HSL method rather than the HSV method, so I fixed that as well.

I've updated the unit tests so that they cover the errors they weren't catching before. If you want to double-check my changes, this Wikipedia page is pretty helpful: https://en.wikipedia.org/wiki/HSL_and_HSV