### PR TITLE
RadialGauge PointerReleased handling

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/RadialGauge/RadialGauge.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/RadialGauge/RadialGauge.cs
@@ -481,6 +481,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// </summary>
         protected override void OnApplyTemplate()
         {
+            PointerReleased += RadialGauge_PointerReleased;
             OnScaleChanged(this);
 
             base.OnApplyTemplate();
@@ -688,6 +689,14 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             SetGaugeValueFromPoint(e.GetPosition(this));
         }
 
+        private void RadialGauge_PointerReleased(object sender, PointerRoutedEventArgs e)
+        {
+            if (IsInteractive)
+            {
+                e.Handled = true;
+            }
+        }
+        
         private void UpdateNormalizedAngles()
         {
             var result = Mod(MinAngle, 360);


### PR DESCRIPTION
Don't propagate the PointerReleased event when the control is in Interactive mode. This makes the control behave like other XAML input controls (like TextBox) after manipulating the value. Releasing the mouse pointer will just set the value and will e.g. NOT trigger row selection when the RadialGauge is used inside a ListView data template.