### PR TITLE
Added HamburgerMenu.PaneForeground to address theming problem

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/HamburgerMenu/HamburgerMenu.Properties.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/HamburgerMenu/HamburgerMenu.Properties.cs
@@ -43,6 +43,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         public static readonly DependencyProperty CompactPaneLengthProperty = DependencyProperty.Register(nameof(CompactPaneLength), typeof(double), typeof(HamburgerMenu), new PropertyMetadata(48.0));
 
         /// <summary>
+        /// Identifies the <see cref="PaneForeground"/> dependency property.
+        /// </summary>
+        public static readonly DependencyProperty PaneForegroundProperty = DependencyProperty.Register(nameof(PaneForeground), typeof(Brush), typeof(HamburgerMenu), new PropertyMetadata(null));
+
+        /// <summary>
         /// Identifies the <see cref="PaneBackground"/> dependency property.
         /// </summary>
         public static readonly DependencyProperty PaneBackgroundProperty = DependencyProperty.Register(nameof(PaneBackground), typeof(Brush), typeof(HamburgerMenu), new PropertyMetadata(null));
@@ -111,6 +116,16 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         {
             get { return (double)GetValue(CompactPaneLengthProperty); }
             set { SetValue(CompactPaneLengthProperty, value); }
+        }
+
+        /// <summary>
+        /// Gets or sets the Brush to apply to the foreground of the Pane area of the control
+        /// (specifically, the hamburger button foreground).
+        /// </summary>
+        public Brush PaneForeground
+        {
+            get { return (Brush)GetValue(PaneForegroundProperty); }
+            set { SetValue(PaneForegroundProperty, value); }
         }
 
         /// <summary>

--- a/Microsoft.Toolkit.Uwp.UI.Controls/HamburgerMenu/HamburgerMenu.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/HamburgerMenu/HamburgerMenu.cs
@@ -40,6 +40,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// </summary>
         protected override void OnApplyTemplate()
         {
+            if (PaneForeground == null)
+            {
+                PaneForeground = Foreground;
+            }
+
             if (_hamburgerButton != null)
             {
                 _hamburgerButton.Click -= HamburgerButton_Click;

--- a/Microsoft.Toolkit.Uwp.UI.Controls/HamburgerMenu/HamburgerMenu.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/HamburgerMenu/HamburgerMenu.xaml
@@ -100,7 +100,7 @@
                                 TabIndex="0">
                             <ContentControl Margin="{TemplateBinding HamburgerMargin}"
                                             ContentTemplate="{TemplateBinding HamburgerMenuTemplate}"
-                                            Foreground="{TemplateBinding Foreground}"
+                                            Foreground="{TemplateBinding PaneForeground}"
                                             IsTabStop="False" />
                         </Button>
                     </Grid>


### PR DESCRIPTION
Using Foreground to set the hamburger button color blocks theme inheritance in the content frame. This PR adds a PaneForeground property that targets the button but not the content frame, and defaults to the Foreground value so it won't break current Foreground usage. 