### PR TITLE
Add ImageUri to ToastSnooze/ToastDismiss buttons

### DIFF
--- a/Notifications/Microsoft.Toolkit.Uwp.Notifications.Shared/Toasts/ToastButtonDismiss.cs
+++ b/Notifications/Microsoft.Toolkit.Uwp.Notifications.Shared/Toasts/ToastButtonDismiss.cs
@@ -25,6 +25,11 @@ namespace Microsoft.Toolkit.Uwp.Notifications
         public string CustomContent { get; private set; }
 
         /// <summary>
+        /// An optional image icon for the button to display.
+        /// </summary>
+        public string ImageUri { get; set; }
+
+        /// <summary>
         /// Initializes a system-handled dismiss button that displays localized "Dismiss" text on the button.
         /// </summary>
         public ToastButtonDismiss()
@@ -51,9 +56,9 @@ namespace Microsoft.Toolkit.Uwp.Notifications
                        {
                            Content = this.CustomContent == null ? string.Empty : this.CustomContent, // If not using custom content, we need to provide empty string, otherwise Toast doesn't get displayed
                            Arguments = "dismiss",
-                           ActivationType = Element_ToastActivationType.System
+                           ActivationType = Element_ToastActivationType.System,
+                           ImageUri = ImageUri
 
-                           // ImageUri is useless since Shell doesn't display it for system buttons
                            // InputId is useless since dismiss button can't be placed to the right of text box (shell doesn't display it)
                        };
         }

--- a/Notifications/Microsoft.Toolkit.Uwp.Notifications.Shared/Toasts/ToastButtonSnooze.cs
+++ b/Notifications/Microsoft.Toolkit.Uwp.Notifications.Shared/Toasts/ToastButtonSnooze.cs
@@ -25,6 +25,11 @@ namespace Microsoft.Toolkit.Uwp.Notifications
         public string CustomContent { get; private set; }
 
         /// <summary>
+        /// An optional image icon for the button to display.
+        /// </summary>
+        public string ImageUri { get; set; }
+
+        /// <summary>
         /// Optionally specify the ID of an existing <see cref="ToastSelectionBox"/> in order to allow the user to pick a custom snooze time. The ID's of the <see cref="ToastSelectionBoxItem"/>s inside the selection box must represent the snooze interval in minutes. For example, if the user selects an item that has an ID of "120", then the notification will be snoozed for 2 hours. When the user clicks this button, if you specified a SelectionBoxId, the system will parse the ID of the selected item and snooze by that amount of minutes. If you didn't specify a SelectionBoxId, the system will snooze by the default system snooze time.
         /// </summary>
         public string SelectionBoxId { get; set; }
@@ -57,9 +62,8 @@ namespace Microsoft.Toolkit.Uwp.Notifications
                            Content = CustomContent ?? string.Empty, // If not using custom content, we need to provide empty string, otherwise Toast doesn't get displayed
                            Arguments = "snooze",
                            ActivationType = Element_ToastActivationType.System,
-                           InputId = SelectionBoxId
-
-                           // ImageUri is useless since Shell doesn't display it for system buttons
+                           InputId = SelectionBoxId,
+                           ImageUri = ImageUri
                        };
         }
     }

--- a/UnitTests/UnitTests.Notifications.Shared/Test_Toast_Xml.cs
+++ b/UnitTests/UnitTests.Notifications.Shared/Test_Toast_Xml.cs
@@ -941,6 +941,17 @@ namespace UnitTests.Notifications
         }
 
         [TestMethod]
+        public void Test_Toast_Xml_ButtonSnooze_Image()
+        {
+            ToastButtonSnooze button = new ToastButtonSnooze()
+            {
+                ImageUri = "Assets/Snooze.png"
+            };
+
+            AssertButtonPayload("<action activationType='system' arguments='snooze' content='' imageUri='Assets/Snooze.png'/>", button);
+        }
+
+        [TestMethod]
         public void Test_Toast_Xml_ButtonSnooze_SelectionId()
         {
             ToastButtonSnooze button = new ToastButtonSnooze()
@@ -966,7 +977,18 @@ namespace UnitTests.Notifications
 
             AssertButtonPayload("<action activationType='system' arguments='dismiss' content='my dismiss'/>", button);
         }
-        
+
+        [TestMethod]
+        public void Test_Toast_Xml_ButtonDismiss_Image()
+        {
+            ToastButtonDismiss button = new ToastButtonDismiss()
+            {
+                ImageUri = "Assets/Dismiss.png"
+            };
+
+            AssertButtonPayload("<action activationType='system' arguments='dismiss' content='' imageUri='Assets/Dismiss.png'/>", button);
+        }
+
         [TestMethod]
         public void Test_Toast_Xml_ContextMenuItem_Defaults()
         {


### PR DESCRIPTION
Action Center displays the images on these system activation buttons
now, so devs need to be able to assign them!

Fixes #1121