### PR TITLE
Add MarkdownTextBlock.ResolveImage event

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/Display/IImageResolver.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/Display/IImageResolver.cs
@@ -1,0 +1,24 @@
+﻿// ******************************************************************
+// Copyright (c) Microsoft. All rights reserved.
+// This code is licensed under the MIT License (MIT).
+// THE CODE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH
+// THE CODE OR THE USE OR OTHER DEALINGS IN THE CODE.
+// ******************************************************************
+
+using Windows.UI.Xaml.Media;
+
+namespace Microsoft.Toolkit.Uwp.UI.Controls.Markdown.Display
+{
+    /// <summary>
+    /// An internal interface used to resolve images in the markdown.
+    /// </summary>
+    internal interface IImageResolver
+    {
+        ImageSource ResolveImage(string url, string tooltip);
+    }
+}

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/Display/IImageResolver.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/Display/IImageResolver.cs
@@ -10,6 +10,7 @@
 // THE CODE OR THE USE OR OTHER DEALINGS IN THE CODE.
 // ******************************************************************
 
+using System.Threading.Tasks;
 using Windows.UI.Xaml.Media;
 
 namespace Microsoft.Toolkit.Uwp.UI.Controls.Markdown.Display
@@ -19,6 +20,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls.Markdown.Display
     /// </summary>
     internal interface IImageResolver
     {
-        ImageSource ResolveImage(string url, string tooltip);
+        Task<ImageSource> ResolveImageAsync(string url, string tooltip);
     }
 }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/Display/XamlRenderer.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/Display/XamlRenderer.cs
@@ -912,7 +912,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls.Markdown.Display
         {
             var placeholder = RenderTextRun(inlineCollection, new TextRunInline { Text = element.Text, Type = MarkdownInlineType.TextRun }, context);
 
-            var resolvedImage = await this._imageResolver.ResolveImageAsync(element.Url, element.Tooltip);
+            var resolvedImage = await _imageResolver.ResolveImageAsync(element.Url, element.Tooltip);
 
             // if image can not be resolved we have to return
             if (resolvedImage == null)

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/MarkdownTextBlock.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/MarkdownTextBlock.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// Fired when an image from the markdown document needs to be resolved.
         /// The default implementation is basically <code>new BitmapImage(new Uri(e.Url));</code>.
         /// </summary>
-        public event EventHandler<ResolveImageEventArgs> ResolveImage;
+        public event EventHandler<ImageResolveEventArgs> ImageResolving;
 
         /// <summary>
         /// Gets the dependency property for <see cref="ImageStretch"/>.
@@ -1242,8 +1242,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// </summary>
         async Task<ImageSource> IImageResolver.ResolveImageAsync(string url, string tooltip)
         {
-            var eventArgs = new ResolveImageEventArgs(url, tooltip);
-            ResolveImage?.Invoke(this, eventArgs);
+            var eventArgs = new ImageResolveEventArgs(url, tooltip);
+            this.ImageResolving?.Invoke(this, eventArgs);
 
             await eventArgs.WaitForDeferrals();
 

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/MarkdownTextBlock.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/MarkdownTextBlock.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// Fired when an image from the markdown document needs to be resolved.
         /// The default implementation is basically <code>new BitmapImage(new Uri(e.Url));</code>.
         /// </summary>
-        public event EventHandler<ImageResolveEventArgs> ImageResolving;
+        public event EventHandler<ImageResolvingEventArgs> ImageResolving;
 
         /// <summary>
         /// Gets the dependency property for <see cref="ImageStretch"/>.
@@ -1242,8 +1242,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// </summary>
         async Task<ImageSource> IImageResolver.ResolveImageAsync(string url, string tooltip)
         {
-            var eventArgs = new ImageResolveEventArgs(url, tooltip);
-            this.ImageResolving?.Invoke(this, eventArgs);
+            var eventArgs = new ImageResolvingEventArgs(url, tooltip);
+            ImageResolving?.Invoke(this, eventArgs);
 
             await eventArgs.WaitForDeferrals();
 

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/MarkdownTextBlock.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/MarkdownTextBlock.cs
@@ -12,6 +12,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.Toolkit.Uwp.UI.Controls.Markdown.Display;
 using Microsoft.Toolkit.Uwp.UI.Controls.Markdown.Helpers;
 using Microsoft.Toolkit.Uwp.UI.Controls.Markdown.Parse;
@@ -1239,13 +1240,15 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// <summary>
         /// Called when the renderer needs to display a image.
         /// </summary>
-        ImageSource IImageResolver.ResolveImage(string url, string tooltip)
+        async Task<ImageSource> IImageResolver.ResolveImageAsync(string url, string tooltip)
         {
             var eventArgs = new ResolveImageEventArgs(url, tooltip);
             ResolveImage?.Invoke(this, eventArgs);
 
-            return eventArgs.Handled 
-                ? eventArgs.Image 
+            await eventArgs.WaitForDeferrals();
+
+            return eventArgs.Handled
+                ? eventArgs.Image
                 : new BitmapImage(new Uri(url));
         }
     }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/ResolveMarkdownImageEventArgs.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/ResolveMarkdownImageEventArgs.cs
@@ -22,15 +22,15 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
     /// <summary>
     /// Arguments for the <see cref="MarkdownTextBlock.ImageResolving"/> event which is called when a url needs to be resolved to a <see cref="ImageSource"/>.
     /// </summary>
-    public class ImageResolveEventArgs : EventArgs
+    public class ImageResolvingEventArgs : EventArgs
     {
         private readonly IList<TaskCompletionSource<object>> _deferrals;
 
-        internal ImageResolveEventArgs(string url, string tooltip)
+        internal ImageResolvingEventArgs(string url, string tooltip)
         {
-            this._deferrals = new List<TaskCompletionSource<object>>();
-            this.Url = url;
-            this.Tooltip = tooltip;
+            _deferrals = new List<TaskCompletionSource<object>>();
+            Url = url;
+            Tooltip = tooltip;
         }
 
         /// <summary>
@@ -59,7 +59,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         public Deferral GetDeferral()
         {
             var task = new TaskCompletionSource<object>();
-            this._deferrals.Add(task);
+            _deferrals.Add(task);
 
             return new Deferral(() =>
             {
@@ -72,7 +72,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// </summary>
         internal Task WaitForDeferrals()
         {
-            return Task.WhenAll(this._deferrals.Select(f => f.Task));
+            return Task.WhenAll(_deferrals.Select(f => f.Task));
         }
     }
 }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/ResolveMarkdownImageEventArgs.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/ResolveMarkdownImageEventArgs.cs
@@ -1,0 +1,49 @@
+﻿// ******************************************************************
+// Copyright (c) Microsoft. All rights reserved.
+// This code is licensed under the MIT License (MIT).
+// THE CODE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH
+// THE CODE OR THE USE OR OTHER DEALINGS IN THE CODE.
+// ******************************************************************
+
+using System;
+using Windows.UI.Xaml.Media;
+
+namespace Microsoft.Toolkit.Uwp.UI.Controls
+{
+    /// <summary>
+    /// Arguments for the <see cref="MarkdownTextBlock.ResolveImage"/> event which is called when a url needs to be resolved to a <see cref="ImageSource"/>.
+    /// </summary>
+    public class ResolveImageEventArgs : EventArgs
+    {
+        internal ResolveImageEventArgs(string url, string tooltip)
+        {
+            this.Url = url;
+            this.Tooltip = tooltip;
+        }
+
+        /// <summary>
+        /// Gets the url of the image in the markdown document.
+        /// </summary>
+        public string Url { get; }
+
+        /// <summary>
+        /// Gets the tooltip of the image in the markdown document.
+        /// </summary>
+        public string Tooltip { get; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this event was handled successfully.
+        /// </summary>
+        public bool Handled { get; set; }
+
+        /// <summary>
+        /// Gets or sets the image to display in the <see cref="MarkdownTextBlock"/>.
+        /// </summary>
+        public ImageSource Image { get; set; }
+    }
+}

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/ResolveMarkdownImageEventArgs.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/ResolveMarkdownImageEventArgs.cs
@@ -20,13 +20,13 @@ using Windows.UI.Xaml.Media;
 namespace Microsoft.Toolkit.Uwp.UI.Controls
 {
     /// <summary>
-    /// Arguments for the <see cref="MarkdownTextBlock.ResolveImage"/> event which is called when a url needs to be resolved to a <see cref="ImageSource"/>.
+    /// Arguments for the <see cref="MarkdownTextBlock.ImageResolving"/> event which is called when a url needs to be resolved to a <see cref="ImageSource"/>.
     /// </summary>
-    public class ResolveImageEventArgs : EventArgs
+    public class ImageResolveEventArgs : EventArgs
     {
         private readonly IList<TaskCompletionSource<object>> _deferrals;
 
-        internal ResolveImageEventArgs(string url, string tooltip)
+        internal ImageResolveEventArgs(string url, string tooltip)
         {
             this._deferrals = new List<TaskCompletionSource<object>>();
             this.Url = url;

--- a/Microsoft.Toolkit.Uwp.UI.Controls/Microsoft.Toolkit.Uwp.UI.Controls.csproj
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/Microsoft.Toolkit.Uwp.UI.Controls.csproj
@@ -73,6 +73,7 @@
     <Compile Include="HamburgerMenu\MenuItems\HamburgerMenuImageItem.cs" />
     <Compile Include="HeaderedTextBlock\HeaderedTextBlock.cs" />
     <Compile Include="HeaderedTextBlock\HeaderedTextBlock.Properties.cs" />
+    <Compile Include="MarkdownTextBlock\Display\IImageResolver.cs" />
     <Compile Include="ImageEx\ImageExBase.Placeholder.cs" />
     <Compile Include="ImageEx\ImageExBase.Source.cs" />
     <Compile Include="ImageEx\ImageExBase.cs" />
@@ -111,6 +112,7 @@
     <Compile Include="MarkdownTextBlock\Parse\MarkdownDocument.cs" />
     <Compile Include="MarkdownTextBlock\Parse\MarkdownElement.cs" />
     <Compile Include="MarkdownTextBlock\Parse\MarkdownInline.cs" />
+    <Compile Include="MarkdownTextBlock\ResolveMarkdownImageEventArgs.cs" />
     <Compile Include="MasterDetailsView\MasterDetailsView.cs" />
     <Compile Include="MasterDetailsView\MasterDetailsView.Events.cs" />
     <Compile Include="MasterDetailsView\MasterDetailsView.Properties.cs" />

--- a/Microsoft.Toolkit.Uwp.UI.Controls/project.json
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/project.json
@@ -1,6 +1,7 @@
 ﻿{
   "dependencies": {
     "Microsoft.NETCore.UniversalWindowsPlatform": "5.1.0",
+    "Microsoft.Xaml.Behaviors.Uwp.Managed": "1.1.0",
     "Robmikh.CompositionSurfaceFactory": "0.7.1",
     "StyleCop.Analyzers": "1.0.0"
   },

--- a/docs/controls/MarkdownTextBlock.md
+++ b/docs/controls/MarkdownTextBlock.md
@@ -80,15 +80,15 @@ The MarkdownTextBlock control is highly customizable to blend with any theme. Cu
 
 ## Events
 
-### ResolveImage
+### ImageResolving
 
 Use this event to customize how images in the markdown document are resolved.  
 
-Set the ResolveImageEventArgs.Image property to the image that should be shown in the rendered markdown document.  
-Also don't forget to set the ResolveImageEventArgs.Handled flag to true, otherwise your own image will not be used.
+Set the ImageResolvingEventArgs.Image property to the image that should be shown in the rendered markdown document.  
+Also don't forget to set the ImageResolvingEventArgs.Handled flag to true, otherwise your custom image will not be used.
 
 ```c#
-private void MarkdownText_OnResolveImage(object sender, ResolveImageEventArgs e)
+private void MarkdownText_OnImageResolving(object sender, ImageResolvingEventArgs e)
 {
     // This is basically the default implementation
     e.Image = new BitmapImage(new Uri(e.Url));
@@ -100,7 +100,7 @@ This event also supports loading the image in an asynchronous way.
 Just request a Deferral which you complete when you're done.
 
 ```c#
-private async void MarkdownText_OnResolveImage(object sender, ResolveImageEventArgs e)
+private async void MarkdownText_OnImageResolving(object sender, ImageResolvingEventArgs e)
 {
     var deferral = e.GetDeferral();
 

--- a/docs/controls/MarkdownTextBlock.md
+++ b/docs/controls/MarkdownTextBlock.md
@@ -78,6 +78,40 @@ The MarkdownTextBlock control is highly customizable to blend with any theme. Cu
 * TableMargin
 * TextWrapping
 
+## Events
+
+### ResolveImage
+
+Use this event to customize how images in the markdown document are resolved.  
+
+Set the ResolveImageEventArgs.Image property to the image that should be shown in the rendered markdown document.  
+Also don't forget to set the ResolveImageEventArgs.Handled flag to true, otherwise your own image will not be used.
+
+```c#
+private void MarkdownText_OnResolveImage(object sender, ResolveImageEventArgs e)
+{
+    // This is basically the default implementation
+    e.Image = new BitmapImage(new Uri(e.Url));
+    e.Handled = true;
+}
+```
+
+This event also supports loading the image in an asynchronous way.  
+Just request a Deferral which you complete when you're done.
+
+```c#
+private async void MarkdownText_OnResolveImage(object sender, ResolveImageEventArgs e)
+{
+    var deferral = e.GetDeferral();
+
+    e.Image = await GetImageFromDatabaseAsync(e.Url);
+    e.Handled = true;
+
+    deferral.Complete();
+}
+```
+
+
 ## Example Code
 
 [MarkdownTextBlock Sample Page](../../Microsoft.Toolkit.Uwp.SampleApp/SamplePages/MarkdownTextBlock)


### PR DESCRIPTION
Hi, this is the PR for issue #1092  

There are still 2 things we might change here:
- The name of the event is **ResolveImage**. Is this fine or can we find something that fits better?
- Whether this event should be called for all images, or just for the ones that fail with ```new BitmapImage(new Uri(url));```

Oh, and I just remember another thing:  

Previously it would not try to create the image if the URL started with something else than ```http``` or ```ms-app```.
Right now I have removed that line.  
But that might lead to some errors if you try to load a markdown document with a image that cannot be resolved with ```new BitmapImage(new Uri(url))```.
