### PR TITLE
Fix toast progress bar

### DIFF
--- a/Notifications/Microsoft.Toolkit.Uwp.Notifications.Shared/Adaptive/AdaptiveProgressBar.cs
+++ b/Notifications/Microsoft.Toolkit.Uwp.Notifications.Shared/Adaptive/AdaptiveProgressBar.cs
@@ -14,6 +14,7 @@
 using System.Collections.Generic;
 #endif
 using Microsoft.Toolkit.Uwp.Notifications.Adaptive.Elements;
+using System;
 
 namespace Microsoft.Toolkit.Uwp.Notifications
 {
@@ -63,7 +64,7 @@ namespace Microsoft.Toolkit.Uwp.Notifications
             ValueStringOverride { get; set; }
 
         /// <summary>
-        /// Gets or sets an optional status string, which is displayed underneath the progress bar. If provided, this string should reflect the status of the download, like "Downloading..." or "Installing..."
+        /// Required. Gets or sets a status string, which is displayed underneath the progress bar. This string should reflect the status of the operation, like "Downloading..." or "Installing..."
         /// </summary>
         public
 #if WINRT
@@ -95,6 +96,11 @@ namespace Microsoft.Toolkit.Uwp.Notifications
             answer.ValueStringOverride = ValueStringOverride?.ToXmlString();
             answer.Status = Status?.ToXmlString();
 #endif
+
+            if (answer.Status == null)
+            {
+                throw new NullReferenceException("Status property is required.");
+            }
 
             return answer;
         }

--- a/Notifications/Microsoft.Toolkit.Uwp.Notifications.Shared/Adaptive/Elements/Element_AdaptiveProgressBar.cs
+++ b/Notifications/Microsoft.Toolkit.Uwp.Notifications.Shared/Adaptive/Elements/Element_AdaptiveProgressBar.cs
@@ -12,7 +12,7 @@
 
 namespace Microsoft.Toolkit.Uwp.Notifications.Adaptive.Elements
 {
-    [NotificationXmlElement("progressBar")]
+    [NotificationXmlElement("progress")]
     internal sealed class Element_AdaptiveProgressBar : IElement_ToastBindingChild
     {
         [NotificationXmlAttribute("value")]

--- a/UnitTests/UnitTests.Notifications.Shared/Test_Toast_Xml.cs
+++ b/UnitTests/UnitTests.Notifications.Shared/Test_Toast_Xml.cs
@@ -1541,41 +1541,46 @@ namespace UnitTests.Notifications
         [TestMethod]
         public void Test_Toast_ProgressBar_Value()
         {
-            AssertProgressBar("<progressBar value='0'/>", new AdaptiveProgressBar());
+            AssertProgressBar("<progress value='0' status='Downloading...'/>", new AdaptiveProgressBar() { Status = "Downloading..." });
 
             // Only non-WinRT supports implicit converters
 #if !WINRT
-            AssertProgressBar("<progressBar value='0.3'/>", new AdaptiveProgressBar()
+            AssertProgressBar("<progress value='0.3' status='Downloading...'/>", new AdaptiveProgressBar()
             {
-                Value = 0.3
+                Value = 0.3,
+                Status = "Downloading..."
             });
 #endif
 
-            AssertProgressBar("<progressBar value='0.3'/>", new AdaptiveProgressBar()
+            AssertProgressBar("<progress value='0.3' status='Downloading...'/>", new AdaptiveProgressBar()
             {
-                Value = AdaptiveProgressBarValue.FromValue(0.3)
+                Value = AdaptiveProgressBarValue.FromValue(0.3),
+                Status = "Downloading..."
             });
-            AssertProgressBar("<progressBar value='indeterminate'/>", new AdaptiveProgressBar()
+            AssertProgressBar("<progress value='indeterminate' status='Downloading...'/>", new AdaptiveProgressBar()
             {
-                Value = AdaptiveProgressBarValue.Indeterminate
+                Value = AdaptiveProgressBarValue.Indeterminate,
+                Status = "Downloading..."
             });
-            AssertProgressBar("<progressBar value='{progressValue}'/>", new AdaptiveProgressBar()
+            AssertProgressBar("<progress value='{progressValue}' status='Downloading...'/>", new AdaptiveProgressBar()
             {
 #if WINRT
                 Bindings =
                 {
                     { AdaptiveProgressBarBindableProperty.Value, "progressValue" }
-                }
+                },
 #else
-                Value = new BindableProgressBarValue("progressValue")
+                Value = new BindableProgressBarValue("progressValue"),
 #endif
+                Status = "Downloading..."
             });
 
             try
             {
                 new AdaptiveProgressBar()
                 {
-                    Value = AdaptiveProgressBarValue.FromValue(-4)
+                    Value = AdaptiveProgressBarValue.FromValue(-4),
+                    Status = "Downloading..."
                 };
                 Assert.Fail("Exception should have been thrown, only values 0-1 allowed");
             }
@@ -1585,7 +1590,8 @@ namespace UnitTests.Notifications
             {
                 new AdaptiveProgressBar()
                 {
-                    Value = AdaptiveProgressBarValue.FromValue(1.3)
+                    Value = AdaptiveProgressBarValue.FromValue(1.3),
+                    Status = "Downloading..."
                 };
                 Assert.Fail("Exception should have been thrown, only values 0-1 allowed");
             }
@@ -1597,24 +1603,32 @@ namespace UnitTests.Notifications
         {
             // There is NOT an escape string. Guidance to developers is if you're using data binding,
             // use data binding for ALL your user-generated strings.
-            AssertProgressBar("<progressBar value='0' title='{I like tacos}'/>", new AdaptiveProgressBar()
+            AssertProgressBar("<progress value='0' title='{I like tacos}' status='Downloading...'/>", new AdaptiveProgressBar()
             {
-                Title = "{I like tacos}"
+                Title = "{I like tacos}",
+                Status = "Downloading..."
             });
         }
 
         [TestMethod]
         public void Test_Toast_ProgressBar()
         {
-            AssertProgressBar("<progressBar value='0.3' title='Katy Perry' valueStringOverride='3/10 songs' status='Downloading...'/>", new AdaptiveProgressBar()
+            try
+            {
+                AssertProgressBar("Exception should be thrown", new AdaptiveProgressBar());
+                Assert.Fail("Exception should have been thrown, Status property is required");
+            }
+            catch (NullReferenceException) { }
+
+            AssertProgressBar("<progress value='0.3' title='Katy Perry' valueStringOverride='3/10 songs' status='Adding music...'/>", new AdaptiveProgressBar()
             {
                 Value = AdaptiveProgressBarValue.FromValue(0.3),
                 Title = "Katy Perry",
                 ValueStringOverride = "3/10 songs",
-                Status = "Downloading..."
+                Status = "Adding music..."
             });
 
-            AssertProgressBar("<progressBar value='{progressValue}' title='{progressTitle}' valueStringOverride='{progressValueOverride}' status='{progressStatus}'/>", new AdaptiveProgressBar()
+            AssertProgressBar("<progress value='{progressValue}' title='{progressTitle}' valueStringOverride='{progressValueOverride}' status='{progressStatus}'/>", new AdaptiveProgressBar()
             {
 #if WINRT
                 Bindings =
@@ -1632,12 +1646,12 @@ namespace UnitTests.Notifications
 #endif
             });
 
-            AssertProgressBar("<progressBar value='0'/>", new AdaptiveProgressBar()
+            AssertProgressBar("<progress value='0' status='Downloading...'/>", new AdaptiveProgressBar()
             {
                 Value = null,
                 Title = null,
                 ValueStringOverride = null,
-                Status = null
+                Status = "Downloading..."
             });
         }
 


### PR DESCRIPTION
The toast progress bar -> XML code had a few mistakes due to us adding this element early before things were finalized for the Creators Update :)

* XML element should be <progress> rather than <progressBar>
* Status is a required property

I've made these changes to the code and the tests, and also validated that you can successfully send a progress bar toast on the latest Insider build using the Notifications DLL with these changes.