### PR TITLE
Deprecate toast AfterActivationBehavior

### DIFF
--- a/Notifications/Microsoft.Toolkit.Uwp.Notifications.Shared/Toasts/ToastActivationOptions.cs
+++ b/Notifications/Microsoft.Toolkit.Uwp.Notifications.Shared/Toasts/ToastActivationOptions.cs
@@ -25,8 +25,9 @@ namespace Microsoft.Toolkit.Uwp.Notifications
         public string ProtocolActivationTargetApplicationPfn { get; set; }
 
         /// <summary>
-        /// Specifies the behavior that the toast should use when the user invokes this action. Note that this option only works on <see cref="ToastButton"/> and <see cref="ToastContextMenuItem"/>.
+        /// Not supported on Windows: Specifies the behavior that the toast should use when the user invokes this action. Note that this option only works on <see cref="ToastButton"/> and <see cref="ToastContextMenuItem"/>.
         /// </summary>
+        [Obsolete("Windows does not support AfterActivationBehavior. If a future version of Windows supports this, we will undeprecate the property when support is added.")]
         public ToastAfterActivationBehavior AfterActivationBehavior { get; set; } = ToastAfterActivationBehavior.Default;
 
         internal void PopulateElement(IElement_ToastActivatable el)
@@ -38,7 +39,9 @@ namespace Microsoft.Toolkit.Uwp.Notifications
             }
 
             el.ProtocolActivationTargetApplicationPfn = ProtocolActivationTargetApplicationPfn;
+#pragma warning disable 618
             el.AfterActivationBehavior = AfterActivationBehavior;
+#pragma warning restore 618
         }
     }
 }

--- a/Notifications/Microsoft.Toolkit.Uwp.Notifications.Shared/Toasts/ToastContent.cs
+++ b/Notifications/Microsoft.Toolkit.Uwp.Notifications.Shared/Toasts/ToastContent.cs
@@ -102,7 +102,9 @@ namespace Microsoft.Toolkit.Uwp.Notifications
         {
             if (ActivationOptions != null)
             {
+#pragma warning disable 618
                 if (ActivationOptions.AfterActivationBehavior != ToastAfterActivationBehavior.Default)
+#pragma warning restore 618
                 {
                     throw new InvalidOperationException("ToastContent does not support a custom AfterActivationBehavior. Please ensure ActivationOptions.AfterActivationBehavior is set to Default.");
                 }

--- a/Notifications/Microsoft.Toolkit.Uwp.Notifications.Shared/Toasts/ToastHeader.cs
+++ b/Notifications/Microsoft.Toolkit.Uwp.Notifications.Shared/Toasts/ToastHeader.cs
@@ -101,7 +101,9 @@ namespace Microsoft.Toolkit.Uwp.Notifications
         {
             if (ActivationOptions != null)
             {
+#pragma warning disable 618
                 if (ActivationOptions.AfterActivationBehavior != ToastAfterActivationBehavior.Default)
+#pragma warning restore 618
                 {
                     throw new InvalidOperationException("ToastHeader does not support a custom AfterActivationBehavior. Please ensure ActivationOptions.AfterActivationBehavior is set to Default.");
                 }

--- a/UnitTests/UnitTests.Notifications.Shared/Test_Toast_Xml.cs
+++ b/UnitTests/UnitTests.Notifications.Shared/Test_Toast_Xml.cs
@@ -1320,7 +1320,9 @@ namespace UnitTests.Notifications
                 ActivationType = ToastActivationType.Protocol,
                 ActivationOptions = new ToastActivationOptions()
                 {
+#pragma warning disable 618
                     AfterActivationBehavior = ToastAfterActivationBehavior.PendingUpdate,
+#pragma warning restore 618
                     ProtocolActivationTargetApplicationPfn = "Microsoft.Settings"
                 }
             });
@@ -1338,7 +1340,9 @@ namespace UnitTests.Notifications
                 ActivationType = ToastActivationType.Background,
                 ActivationOptions = new ToastActivationOptions()
                 {
+#pragma warning disable 618
                     AfterActivationBehavior = ToastAfterActivationBehavior.Default
+#pragma warning restore 618
                 }
             });
 
@@ -1368,7 +1372,9 @@ namespace UnitTests.Notifications
                 ActivationType = ToastActivationType.Protocol,
                 ActivationOptions = new ToastActivationOptions()
                 {
+#pragma warning disable 618
                     AfterActivationBehavior = ToastAfterActivationBehavior.PendingUpdate,
+#pragma warning restore 618
                     ProtocolActivationTargetApplicationPfn = "Microsoft.Settings"
                 }
             };
@@ -1381,7 +1387,9 @@ namespace UnitTests.Notifications
             AssertContextMenuItemPayload("<action placement='contextMenu' content='My content' arguments='myArgs' activationType='protocol' />", item);
 
             // Default should be ignored
+#pragma warning disable 618
             item.ActivationOptions.AfterActivationBehavior = ToastAfterActivationBehavior.Default;
+#pragma warning restore 618
 
             AssertContextMenuItemPayload("<action placement='contextMenu' content='My content' arguments='myArgs' activationType='protocol' />", item);
 
@@ -1431,7 +1439,9 @@ namespace UnitTests.Notifications
                 ActivationType = ToastActivationType.Background,
                 ActivationOptions = new ToastActivationOptions()
                 {
+#pragma warning disable 618
                     AfterActivationBehavior = ToastAfterActivationBehavior.Default
+#pragma warning restore 618
                 }
             });
 
@@ -1443,7 +1453,9 @@ namespace UnitTests.Notifications
                     Launch = "myArgs",
                     ActivationOptions = new ToastActivationOptions()
                     {
+#pragma warning disable 618
                         AfterActivationBehavior = ToastAfterActivationBehavior.PendingUpdate
+#pragma warning restore 618
                     }
                 });
                 Assert.Fail("InvalidOperationException should have been thrown.");
@@ -1490,13 +1502,17 @@ namespace UnitTests.Notifications
             AssertHeaderPayload("<header id='myId' title='My title' arguments='settings:about' activationType='protocol' />", header);
 
             // Default should be ignored
+#pragma warning disable 618
             header.ActivationOptions.AfterActivationBehavior = ToastAfterActivationBehavior.Default;
+#pragma warning restore 618
             AssertHeaderPayload("<header id='myId' title='My title' arguments='settings:about' activationType='protocol' />", header);
 
             // Using anything other than default should throw exception
             try
             {
+#pragma warning disable 618
                 header.ActivationOptions.AfterActivationBehavior = ToastAfterActivationBehavior.PendingUpdate;
+#pragma warning restore 618
                 AssertHeaderPayload("Exception should be thrown", header);
                 Assert.Fail("InvalidOperationException should have been thrown.");
             }


### PR DESCRIPTION
Windows does not support this, hence the property does nothing. Adding obsolete tag (and adding pragmas to ignore the obsolete warnings within our own code when we use the property)