### PR TITLE
Remove AdaptiveGridView padding from width for layout calculation

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveGridView.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveGridView.cs
@@ -222,6 +222,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
         private void RecalculateLayout(double containerWidth)
         {
+            // width should be the displayable width
+            containerWidth = containerWidth - Padding.Left - Padding.Top;
             if (containerWidth > 0)
             {
                 var newWidth = CalculateItemWidth(containerWidth);


### PR DESCRIPTION
Account for the padding when calculating the width of the panel.
Addresses #1078