### PR TITLE
Use Rectangle instead of Border for RoundImageEx

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/ImageEx/ImageExPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/ImageEx/ImageExPage.xaml.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
                 {
                     Height = 200,
                     Width = 200,
-                    CornerRadius = new CornerRadius(999)
+                    CornerRadius = 999
                 };
             }
             else

--- a/Microsoft.Toolkit.Uwp.UI.Controls/ImageEx/RoundImageEx.Members.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/ImageEx/RoundImageEx.Members.cs
@@ -23,14 +23,14 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
     /// </summary>
     public partial class RoundImageEx
     {
-        public CornerRadius CornerRadius
+        public double CornerRadius
         {
-            get { return (CornerRadius)GetValue(CornerRadiusProperty); }
+            get { return (double)GetValue(CornerRadiusProperty); }
             set { SetValue(CornerRadiusProperty, value); }
         }
 
         // Using a DependencyProperty as the backing store for CornerRadius.  This enables animation, styling, binding, etc...
         public static readonly DependencyProperty CornerRadiusProperty =
-            DependencyProperty.Register(nameof(CornerRadius), typeof(CornerRadius), typeof(RoundImageEx), new PropertyMetadata(0));
+            DependencyProperty.Register(nameof(CornerRadius), typeof(double), typeof(RoundImageEx), new PropertyMetadata(0));
     }
 }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/ImageEx/RoundImageEx.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/ImageEx/RoundImageEx.xaml
@@ -9,35 +9,37 @@
             <Setter.Value>
                 <ControlTemplate TargetType="controls:RoundImageEx">
                     <Grid>
-                        <Border x:Name="PlaceholderEllipse"
-                                 Width="{TemplateBinding Width}"
-                                 Height="{TemplateBinding Height}"
-                                 HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
-                                 VerticalAlignment="{TemplateBinding VerticalAlignment}"
-                                 Opacity="1.0"
-                                 CornerRadius="{TemplateBinding CornerRadius}"
-                                 BorderBrush="{TemplateBinding BorderBrush}"
-                                 BorderThickness="{TemplateBinding BorderThickness}">
-                            <Border.Background>
+                        <Rectangle x:Name="PlaceholderRectangle"
+                                   Width="{TemplateBinding Width}"
+                                   Height="{TemplateBinding Height}"
+                                   HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
+                                   VerticalAlignment="{TemplateBinding VerticalAlignment}"
+                                   Opacity="1.0"
+                                   RadiusX="{TemplateBinding CornerRadius}"
+                                   RadiusY="{TemplateBinding CornerRadius}"
+                                   Stroke="{TemplateBinding BorderBrush}"
+                                   StrokeThickness="{TemplateBinding BorderThickness}">
+                            <Rectangle.Fill>
                                 <ImageBrush x:Name="PlaceholderImage"
                                             ImageSource="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=PlaceholderSource}"
                                             Stretch="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=PlaceholderStretch}" />
-                            </Border.Background>
-                        </Border>
-                        <Border x:Name="ImageEllipse"
-                                 Width="{TemplateBinding Width}"
-                                 Height="{TemplateBinding Height}"
-                                 HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
-                                 VerticalAlignment="{TemplateBinding VerticalAlignment}"
-                                 Opacity="0.0"
-                                 CornerRadius="{TemplateBinding CornerRadius}"
-                                 BorderBrush="{TemplateBinding BorderBrush}"
-                                 BorderThickness="{TemplateBinding BorderThickness}">
-                            <Border.Background>
+                            </Rectangle.Fill>
+                        </Rectangle>
+                        <Rectangle x:Name="ImageRectangle"
+                                   Width="{TemplateBinding Width}"
+                                   Height="{TemplateBinding Height}"
+                                   HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
+                                   VerticalAlignment="{TemplateBinding VerticalAlignment}"
+                                   Opacity="0.0"
+                                   RadiusX="{TemplateBinding CornerRadius}"
+                                   RadiusY="{TemplateBinding CornerRadius}"
+                                   Stroke="{TemplateBinding BorderBrush}"
+                                   StrokeThickness="{TemplateBinding BorderThickness}">
+                            <Rectangle.Fill>
                                 <ImageBrush x:Name="Image"
                                             Stretch="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Stretch}" />
-                            </Border.Background>
-                        </Border>
+                            </Rectangle.Fill>
+                        </Rectangle>
                         <ProgressRing Name="Progress"
                                       Margin="16"
                                       HorizontalAlignment="Center"
@@ -50,12 +52,12 @@
                             <VisualStateGroup x:Name="CommonStates">
                                 <VisualState x:Name="Failed">
                                     <Storyboard>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ImageEllipse"
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ImageRectangle"
                                                                        Storyboard.TargetProperty="Opacity">
                                             <DiscreteObjectKeyFrame KeyTime="0"
                                                                     Value="0" />
                                         </ObjectAnimationUsingKeyFrames>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PlaceholderEllipse"
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PlaceholderRectangle"
                                                                        Storyboard.TargetProperty="Opacity">
                                             <DiscreteObjectKeyFrame KeyTime="0"
                                                                     Value="1" />
@@ -69,12 +71,12 @@
                                             <DiscreteObjectKeyFrame KeyTime="0"
                                                                     Value="True" />
                                         </ObjectAnimationUsingKeyFrames>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ImageEllipse"
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ImageRectangle"
                                                                        Storyboard.TargetProperty="Opacity">
                                             <DiscreteObjectKeyFrame KeyTime="0"
                                                                     Value="0" />
                                         </ObjectAnimationUsingKeyFrames>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PlaceholderEllipse"
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PlaceholderRectangle"
                                                                        Storyboard.TargetProperty="Opacity">
                                             <DiscreteObjectKeyFrame KeyTime="0"
                                                                     Value="1" />
@@ -90,13 +92,13 @@
                                         </ObjectAnimationUsingKeyFrames>
                                         <DoubleAnimation AutoReverse="False"
                                                          BeginTime="0"
-                                                         Storyboard.TargetName="ImageEllipse"
+                                                         Storyboard.TargetName="ImageRectangle"
                                                          Storyboard.TargetProperty="Opacity"
                                                          From="0"
                                                          To="1" />
                                         <DoubleAnimation AutoReverse="False"
                                                          BeginTime="0"
-                                                         Storyboard.TargetName="PlaceholderEllipse"
+                                                         Storyboard.TargetName="PlaceholderRectangle"
                                                          Storyboard.TargetProperty="Opacity"
                                                          From="1"
                                                          To="0" />


### PR DESCRIPTION
Use Rectangle instead of Border for RoundImageEx
This should simplify support for DropShadowPanel as shape supports GetAlphaMask
Issue #1178 