### PR TITLE
add tap handler for rangeselector and move the closest thumb to position

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/RangeSelector/RangeSelector.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/RangeSelector/RangeSelector.cs
@@ -11,6 +11,7 @@
 // ******************************************************************
 
 using System;
+using System.Diagnostics;
 using Windows.System;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -130,6 +131,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             if (_containerCanvas != null)
             {
                 _containerCanvas.SizeChanged -= ContainerCanvas_SizeChanged;
+                _containerCanvas.Tapped -= ContainerCanvas_Tapped;
             }
 
             IsEnabledChanged -= RangeSelector_IsEnabledChanged;
@@ -173,6 +175,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 _containerCanvas.SizeChanged += ContainerCanvas_SizeChanged;
                 _containerCanvas.PointerEntered += ContainerCanvas_PointerEntered;
                 _containerCanvas.PointerExited += ContainerCanvas_PointerExited;
+                _containerCanvas.Tapped += ContainerCanvas_Tapped;
             }
 
             VisualStateManager.GoToState(this, IsEnabled ? "Normal" : "Disabled", false);
@@ -294,6 +297,23 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         private void ContainerCanvas_SizeChanged(object sender, SizeChangedEventArgs e)
         {
             SyncThumbs();
+        }
+
+        private void ContainerCanvas_Tapped(object sender, TappedRoutedEventArgs e)
+        {
+            var position = e.GetPosition(_containerCanvas).X;
+            var tappedValue = position * Math.Abs(Maximum - Minimum) / _containerCanvas.ActualWidth;
+            double upperValueDiff = Math.Abs(RangeMax - tappedValue);
+            double lowerValueDiff = Math.Abs(RangeMin - tappedValue);
+
+            if (upperValueDiff < lowerValueDiff)
+            {
+                RangeMax = tappedValue;
+            }
+            else
+            {
+                RangeMin = tappedValue;
+            }
         }
 
         private void VerifyValues()

--- a/Microsoft.Toolkit.Uwp.UI.Controls/RangeSelector/RangeSelector.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/RangeSelector/RangeSelector.cs
@@ -170,6 +170,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
             IsEnabledChanged += RangeSelector_IsEnabledChanged;
 
+            if (IsTouchOptimized)
+            {
+                ArrangeForTouch();
+            }
+
             base.OnApplyTemplate();
         }
 

--- a/Microsoft.Toolkit.Uwp.UI.Controls/RangeSelector/RangeSelector.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/RangeSelector/RangeSelector.cs
@@ -103,14 +103,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// </summary>
         protected override void OnApplyTemplate()
         {
-            if (_outOfRangeContentContainer != null)
-            {
-                _outOfRangeContentContainer.PointerPressed -= OutOfRangeContentContainer_PointerPressed;
-                _outOfRangeContentContainer.PointerMoved -= OutOfRangeContentContainer_PointerMoved;
-                _outOfRangeContentContainer.PointerReleased -= OutOfRangeContentContainer_PointerReleased;
-                _outOfRangeContentContainer.PointerExited -= OutOfRangeContentContainer_PointerExited;
-            }
-
             if (_minThumb != null)
             {
                 _minThumb.DragCompleted -= Thumb_DragCompleted;
@@ -130,7 +122,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             if (_containerCanvas != null)
             {
                 _containerCanvas.SizeChanged -= ContainerCanvas_SizeChanged;
-                _containerCanvas.Tapped -= ContainerCanvas_Tapped;
+                _containerCanvas.PointerPressed -= ContainerCanvas_PointerPressed;
+                _containerCanvas.PointerMoved -= ContainerCanvas_PointerMoved;
+                _containerCanvas.PointerReleased -= ContainerCanvas_PointerReleased;
+                _containerCanvas.PointerExited -= ContainerCanvas_PointerExited;
             }
 
             IsEnabledChanged -= RangeSelector_IsEnabledChanged;
@@ -144,14 +139,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             _minThumb = GetTemplateChild("MinThumb") as Thumb;
             _maxThumb = GetTemplateChild("MaxThumb") as Thumb;
             _containerCanvas = GetTemplateChild("ContainerCanvas") as Canvas;
-
-            if (_outOfRangeContentContainer != null)
-            {
-                _outOfRangeContentContainer.PointerPressed += OutOfRangeContentContainer_PointerPressed;
-                _outOfRangeContentContainer.PointerMoved += OutOfRangeContentContainer_PointerMoved;
-                _outOfRangeContentContainer.PointerReleased += OutOfRangeContentContainer_PointerReleased;
-                _outOfRangeContentContainer.PointerExited += OutOfRangeContentContainer_PointerExited;
-            }
 
             if (_minThumb != null)
             {
@@ -173,8 +160,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             {
                 _containerCanvas.SizeChanged += ContainerCanvas_SizeChanged;
                 _containerCanvas.PointerEntered += ContainerCanvas_PointerEntered;
+                _containerCanvas.PointerPressed += ContainerCanvas_PointerPressed;
+                _containerCanvas.PointerMoved += ContainerCanvas_PointerMoved;
+                _containerCanvas.PointerReleased += ContainerCanvas_PointerReleased;
                 _containerCanvas.PointerExited += ContainerCanvas_PointerExited;
-                _containerCanvas.Tapped += ContainerCanvas_Tapped;
             }
 
             VisualStateManager.GoToState(this, IsEnabled ? "Normal" : "Disabled", false);
@@ -214,20 +203,35 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             }
         }
 
-        private void ContainerCanvas_PointerExited(object sender, PointerRoutedEventArgs e)
-        {
-            VisualStateManager.GoToState(this, "Normal", false);
-        }
-
         private void ContainerCanvas_PointerEntered(object sender, PointerRoutedEventArgs e)
         {
             VisualStateManager.GoToState(this, "PointerOver", false);
         }
 
-        private void OutOfRangeContentContainer_PointerExited(object sender, PointerRoutedEventArgs e)
+        private void ContainerCanvas_PointerExited(object sender, PointerRoutedEventArgs e)
+        {            
+            var position = e.GetCurrentPoint(_containerCanvas).Position.X;
+            var normalizedPosition = ((position / _containerCanvas.ActualWidth) * (Maximum - Minimum)) + Minimum;
+
+            if (_pointerManipulatingMin)
+            {
+                _pointerManipulatingMin = false;
+                _containerCanvas.IsHitTestVisible = true;
+                ValueChanged?.Invoke(this, new RangeChangedEventArgs(RangeMin, normalizedPosition, RangeSelectorProperty.MinimumValue));
+            }
+            else if (_pointerManipulatingMax)
+            {
+                _pointerManipulatingMax = false;
+                _containerCanvas.IsHitTestVisible = true;
+                ValueChanged?.Invoke(this, new RangeChangedEventArgs(RangeMax, normalizedPosition, RangeSelectorProperty.MaximumValue));
+            }
+            VisualStateManager.GoToState(this, "Normal", false);
+        }
+
+        private void ContainerCanvas_PointerReleased(object sender, PointerRoutedEventArgs e)
         {
-            var position = e.GetCurrentPoint(_outOfRangeContentContainer).Position.X;
-            var normalizedPosition = ((position / _outOfRangeContentContainer.ActualWidth) * (Maximum - Minimum)) + Minimum;
+            var position = e.GetCurrentPoint(_containerCanvas).Position.X;
+            var normalizedPosition = ((position / _containerCanvas.ActualWidth) * (Maximum - Minimum)) + Minimum;
 
             if (_pointerManipulatingMin)
             {
@@ -243,29 +247,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             }
         }
 
-        private void OutOfRangeContentContainer_PointerReleased(object sender, PointerRoutedEventArgs e)
+        private void ContainerCanvas_PointerMoved(object sender, PointerRoutedEventArgs e)
         {
-            var position = e.GetCurrentPoint(_outOfRangeContentContainer).Position.X;
-            var normalizedPosition = ((position / _outOfRangeContentContainer.ActualWidth) * (Maximum - Minimum)) + Minimum;
-
-            if (_pointerManipulatingMin)
-            {
-                _pointerManipulatingMin = false;
-                _containerCanvas.IsHitTestVisible = true;
-                ValueChanged?.Invoke(this, new RangeChangedEventArgs(RangeMin, normalizedPosition, RangeSelectorProperty.MinimumValue));
-            }
-            else if (_pointerManipulatingMax)
-            {
-                _pointerManipulatingMax = false;
-                _containerCanvas.IsHitTestVisible = true;
-                ValueChanged?.Invoke(this, new RangeChangedEventArgs(RangeMax, normalizedPosition, RangeSelectorProperty.MaximumValue));
-            }
-        }
-
-        private void OutOfRangeContentContainer_PointerMoved(object sender, PointerRoutedEventArgs e)
-        {
-            var position = e.GetCurrentPoint(_outOfRangeContentContainer).Position.X;
-            var normalizedPosition = ((position / _outOfRangeContentContainer.ActualWidth) * (Maximum - Minimum)) + Minimum;
+            var position = e.GetCurrentPoint(_containerCanvas).Position.X;
+            var normalizedPosition = ((position / _containerCanvas.ActualWidth) * (Maximum - Minimum)) + Minimum;
 
             if (_pointerManipulatingMin && normalizedPosition < RangeMax)
             {
@@ -277,42 +262,28 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             }
         }
 
-        private void OutOfRangeContentContainer_PointerPressed(object sender, PointerRoutedEventArgs e)
+        private void ContainerCanvas_PointerPressed(object sender, PointerRoutedEventArgs e)
         {
-            var position = e.GetCurrentPoint(_outOfRangeContentContainer).Position.X;
-            var normalizedPosition = ((position / _outOfRangeContentContainer.ActualWidth) * (Maximum - Minimum)) + Minimum;
-            if (normalizedPosition < RangeMin)
+            var position = e.GetCurrentPoint(_containerCanvas).Position.X;
+            var normalizedPosition = position * Math.Abs(Maximum - Minimum) / _containerCanvas.ActualWidth;
+            double upperValueDiff = Math.Abs(RangeMax - normalizedPosition);
+            double lowerValueDiff = Math.Abs(RangeMin - normalizedPosition);
+
+            if (upperValueDiff < lowerValueDiff)
             {
-                _pointerManipulatingMin = true;
-                _containerCanvas.IsHitTestVisible = false;
-            }
-            else if (normalizedPosition > RangeMax)
-            {
+                RangeMax = normalizedPosition;
                 _pointerManipulatingMax = true;
-                _containerCanvas.IsHitTestVisible = false;
+            }
+            else
+            {
+                RangeMin = normalizedPosition;
+                _pointerManipulatingMin = true;
             }
         }
 
         private void ContainerCanvas_SizeChanged(object sender, SizeChangedEventArgs e)
         {
             SyncThumbs();
-        }
-
-        private void ContainerCanvas_Tapped(object sender, TappedRoutedEventArgs e)
-        {
-            var position = e.GetPosition(_containerCanvas).X;
-            var tappedValue = position * Math.Abs(Maximum - Minimum) / _containerCanvas.ActualWidth;
-            double upperValueDiff = Math.Abs(RangeMax - tappedValue);
-            double lowerValueDiff = Math.Abs(RangeMin - tappedValue);
-
-            if (upperValueDiff < lowerValueDiff)
-            {
-                RangeMax = tappedValue;
-            }
-            else
-            {
-                RangeMin = tappedValue;
-            }
         }
 
         private void VerifyValues()

--- a/Microsoft.Toolkit.Uwp.UI.Controls/RangeSelector/RangeSelector.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/RangeSelector/RangeSelector.cs
@@ -11,7 +11,6 @@
 // ******************************************************************
 
 using System;
-using System.Diagnostics;
 using Windows.System;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;


### PR DESCRIPTION
This is a suggestion, because I noticed that the native slider supports this functionality, when you tap/click somewhere inside the slider area the thumb is moved to this position. I added a tap event handler, it moves the closest thumb to the tap position.