### PR TITLE
Always set _detailsPresenter.Content even if SelectedItem is null

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.cs
@@ -325,7 +325,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
         private void SetDetailsContent()
         {
-            if ((SelectedItem != null) && (_detailsPresenter != null))
+            if (_detailsPresenter != null)
             {
                 _detailsPresenter.Content = MapDetails == null
                     ? SelectedItem

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.cs
@@ -329,7 +329,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             {
                 _detailsPresenter.Content = MapDetails == null
                     ? SelectedItem
-                    : MapDetails(SelectedItem);
+                    : SelectedItem != null ? MapDetails(SelectedItem) : null;
             }
         }
 


### PR DESCRIPTION
Fixes https://github.com/Microsoft/UWPCommunityToolkit/issues/1197
(and likely https://github.com/Microsoft/UWPCommunityToolkit/issues/745 as well)