### PR TITLE
Fix GridSplitter behavior when using MaxWidth on ColumnDefinition

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/GridSplitter/GridSplitter.bind
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/GridSplitter/GridSplitter.bind
@@ -10,14 +10,15 @@
 
   <Grid Background="{StaticResource Brush-Grey-05}" Padding="48">
     <Grid.RowDefinitions>
-      <RowDefinition MinHeight="100"></RowDefinition>
-      <RowDefinition Height="11"></RowDefinition>
-      <RowDefinition></RowDefinition>
+      <RowDefinition MinHeight="100" MaxHeight="300" />
+      <RowDefinition Height="11" />
+      <RowDefinition />
+      <RowDefinition Height="200" />
     </Grid.RowDefinitions>
     <Grid.ColumnDefinitions>
-      <ColumnDefinition></ColumnDefinition>
-      <ColumnDefinition></ColumnDefinition>
-      <ColumnDefinition></ColumnDefinition>
+      <ColumnDefinition MinWidth="100" MaxWidth="300" />
+      <ColumnDefinition />
+      <ColumnDefinition />
     </Grid.ColumnDefinitions>
 
     <Rectangle Grid.Column="0"

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/GridSplitter/GridSplitterPage.xaml
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/GridSplitter/GridSplitterPage.xaml
@@ -11,13 +11,13 @@
           Padding="48"
           Background="{StaticResource Brush-Grey-05}">
         <Grid.RowDefinitions>
-            <RowDefinition MinHeight="100" />
+            <RowDefinition MinHeight="100" MaxHeight="200" />
             <RowDefinition Height="11" />
             <RowDefinition />
             <RowDefinition Height="200" />
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
-            <ColumnDefinition />
+            <ColumnDefinition MinWidth="100" MaxWidth="200" />
             <ColumnDefinition />
             <ColumnDefinition />
         </Grid.ColumnDefinitions>

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/GridSplitter/GridSplitterPage.xaml
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/GridSplitter/GridSplitterPage.xaml
@@ -11,13 +11,13 @@
           Padding="48"
           Background="{StaticResource Brush-Grey-05}">
         <Grid.RowDefinitions>
-            <RowDefinition MinHeight="100" MaxHeight="200" />
+            <RowDefinition MinHeight="100" MaxHeight="300" />
             <RowDefinition Height="11" />
             <RowDefinition />
             <RowDefinition Height="200" />
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
-            <ColumnDefinition MinWidth="100" MaxWidth="200" />
+            <ColumnDefinition MinWidth="100" MaxWidth="300" />
             <ColumnDefinition />
             <ColumnDefinition />
         </Grid.ColumnDefinitions>

--- a/Microsoft.Toolkit.Uwp.UI.Controls/GridSplitter/GridSplitter.Events.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/GridSplitter/GridSplitter.Events.cs
@@ -230,13 +230,19 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             if (!IsStarColumn(CurrentColumn))
             {
                 // No need to check for the Column Min width because it is automatically respected
-                SetColumnWidth(CurrentColumn, horizontalChange, GridUnitType.Pixel);
+                if (!SetColumnWidth(CurrentColumn, horizontalChange, GridUnitType.Pixel))
+                {
+                    return true;
+                }
             }
 
             // if sibling column has fixed width then resize it
             else if (!IsStarColumn(SiblingColumn))
             {
-                SetColumnWidth(SiblingColumn, horizontalChange * -1, GridUnitType.Pixel);
+                if (!SetColumnWidth(SiblingColumn, horizontalChange * -1, GridUnitType.Pixel))
+                {
+                    return true;
+                }
             }
 
             // if both column haven't fixed width (auto *)

--- a/Microsoft.Toolkit.Uwp.UI.Controls/GridSplitter/GridSplitter.Events.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/GridSplitter/GridSplitter.Events.cs
@@ -177,13 +177,19 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             if (!IsStarRow(CurrentRow))
             {
                 // No need to check for the row Min height because it is automatically respected
-                SetRowHeight(CurrentRow, verticalChange, GridUnitType.Pixel);
+                if (!SetRowHeight(CurrentRow, verticalChange, GridUnitType.Pixel))
+                {
+                    return true;
+                }
             }
 
             // if sibling row has fixed width then resize it
             else if (!IsStarRow(SiblingRow))
             {
-                SetRowHeight(SiblingRow, verticalChange * -1, GridUnitType.Pixel);
+                if (!SetRowHeight(SiblingRow, verticalChange * -1, GridUnitType.Pixel))
+                {
+                    return true;
+                }
             }
 
             // if both row haven't fixed height (auto *)
@@ -194,7 +200,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 // respect the other star row height by setting it's height to it's actual height with stars
 
                 // We need to validate current and sibling height to not cause any un expected behavior
-                if (!IsValidRowHeight(CurrentRow, verticalChange) || !IsValidRowHeight(SiblingRow, verticalChange * -1))
+                if (!IsValidRowHeight(CurrentRow, verticalChange) || 
+                    !IsValidRowHeight(SiblingRow, verticalChange * -1))
                 {
                     return true;
                 }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/GridSplitter/GridSplitter.Helper.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/GridSplitter/GridSplitter.Helper.cs
@@ -82,21 +82,53 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             return true;
         }
 
-        private void SetRowHeight(RowDefinition rowDefinition, double verticalChange, GridUnitType unitType)
+        private bool SetRowHeight(RowDefinition rowDefinition, double verticalChange, GridUnitType unitType)
         {
             var newHeight = rowDefinition.ActualHeight + verticalChange;
+
+            var minHeight = rowDefinition.MinHeight;
+            if (minHeight != double.NaN && newHeight < minHeight)
+            {
+                newHeight = minHeight;
+            }
+
+            var maxWidth = rowDefinition.MaxHeight;
+            if (maxWidth != double.NaN && newHeight > maxWidth)
+            {
+                newHeight = maxWidth;
+            }
+
             if (newHeight > ActualHeight)
             {
-                rowDefinition.Height = new GridLength(newHeight, unitType);
+                if (rowDefinition.Height.Value != newHeight)
+                {
+                    rowDefinition.Height = new GridLength(newHeight, unitType);
+                    return true;
+                }
             }
+
+            return false;
         }
 
         private bool IsValidRowHeight(RowDefinition rowDefinition, double verticalChange)
         {
             var newHeight = rowDefinition.ActualHeight + verticalChange;
-            if (newHeight > ActualHeight)
+
+            var minHeight = rowDefinition.MinHeight;
+            if (minHeight != double.NaN && newHeight < minHeight)
             {
-                return true;
+                return false;
+            }
+
+            var maxHeight = rowDefinition.MaxHeight;
+            if (maxHeight != double.NaN && newHeight > maxHeight)
+            {
+                return false;
+            }
+
+            if (newHeight <= ActualHeight)
+            {
+                return false;
             }
 
             return false;

--- a/Microsoft.Toolkit.Uwp.UI.Controls/GridSplitter/GridSplitter.Helper.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/GridSplitter/GridSplitter.Helper.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 return false;
             }
 
-            return false;
+            return true;
         }
 
         // Return the targeted Column based on the resize behavior

--- a/Microsoft.Toolkit.Uwp.UI.Controls/GridSplitter/GridSplitter.Helper.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/GridSplitter/GridSplitter.Helper.cs
@@ -48,11 +48,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
             if (newWidth > ActualWidth)
             {
-                if (columnDefinition.Width.Value != newWidth)
-                {
-                    columnDefinition.Width = new GridLength(newWidth, unitType);
-                    return true;
-                }
+                columnDefinition.Width = new GridLength(newWidth, unitType);
+                return true;
             }
 
             return false;
@@ -100,11 +97,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
             if (newHeight > ActualHeight)
             {
-                if (rowDefinition.Height.Value != newHeight)
-                {
-                    rowDefinition.Height = new GridLength(newHeight, unitType);
-                    return true;
-                }
+                rowDefinition.Height = new GridLength(newHeight, unitType);
+                return true;
             }
 
             return false;

--- a/Microsoft.Toolkit.Uwp.UI.Controls/GridSplitter/GridSplitter.Helper.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/GridSplitter/GridSplitter.Helper.cs
@@ -30,24 +30,56 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             return ((GridLength)definition.GetValue(RowDefinition.HeightProperty)).IsStar;
         }
 
-        private void SetColumnWidth(ColumnDefinition columnDefinition, double horizontalChange, GridUnitType unitType)
+        private bool SetColumnWidth(ColumnDefinition columnDefinition, double horizontalChange, GridUnitType unitType)
         {
             var newWidth = columnDefinition.ActualWidth + horizontalChange;
+
+            var minWidth = columnDefinition.MinWidth;
+            if (minWidth != double.NaN && newWidth < minWidth)
+            {
+                newWidth = minWidth;
+            }
+
+            var maxWidth = columnDefinition.MaxWidth;
+            if (maxWidth != double.NaN && newWidth > maxWidth)
+            {
+                newWidth = maxWidth;
+            }
+
             if (newWidth > ActualWidth)
             {
-                columnDefinition.Width = new GridLength(newWidth, unitType);
+                if (columnDefinition.Width.Value != newWidth)
+                {
+                    columnDefinition.Width = new GridLength(newWidth, unitType);
+                    return true;
+                }
             }
+
+            return false;
         }
 
         private bool IsValidColumnWidth(ColumnDefinition columnDefinition, double horizontalChange)
         {
             var newWidth = columnDefinition.ActualWidth + horizontalChange;
-            if (newWidth > ActualWidth)
+
+            var minWidth = columnDefinition.MinWidth;
+            if (minWidth != double.NaN && newWidth < minWidth)
             {
-                return true;
+                return false;
             }
 
-            return false;
+            var maxWidth = columnDefinition.MaxWidth;
+            if (maxWidth != double.NaN && newWidth > maxWidth)
+            {
+                return false;
+            }
+
+            if (newWidth <= ActualWidth)
+            {
+                return false;
+            }
+
+            return true;
         }
 
         private void SetRowHeight(RowDefinition rowDefinition, double verticalChange, GridUnitType unitType)

--- a/Microsoft.Toolkit.Uwp.UI.Controls/GridSplitter/GridSplitter.Helper.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/GridSplitter/GridSplitter.Helper.cs
@@ -35,13 +35,13 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             var newWidth = columnDefinition.ActualWidth + horizontalChange;
 
             var minWidth = columnDefinition.MinWidth;
-            if (minWidth != double.NaN && newWidth < minWidth)
+            if (!double.IsNaN(minWidth) && newWidth < minWidth)
             {
                 newWidth = minWidth;
             }
 
             var maxWidth = columnDefinition.MaxWidth;
-            if (maxWidth != double.NaN && newWidth > maxWidth)
+            if (!double.IsNaN(maxWidth) && newWidth > maxWidth)
             {
                 newWidth = maxWidth;
             }
@@ -63,13 +63,13 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             var newWidth = columnDefinition.ActualWidth + horizontalChange;
 
             var minWidth = columnDefinition.MinWidth;
-            if (minWidth != double.NaN && newWidth < minWidth)
+            if (!double.IsNaN(minWidth) && newWidth < minWidth)
             {
                 return false;
             }
 
             var maxWidth = columnDefinition.MaxWidth;
-            if (maxWidth != double.NaN && newWidth > maxWidth)
+            if (!double.IsNaN(maxWidth) && newWidth > maxWidth)
             {
                 return false;
             }
@@ -87,13 +87,13 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             var newHeight = rowDefinition.ActualHeight + verticalChange;
 
             var minHeight = rowDefinition.MinHeight;
-            if (minHeight != double.NaN && newHeight < minHeight)
+            if (!double.IsNaN(minHeight) && newHeight < minHeight)
             {
                 newHeight = minHeight;
             }
 
             var maxWidth = rowDefinition.MaxHeight;
-            if (maxWidth != double.NaN && newHeight > maxWidth)
+            if (!double.IsNaN(maxWidth) && newHeight > maxWidth)
             {
                 newHeight = maxWidth;
             }
@@ -115,13 +115,13 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             var newHeight = rowDefinition.ActualHeight + verticalChange;
 
             var minHeight = rowDefinition.MinHeight;
-            if (minHeight != double.NaN && newHeight < minHeight)
+            if (!double.IsNaN(minHeight) && newHeight < minHeight)
             {
                 return false;
             }
 
             var maxHeight = rowDefinition.MaxHeight;
-            if (maxHeight != double.NaN && newHeight > maxHeight)
+            if (!double.IsNaN(maxHeight) && newHeight > maxHeight)
             {
                 return false;
             }


### PR DESCRIPTION
Fixes the issue as described in #1156.

Broken behavior:

![gridsplitter](https://cloud.githubusercontent.com/assets/1246444/25840415/fe63bf5c-349b-11e7-96a9-7c6953ed5a50.gif)

Fixed behavior:

![gridsplitter_fixed](https://cloud.githubusercontent.com/assets/1246444/25840417/0027a038-349c-11e7-91fd-c791ef69ac3c.gif)