### PR TITLE
Add method to get translation language names

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Microsoft Translator Service/MicrosoftTranslatorPage.xaml
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Microsoft Translator Service/MicrosoftTranslatorPage.xaml
@@ -31,9 +31,9 @@
             <ComboBox x:Name="Languages"
                       Margin="0,10,0,0"
                       HorizontalAlignment="Stretch"
-                      DisplayMemberPath="Value"
+                      DisplayMemberPath="Name"
                       Header="Target Language:"
-                      SelectedValuePath="Key" />
+                      SelectedValuePath="Code" />
             <Button x:Name="Translate"
                     Margin="0,10,0,0"
                     Click="Translate_OnClick"

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Microsoft Translator Service/MicrosoftTranslatorPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Microsoft Translator Service/MicrosoftTranslatorPage.xaml.cs
@@ -59,26 +59,10 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
             Languages.ItemsSource = null;
 
             _translatorClient.SubscriptionKey = TranslatorServiceKey.Text;
-            var languages = await _translatorClient.GetLanguagesAsync();
+            var languages = await _translatorClient.GetLanguageNamesAsync();
 
-            var dictionary = new Dictionary<string, string>();
-            languages.ToList().ForEach(lang =>
-            {
-                try
-                {
-                    var culture = new CultureInfo(lang);
-                    if (!culture.EnglishName.StartsWith("Unknown"))
-                    {
-                        dictionary.Add(lang, culture.EnglishName);
-                    }
-                }
-                catch
-                {
-                }
-            });
-
-            Languages.ItemsSource = dictionary.OrderBy(d => d.Key);
-            Languages.SelectedValue = dictionary.Keys.FirstOrDefault();
+            Languages.ItemsSource = languages.OrderBy(d => d.Name);
+            Languages.SelectedIndex = 0;
 
             Shell.Current.DisplayWaitRing = false;
         }

--- a/Microsoft.Toolkit.Uwp.Services/Microsoft.Toolkit.Uwp.Services.csproj
+++ b/Microsoft.Toolkit.Uwp.Services/Microsoft.Toolkit.Uwp.Services.csproj
@@ -51,6 +51,7 @@
     <Compile Include="Core\DataProviderBase{TConfig,TSchema}.cs" />
     <Compile Include="Core\ExtensionMethods.cs" />
     <Compile Include="Core\IDataService{T,U,V}.cs" />
+    <Compile Include="Services\MicrosoftTranslator\ServiceLanguage.cs" />
     <Compile Include="Services\Twitter\TwitterStreamCallbacks.cs" />
     <Compile Include="Services\Bing\BingLanguage.cs" />
     <Compile Include="Services\Bing\BingCountry.cs" />

--- a/Microsoft.Toolkit.Uwp.Services/Services/MicrosoftTranslator/ITranslatorService.cs
+++ b/Microsoft.Toolkit.Uwp.Services/Services/MicrosoftTranslator/ITranslatorService.cs
@@ -38,6 +38,15 @@ namespace Microsoft.Toolkit.Uwp.Services.MicrosoftTranslator
         string Language { get; set; }
 
         /// <summary>
+        /// Initializes the <see cref="TranslatorService"/> class by getting an access token for the service.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> that represents the initialize operation.</returns>
+        /// <exception cref="ArgumentNullException">The <see cref="SubscriptionKey"/> property hasn't been set.</exception>
+        /// <exception cref="TranslatorServiceException">The provided <see cref="SubscriptionKey"/> isn't valid or has expired.</exception>
+        /// <remarks>Calling this method isn't mandatory, because the token is get/refreshed everytime is needed. However, it is called at startup, it can speed-up subsequest requests.</remarks>
+        Task InitializeAsync();
+
+        /// <summary>
         /// Detects the language of a text.
         /// </summary>
         /// <param name="text">A string represeting the text whose language must be detected.</param>
@@ -50,7 +59,7 @@ namespace Microsoft.Toolkit.Uwp.Services.MicrosoftTranslator
         /// </exception>
         /// <exception cref="TranslatorServiceException">The provided <see cref="SubscriptionKey"/> isn't valid or has expired.</exception>
         /// <remarks><para>This method performs a non-blocking request for language detection.</para>
-        /// <para>For more information, go to http://msdn.microsoft.com/en-us/library/ff512427.aspx.
+        /// <para>For more information, go to https://docs.microsofttranslator.com/text-translate.html#!/default/get_Detect.
         /// </para></remarks>
         /// <seealso cref="GetLanguagesAsync"/>
         /// <seealso cref="Language"/>
@@ -63,19 +72,24 @@ namespace Microsoft.Toolkit.Uwp.Services.MicrosoftTranslator
         /// <exception cref="ArgumentNullException">The <see cref="SubscriptionKey"/> property hasn't been set.</exception>
         /// <exception cref="TranslatorServiceException">The provided <see cref="SubscriptionKey"/> isn't valid or has expired.</exception>
         /// <remarks><para>This method performs a non-blocking request for language codes.</para>
-        /// <para>For more information, go to http://msdn.microsoft.com/en-us/library/ff512415.aspx.
+        /// <para>For more information, go to https://docs.microsofttranslator.com/text-translate.html#!/default/get_GetLanguagesForTranslate.
         /// </para>
         /// </remarks>
         Task<IEnumerable<string>> GetLanguagesAsync();
 
         /// <summary>
-        /// Initializes the <see cref="TranslatorService"/> class by getting an access token for the service.
+        /// Retrieves friendly names for the languages available for text translation.
         /// </summary>
-        /// <returns>A <see cref="Task"/> that represents the initialize operation.</returns>
+        /// <param name="language">The language used to localize the language names. If the parameter is set to <strong>null</strong>, the language specified in the <seealso cref="Language"/> property will be used.</param>
+        /// <returns>An array of <see cref="ServiceLanguage"/> containing the language codes and names supported for translation by <strong>Microsoft Translator Service</strong>.</returns>
         /// <exception cref="ArgumentNullException">The <see cref="SubscriptionKey"/> property hasn't been set.</exception>
         /// <exception cref="TranslatorServiceException">The provided <see cref="SubscriptionKey"/> isn't valid or has expired.</exception>
-        /// <remarks>Calling this method isn't mandatory, because the token is get/refreshed everytime is needed. However, it is called at startup, it can speed-up subsequest requests.</remarks>
-        Task InitializeAsync();
+        /// <remarks><para>This method performs a non-blocking request for language name.</para>
+        /// <para>For more information, go to https://docs.microsofttranslator.com/text-translate.html#!/default/post_GetLanguageNames.
+        /// </para>
+        /// </remarks>
+        /// <see cref="GetLanguagesAsync"/>
+        Task<IEnumerable<ServiceLanguage>> GetLanguageNamesAsync(string language = null);
 
         /// <summary>
         /// Translates a text string into the specified language.
@@ -93,7 +107,7 @@ namespace Microsoft.Toolkit.Uwp.Services.MicrosoftTranslator
         /// <exception cref="ArgumentException">The <paramref name="text"/> parameter is longer than 1000 characters.</exception>
         /// <exception cref="TranslatorServiceException">The provided <see cref="SubscriptionKey"/> isn't valid or has expired.</exception>
         /// <remarks><para>This method perform a non-blocking request for text translation.</para>
-        /// <para>For more information, go to http://msdn.microsoft.com/en-us/library/ff512421.aspx.
+        /// <para>For more information, go to https://docs.microsofttranslator.com/text-translate.html#!/default/get_Translate.
         /// </para>
         /// </remarks>
         /// <seealso cref="Language"/>
@@ -114,7 +128,7 @@ namespace Microsoft.Toolkit.Uwp.Services.MicrosoftTranslator
         /// <exception cref="ArgumentException">The <paramref name="text"/> parameter is longer than 1000 characters.</exception>
         /// <exception cref="TranslatorServiceException">The provided <see cref="SubscriptionKey"/> isn't valid or has expired.</exception>
         /// <remarks><para>This method perform a non-blocking request for text translation.</para>
-        /// <para>For more information, go to http://msdn.microsoft.com/en-us/library/ff512421.aspx.
+        /// <para>For more information, go to https://docs.microsofttranslator.com/text-translate.html#!/default/get_Translate.
         /// </para>
         /// </remarks>
         /// <seealso cref="Language"/>

--- a/Microsoft.Toolkit.Uwp.Services/Services/MicrosoftTranslator/ServiceLanguage.cs
+++ b/Microsoft.Toolkit.Uwp.Services/Services/MicrosoftTranslator/ServiceLanguage.cs
@@ -1,0 +1,47 @@
+﻿// ******************************************************************
+// Copyright (c) Microsoft. All rights reserved.
+// This code is licensed under the MIT License (MIT).
+// THE CODE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH
+// THE CODE OR THE USE OR OTHER DEALINGS IN THE CODE.
+// ******************************************************************
+
+namespace Microsoft.Toolkit.Uwp.Services.MicrosoftTranslator
+{
+    /// <summary>
+    /// Holds information about langagues supported for text translation and speech synthesis.
+    /// </summary>
+    public class ServiceLanguage
+    {
+        /// <summary>
+        /// Gets the language code.
+        /// </summary>
+        public string Code { get; }
+
+        /// <summary>
+        /// Gets the language friendly name.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// Returns the language friendly name.
+        /// </summary>
+        /// <returns>The language friendly name.</returns>
+        public override string ToString() => Name;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ServiceLanguage"/> class, using the specified code and name.
+        /// </summary>
+        /// <param name="code">The language code.</param>
+        /// <param name="name">The language friendly name.</param>
+        public ServiceLanguage(string code, string name)
+        {
+            Code = code;
+            Name = name;
+        }
+    }
+}

--- a/Microsoft.Toolkit.Uwp.Services/Services/MicrosoftTranslator/TranslatorService.cs
+++ b/Microsoft.Toolkit.Uwp.Services/Services/MicrosoftTranslator/TranslatorService.cs
@@ -16,6 +16,8 @@ using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Xml.Linq;
+using Windows.Web.Http;
+using Windows.Web.Http.Headers;
 
 namespace Microsoft.Toolkit.Uwp.Services.MicrosoftTranslator
 {
@@ -33,11 +35,15 @@ namespace Microsoft.Toolkit.Uwp.Services.MicrosoftTranslator
         private const string TranslateUri = "Translate?text={0}&to={1}&contentType=text/plain";
         private const string TranslateWithFromUri = "Translate?text={0}&from={1}&to={2}&contentType=text/plain";
         private const string DetectUri = "Detect?text={0}";
+        private const string LanguageNamesUri = "GetLanguageNames?locale={0}";
         private const string AuthorizationUri = "Authorization";
 
         private const string ArrayNamespace = "http://schemas.microsoft.com/2003/10/Serialization/Arrays";
+        private const string ArrayOfStringXmlElement = "ArrayOfstring";
+        private const string StringXmlElement = "string";
+        private const string XmlContentType = "text/xml";
 
-        private const int _maxTextLenght = 1000;
+        private const int _maxTextLength = 1000;
         private const int _MaxTextLengthForAutoDetection = 100;
 
         /// <summary>
@@ -87,13 +93,55 @@ namespace Microsoft.Toolkit.Uwp.Services.MicrosoftTranslator
         public string Language { get; set; }
 
         /// <summary>
+        /// Detects the language of a text.
+        /// </summary>
+        /// <param name="text">A string represeting the text whose language must be detected.</param>
+        /// <returns>A string containing a two-character Language code for the given text.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// <list type="bullet">
+        /// <term>The <see cref="SubscriptionKey"/> property hasn't been set.</term>
+        /// <term>The <paramref name="text"/> parameter is <strong>null</strong> (<strong>Nothing</strong> in Visual Basic) or empty.</term>
+        /// </list>
+        /// </exception>
+        /// <exception cref="TranslatorServiceException">The provided <see cref="SubscriptionKey"/> isn't valid or has expired.</exception>
+        /// <remarks><para>This method performs a non-blocking request for language detection.</para>
+        /// <para>For more information, go to https://docs.microsofttranslator.com/text-translate.html#!/default/get_Detect.
+        /// </para></remarks>
+        /// <seealso cref="GetLanguagesAsync"/>
+        public async Task<string> DetectLanguageAsync(string text)
+        {
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                throw new ArgumentNullException(nameof(text));
+            }
+
+            text = text.Substring(0, Math.Min(text.Length, _MaxTextLengthForAutoDetection));
+
+            // Checks if it is necessary to obtain/update access token.
+            await CheckUpdateTokenAsync().ConfigureAwait(false);
+
+            var uriString = string.Format(DetectUri, Uri.EscapeDataString(text));
+
+            using (var request = CreateHttpRequest($"{BaseUrl}{uriString}"))
+            {
+                var response = await HttpHelper.Instance.SendRequestAsync(request).ConfigureAwait(false);
+                var content = await response.GetTextResultAsync().ConfigureAwait(false);
+
+                var doc = XDocument.Parse(content);
+                var detectedLanguage = doc.Root.Value;
+
+                return detectedLanguage;
+            }
+        }
+
+        /// <summary>
         /// Retrieves the languages available for translation.
         /// </summary>
         /// <returns>A string array containing the language codes supported for translation by <strong>Microsoft Translator Service</strong>.</returns>
         /// <exception cref="ArgumentNullException">The <see cref="SubscriptionKey"/> property hasn't been set.</exception>
         /// <exception cref="TranslatorServiceException">The provided <see cref="SubscriptionKey"/> isn't valid or has expired.</exception>
         /// <remarks><para>This method performs a non-blocking request for language codes.</para>
-        /// <para>For more information, go to http://msdn.microsoft.com/en-us/library/ff512415.aspx.
+        /// <para>For more information, go to https://docs.microsofttranslator.com/text-translate.html#!/default/get_GetLanguagesForTranslate.
         /// </para>
         /// </remarks>
         public async Task<IEnumerable<string>> GetLanguagesAsync()
@@ -107,9 +155,55 @@ namespace Microsoft.Toolkit.Uwp.Services.MicrosoftTranslator
                 var content = await response.GetTextResultAsync().ConfigureAwait(false);
 
                 XNamespace ns = ArrayNamespace;
-                var doc = XDocument.Parse(content);
+                var xmlContent = XDocument.Parse(content);
 
-                var languages = doc.Root.Elements(ns + "string").Select(s => s.Value);
+                var languages = xmlContent.Root.Elements(ns + "string").Select(s => s.Value);
+                return languages;
+            }
+        }
+
+        /// <summary>
+        /// Retrieves friendly names for the languages available for text translation.
+        /// </summary>
+        /// <param name="language">The language used to localize the language names. If the parameter is set to <strong>null</strong>, the language specified in the <seealso cref="Language"/> property will be used.</param>
+        /// <returns>An array of <see cref="ServiceLanguage"/> containing the language codes and names supported for translation by <strong>Microsoft Translator Service</strong>.</returns>
+        /// <exception cref="ArgumentNullException">The <see cref="SubscriptionKey"/> property hasn't been set.</exception>
+        /// <exception cref="TranslatorServiceException">The provided <see cref="SubscriptionKey"/> isn't valid or has expired.</exception>
+        /// <remarks><para>This method performs a non-blocking request for language name.</para>
+        /// <para>For more information, go to https://docs.microsofttranslator.com/text-translate.html#!/default/post_GetLanguageNames.
+        /// </para>
+        /// </remarks>
+        /// <see cref="GetLanguagesAsync"/>
+        public async Task<IEnumerable<ServiceLanguage>> GetLanguageNamesAsync(string language = null)
+        {
+            var languageCodes = await GetLanguagesAsync();
+
+            if (string.IsNullOrWhiteSpace(language))
+            {
+                language = Language ?? "en";
+            }
+
+            using (var request = CreateHttpRequest(string.Format($"{BaseUrl}{LanguageNamesUri}", language), HttpMethod.Post))
+            {
+                XNamespace ns = ArrayNamespace;
+                var xmlRequest = new XDocument(new XElement(ns + ArrayOfStringXmlElement, from lang in languageCodes select new XElement(ns + StringXmlElement, lang)));
+
+                request.Content = new HttpStringContent(xmlRequest.ToString());
+                request.Content.Headers.ContentType = new HttpMediaTypeHeaderValue(XmlContentType);
+
+                var response = await HttpHelper.Instance.SendRequestAsync(request).ConfigureAwait(false);
+                var content = await response.GetTextResultAsync().ConfigureAwait(false);
+                var xmlContent = XDocument.Parse(content);
+
+                var languageNames = xmlContent.Root.Elements(ns + StringXmlElement).Select(s => s.Value);
+
+                // Creates the response object.
+                var languages = new ServiceLanguage[languageCodes.Count()];
+                for (int i = 0; i < languages.Length; i++)
+                {
+                    languages[i] = new ServiceLanguage(languageCodes.ElementAt(i), languageNames.ElementAt(i));
+                }
+
                 return languages;
             }
         }
@@ -130,7 +224,7 @@ namespace Microsoft.Toolkit.Uwp.Services.MicrosoftTranslator
         /// <exception cref="ArgumentException">The <paramref name="text"/> parameter is longer than 1000 characters.</exception>
         /// <exception cref="TranslatorServiceException">The provided <see cref="SubscriptionKey"/> isn't valid or has expired.</exception>
         /// <remarks><para>This method perform a non-blocking request for text translation.</para>
-        /// <para>For more information, go to http://msdn.microsoft.com/en-us/library/ff512421.aspx.
+        /// <para>For more information, go to https://docs.microsofttranslator.com/text-translate.html#!/default/get_Translate.
         /// </para>
         /// </remarks>
         /// <seealso cref="Language"/>
@@ -141,9 +235,9 @@ namespace Microsoft.Toolkit.Uwp.Services.MicrosoftTranslator
                 throw new ArgumentNullException(nameof(text));
             }
 
-            if (text.Length > _maxTextLenght)
+            if (text.Length > _maxTextLength)
             {
-                throw new ArgumentException($"{nameof(text)} parameter cannot be longer than {_maxTextLenght} characters");
+                throw new ArgumentException($"{nameof(text)} parameter cannot be longer than {_maxTextLength} characters");
             }
 
             // Checks if it is necessary to obtain/update access token.
@@ -191,53 +285,11 @@ namespace Microsoft.Toolkit.Uwp.Services.MicrosoftTranslator
         /// <exception cref="ArgumentException">The <paramref name="text"/> parameter is longer than 1000 characters.</exception>
         /// <exception cref="TranslatorServiceException">The provided <see cref="SubscriptionKey"/> isn't valid or has expired.</exception>
         /// <remarks><para>This method perform a non-blocking request for text translation.</para>
-        /// <para>For more information, go to http://msdn.microsoft.com/en-us/library/ff512421.aspx.
+        /// <para>For more information, go to https://docs.microsofttranslator.com/text-translate.html#!/default/get_Translate.
         /// </para>
         /// </remarks>
         /// <seealso cref="Language"/>
         public Task<string> TranslateAsync(string text, string to = null) => TranslateAsync(text, null, to);
-
-        /// <summary>
-        /// Detects the language of a text.
-        /// </summary>
-        /// <param name="text">A string represeting the text whose language must be detected.</param>
-        /// <returns>A string containing a two-character Language code for the given text.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// <list type="bullet">
-        /// <term>The <see cref="SubscriptionKey"/> property hasn't been set.</term>
-        /// <term>The <paramref name="text"/> parameter is <strong>null</strong> (<strong>Nothing</strong> in Visual Basic) or empty.</term>
-        /// </list>
-        /// </exception>
-        /// <exception cref="TranslatorServiceException">The provided <see cref="SubscriptionKey"/> isn't valid or has expired.</exception>
-        /// <remarks><para>This method performs a non-blocking request for language detection.</para>
-        /// <para>For more information, go to http://msdn.microsoft.com/en-us/library/ff512427.aspx.
-        /// </para></remarks>
-        /// <seealso cref="GetLanguagesAsync"/>
-        public async Task<string> DetectLanguageAsync(string text)
-        {
-            if (string.IsNullOrWhiteSpace(text))
-            {
-                throw new ArgumentNullException(nameof(text));
-            }
-
-            text = text.Substring(0, Math.Min(text.Length, _MaxTextLengthForAutoDetection));
-
-            // Checks if it is necessary to obtain/update access token.
-            await CheckUpdateTokenAsync().ConfigureAwait(false);
-
-            var uriString = string.Format(DetectUri, Uri.EscapeDataString(text));
-
-            using (var request = CreateHttpRequest($"{BaseUrl}{uriString}"))
-            {
-                var response = await HttpHelper.Instance.SendRequestAsync(request).ConfigureAwait(false);
-                var content = await response.GetTextResultAsync().ConfigureAwait(false);
-
-                var doc = XDocument.Parse(content);
-                var detectedLanguage = doc.Root.Value;
-
-                return detectedLanguage;
-            }
-        }
 
         /// <summary>
         /// Initializes the <see cref="TranslatorService"/> class by getting an access token for the service.
@@ -292,8 +344,11 @@ namespace Microsoft.Toolkit.Uwp.Services.MicrosoftTranslator
         }
 
         private HttpHelperRequest CreateHttpRequest(string uriString)
+            => CreateHttpRequest(uriString, HttpMethod.Get);
+
+        private HttpHelperRequest CreateHttpRequest(string uriString, HttpMethod method)
         {
-            var request = new HttpHelperRequest(new Uri(uriString));
+            var request = new HttpHelperRequest(new Uri(uriString), method);
             request.Headers.Add(AuthorizationUri, _authorizationHeaderValue);
 
             return request;

--- a/Microsoft.Toolkit.Uwp.Services/Services/MicrosoftTranslator/TranslatorServiceException.cs
+++ b/Microsoft.Toolkit.Uwp.Services/Services/MicrosoftTranslator/TranslatorServiceException.cs
@@ -22,8 +22,8 @@ namespace Microsoft.Toolkit.Uwp.Services.MicrosoftTranslator
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TranslatorServiceException"/> class using the specified error message.
-        /// <param name="message">Message that describes the error</param>
         /// </summary>
+        /// <param name="message">Message that describes the error</param>
         public TranslatorServiceException(string message)
             : base(message)
         {


### PR DESCRIPTION
TranslatorService now contains a new method that can be used to automatically get friendly language names.