### PR TITLE
Fix toast displayTimestamp from including too many decimals

### DIFF
--- a/Notifications/Microsoft.Toolkit.Uwp.Notifications.Shared/Toasts/ToastContent.cs
+++ b/Notifications/Microsoft.Toolkit.Uwp.Notifications.Shared/Toasts/ToastContent.cs
@@ -110,13 +110,23 @@ namespace Microsoft.Toolkit.Uwp.Notifications
                 }
             }
 
+            DateTimeOffset? strippedDisplayTimestamp = null;
+            if (DisplayTimestamp != null)
+            {
+                // We need to make sure we don't include more than 3 decimal points on seconds
+                // The Millisecond value itself is limited to 3 decimal points, thus by doing the following
+                // we bypass the more granular value that can come from Ticks and ensure we only have 3 decimals at most.
+                var val = DisplayTimestamp.Value;
+                strippedDisplayTimestamp = new DateTimeOffset(val.Year, val.Month, val.Day, val.Hour, val.Minute, val.Second, val.Millisecond, val.Offset);
+            }
+
             var toast = new Element_Toast()
             {
                 ActivationType = Element_Toast.ConvertActivationType(ActivationType),
                 Duration = Duration,
                 Launch = Launch,
                 Scenario = Scenario,
-                DisplayTimestamp = DisplayTimestamp
+                DisplayTimestamp = strippedDisplayTimestamp
             };
 
             ActivationOptions?.PopulateElement(toast);

--- a/UnitTests/UnitTests.Notifications.Shared/Test_Toast_Xml.cs
+++ b/UnitTests/UnitTests.Notifications.Shared/Test_Toast_Xml.cs
@@ -1310,6 +1310,15 @@ namespace UnitTests.Notifications
             {
                 DisplayTimestamp = new DateTimeOffset(2016, 10, 19, 9, 0, 0, TimeSpan.FromHours(-8))
             });
+
+            // If devs use DateTime.Now, or directly use ticks (like this code), they can actually end up with a seconds decimal
+            // value that is more than 3 decimal places. The platform notification parser will fail if there are
+            // more than three decimal places. Hence this test normally would produce "2017-04-04T10:28:34.7047925Z"
+            // but we've added code to ensure it strips to only at most 3 decimal places.
+            AssertPayload("<toast displayTimestamp='2017-04-04T10:28:34.704Z' />", new ToastContent()
+            {
+                DisplayTimestamp = new DateTimeOffset(636268985147047925, TimeSpan.FromHours(0))
+            });
         }
 
         [TestMethod]


### PR DESCRIPTION
Limit it to 3 decimal places, otherwise the toast breaks when sent to the notification platform.

#1073 