### PR TITLE
Fixed issue where Compare ignored inherited properties.

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI/AdvancedCollectionView/AdvancedCollectionView.cs
+++ b/Microsoft.Toolkit.Uwp.UI/AdvancedCollectionView/AdvancedCollectionView.cs
@@ -375,12 +375,12 @@ namespace Microsoft.Toolkit.Uwp.UI
         {
             if (!_sortProperties.Any())
             {
-                var typeInfo = x.GetType().GetTypeInfo();
+                var type = x.GetType();
                 foreach (var sd in _sortDescriptions)
                 {
                     if (!string.IsNullOrEmpty(sd.PropertyName))
                     {
-                        _sortProperties[sd.PropertyName] = typeInfo.GetDeclaredProperty(sd.PropertyName);
+                        _sortProperties[sd.PropertyName] = type.GetProperty(sd.PropertyName);
                     }
                 }
             }


### PR DESCRIPTION
Previous AdvancedCollectionView compare implementation ignored inherited properties.  

Consider the source code below.  Creating an AdvancedCollectionView based on Employee and creating a SortDescription for "Name" would generate a null exception since Employee does not declare Name, it inherits it from Person.

    public class Person
    {
        public string Name { get; set; }
    }

    public class Employee : Person
    {
    }

    // Set up the original list with a few sample items

    var oc = new ObservableCollection<Employee>
    {
        new Employee { Name = "Staff" },
        new Employee { Name = "42" },
        new Employee { Name = "Swan" },
        new Employee { Name = "Orchid" },
        new Employee { Name = "15" },
        new Employee { Name = "Flame" },
        new Employee { Name = "16" },
        new Employee { Name = "Arrow" },
        new Employee { Name = "Tempest" },
        new Employee { Name = "23" },
        new Employee { Name = "Pearl" },
        new Employee { Name = "Hydra" },
        new Employee { Name = "Lamp Post" },
        new Employee { Name = "4" },
        new Employee { Name = "Looking Glass" },
        new Employee { Name = "8" },
    };

    // Set up the AdvancedCollectionView to filter and sort the original list

    var acv = new AdvancedCollectionView(oc);

    // Let's filter out the integers
    int nul;
    acv.Filter = x => !int.TryParse(((Employee)x).Name, out nul);

    // And sort ascending by the property "Name"
    acv.SortDescriptions.Add(new SortDescription("Name", SortDirection.Ascending));

    // AdvancedCollectionView can be bound to anything that uses collections. 
    YourListView.ItemsSource = acv;