### PR TITLE
fix(Expander): set Background to the entire control

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Expander/ExpanderPage.xaml
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Expander/ExpanderPage.xaml
@@ -12,8 +12,10 @@
             <controls:Expander x:Name="Expander1" VerticalAlignment="Top" Margin="0,0,0,10" 
                                Header="This is the header - expander 1"
                                HorizontalContentAlignment="Stretch"
+                               Foreground="White"
+                               Background="{Binding Path=BackgroundExpander1.Value, Mode=TwoWay}"
                                IsExpanded="{Binding Path=IsExpanded1.Value, Mode=TwoWay}">
-                <Grid Height="250" Background="{StaticResource Brush-Grey-01}">
+                <Grid Height="250">
                     <TextBlock HorizontalAlignment="Center" 
                                TextWrapping="Wrap" 
                                Text="This is the content"
@@ -25,8 +27,10 @@
             <controls:Expander x:Name="Expander2" VerticalAlignment="Top" Margin="0" 
                                Header="This is the header - expander 2"
                                HorizontalContentAlignment="Stretch"
+                               Foreground="White"
+                               Background="{Binding Path=BackgroundExpander2.Value, Mode=TwoWay}"
                                IsExpanded="{Binding Path=IsExpanded2.Value, Mode=TwoWay}">
-                <Grid Height="250" Background="{StaticResource Brush-Grey-02}">
+                <Grid Height="250">
                     <TextBlock HorizontalAlignment="Center" 
                                TextWrapping="Wrap" 
                                Text="This is the content" 

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Expander/ExpanderXaml.bind
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Expander/ExpanderXaml.bind
@@ -10,9 +10,11 @@
   <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
     <StackPanel Margin="20">
       <controls:Expander x:Name="Expander1" VerticalAlignment="Top" Margin="0,0,0,10" 
-                               Header="This is the header - expander 1"
-                               IsExpanded="@[IsExpanded1:Bool:False]">
-        <Grid Height="250" Background="#FFF5F1D9">
+                         Header="This is the header - expander 1"
+                         Foreground="White"
+                         Background="@[BackgroundExpander1:Brush:Gray]"
+                         IsExpanded="@[IsExpanded1:Bool:False]">
+        <Grid Height="250">
           <TextBlock HorizontalAlignment="Center"
                      TextWrapping="Wrap"
                      Text="This is the content"
@@ -22,9 +24,11 @@
       </controls:Expander>
 
       <controls:Expander x:Name="Expander2" VerticalAlignment="Top" Margin="0" 
-                               Header="This is the header - expander 2"
-                               IsExpanded="@[IsExpanded2:Bool:True]">
-        <Grid Height="250" Background="#FFD9F1F5">
+                         Header="This is the header - expander 2"
+                         Foreground="White"
+                         Background="@[BackgroundExpander2:Brush:Black]"
+                         IsExpanded="@[IsExpanded2:Bool:True]">
+        <Grid Height="250">
           <TextBlock HorizontalAlignment="Center"
                      TextWrapping="Wrap"
                      Text="This is the content"

--- a/Microsoft.Toolkit.Uwp.UI.Controls/Expander/Expander.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/Expander/Expander.xaml
@@ -326,6 +326,8 @@
                                           AutomationProperties.Name="Expand"
                                           Style="{StaticResource HeaderToggleButtonStyle}" 
                                           VerticalAlignment="Top" HorizontalAlignment="Stretch"
+                                          Foreground="{TemplateBinding Foreground}"
+                                          Background="{TemplateBinding Background}"
                                           ContentTemplate="{TemplateBinding HeaderTemplate}" Content="{TemplateBinding Header}"
                                           IsChecked="{Binding IsExpanded, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}" />
                             

--- a/docs/controls/Expander.md
+++ b/docs/controls/Expander.md
@@ -19,8 +19,10 @@ You can also use these events :
 ```xml
 
 <controls:Expander Header="Header of the expander"
+                   Foreground="White"
+                   Background="Gray"
                    IsExpanded="True">
-	<Grid Height="250" Background="#FFF5F1D9">
+	<Grid Height="250">
         <TextBlock HorizontalAlignment="Center"
                    TextWrapping="Wrap"
                    Text="This is the content"


### PR DESCRIPTION
Linked to #924 

I set the Background so it is used by the entire control. I updated the sample page and the docs too.

So, here is the new behavior of the Background color : 

* cover the entire control (both Header and Content)
* the Content background can be changed if the root UIElement of the Content has a Background
* of course the Header background changed based on VisualStates because it acts as a "button"

I did not updated the VisualStates of the control and I don't know if I have to.