### PR TITLE
Fix bug of arrange for WrapPanel

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/WrapPanel/WrapPanel.Data.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/WrapPanel/WrapPanel.Data.cs
@@ -29,12 +29,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls.WrapPanel
 
             internal double V { get { return v / FACTOR; } set { v = (int)(value * FACTOR); } }
 
-            public UvMeasure()
-            {
-                U = 0.0;
-                V = 0.0;
-            }
-
             public UvMeasure(Orientation orientation, double width, double height)
             {
                 if (orientation == Orientation.Horizontal)

--- a/Microsoft.Toolkit.Uwp.UI.Controls/WrapPanel/WrapPanel.Data.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/WrapPanel/WrapPanel.Data.cs
@@ -19,11 +19,15 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls.WrapPanel
     /// </summary>
     public partial class WrapPanel
     {
-        internal class UvMeasure
+        [System.Diagnostics.DebuggerDisplay("U = {U} V = {V}")]
+        internal struct UvMeasure
         {
-            internal double U { get; set; }
+            internal const double FACTOR = 10000;
 
-            internal double V { get; set; }
+            private int u, v;
+            internal double U { get => u / FACTOR; set => u = (int)(value * FACTOR); }
+
+            internal double V { get => v / FACTOR; set => v = (int)(value * FACTOR); }
 
             public UvMeasure()
             {
@@ -40,8 +44,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls.WrapPanel
                 }
                 else
                 {
-                    U = height;
                     V = width;
+                    U = height;
                 }
             }
         }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/WrapPanel/WrapPanel.Data.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/WrapPanel/WrapPanel.Data.cs
@@ -10,7 +10,6 @@
 // THE CODE OR THE USE OR OTHER DEALINGS IN THE CODE.
 // ******************************************************************
 
-using System;
 using Windows.UI.Xaml.Controls;
 
 namespace Microsoft.Toolkit.Uwp.UI.Controls.WrapPanel
@@ -25,26 +24,12 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls.WrapPanel
         {
             internal static readonly UvMeasure Zero = default(UvMeasure);
 
-            private double _u;
+            internal double U { get; set; }
 
-            private double _v;
-
-            internal double U
-            {
-                get { return _u; }
-                set { _u = Math.Floor(value); }
-            }
-
-            internal double V
-            {
-                get { return _v; }
-                set { _v = Math.Floor(value); }
-            }
+            internal double V { get; set; }
 
             public UvMeasure(Orientation orientation, double width, double height)
             {
-                _u = 0.0;
-                _v = 0.0;
                 if (orientation == Orientation.Horizontal)
                 {
                     U = width;

--- a/Microsoft.Toolkit.Uwp.UI.Controls/WrapPanel/WrapPanel.Data.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/WrapPanel/WrapPanel.Data.cs
@@ -23,12 +23,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls.WrapPanel
         [System.Diagnostics.DebuggerDisplay("U = {U} V = {V}")]
         private struct UvMeasure
         {
-            private const double FACTOR = 10000;
-
             private double u, v;
-            internal double U { get { return u ; } set { u = Math.Floor(value * FACTOR) / FACTOR; } }
+            internal double U { get { return u; } set { u = Math.Floor(value); } }
 
-            internal double V { get { return v ; } set { v = Math.Floor(value * FACTOR) / FACTOR; } }
+            internal double V { get { return v; } set { v = Math.Floor(value); } }
 
             public UvMeasure(Orientation orientation, double width, double height)
             {

--- a/Microsoft.Toolkit.Uwp.UI.Controls/WrapPanel/WrapPanel.Data.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/WrapPanel/WrapPanel.Data.cs
@@ -1,4 +1,4 @@
-﻿// ******************************************************************
+// ******************************************************************
 // Copyright (c) Microsoft. All rights reserved.
 // This code is licensed under the MIT License (MIT).
 // THE CODE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
@@ -25,9 +25,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls.WrapPanel
             internal const double FACTOR = 10000;
 
             private int u, v;
-            internal double U { get => u / FACTOR; set => u = (int)(value * FACTOR); }
+            internal double U { get { return u / FACTOR; } set { u = (int)(value * FACTOR); } }
 
-            internal double V { get => v / FACTOR; set => v = (int)(value * FACTOR); }
+            internal double V { get { return v / FACTOR; } set { v = (int)(value * FACTOR); } }
 
             public UvMeasure()
             {

--- a/Microsoft.Toolkit.Uwp.UI.Controls/WrapPanel/WrapPanel.Data.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/WrapPanel/WrapPanel.Data.cs
@@ -10,6 +10,7 @@
 // THE CODE OR THE USE OR OTHER DEALINGS IN THE CODE.
 // ******************************************************************
 
+using System;
 using Windows.UI.Xaml.Controls;
 
 namespace Microsoft.Toolkit.Uwp.UI.Controls.WrapPanel

--- a/Microsoft.Toolkit.Uwp.UI.Controls/WrapPanel/WrapPanel.Data.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/WrapPanel/WrapPanel.Data.cs
@@ -26,9 +26,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls.WrapPanel
             private const double FACTOR = 10000;
 
             private double u, v;
-            internal double U { get { return u / FACTOR; } set { u = Math.Floor(value * FACTOR); } }
+            internal double U { get { return u ; } set { u = Math.Floor(value * FACTOR) / FACTOR; } }
 
-            internal double V { get { return v / FACTOR; } set { v = Math.Floor(value * FACTOR); } }
+            internal double V { get { return v ; } set { v = Math.Floor(value * FACTOR) / FACTOR; } }
 
             public UvMeasure(Orientation orientation, double width, double height)
             {

--- a/Microsoft.Toolkit.Uwp.UI.Controls/WrapPanel/WrapPanel.Data.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/WrapPanel/WrapPanel.Data.cs
@@ -31,6 +31,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls.WrapPanel
 
             public UvMeasure(Orientation orientation, double width, double height)
             {
+                this.u = 0;
+                this.v = 0;
                 if (orientation == Orientation.Horizontal)
                 {
                     U = width;

--- a/Microsoft.Toolkit.Uwp.UI.Controls/WrapPanel/WrapPanel.Data.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/WrapPanel/WrapPanel.Data.cs
@@ -1,4 +1,4 @@
-// ******************************************************************
+﻿// ******************************************************************
 // Copyright (c) Microsoft. All rights reserved.
 // This code is licensed under the MIT License (MIT).
 // THE CODE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
@@ -23,15 +23,28 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls.WrapPanel
         [System.Diagnostics.DebuggerDisplay("U = {U} V = {V}")]
         private struct UvMeasure
         {
-            private double u, v;
-            internal double U { get { return u; } set { u = Math.Floor(value); } }
+            internal static readonly UvMeasure Zero = default(UvMeasure);
 
-            internal double V { get { return v; } set { v = Math.Floor(value); } }
+            private double _u;
+
+            private double _v;
+
+            internal double U
+            {
+                get { return _u; }
+                set { _u = Math.Floor(value); }
+            }
+
+            internal double V
+            {
+                get { return _v; }
+                set { _v = Math.Floor(value); }
+            }
 
             public UvMeasure(Orientation orientation, double width, double height)
             {
-                this.u = 0.0;
-                this.v = 0.0;
+                _u = 0.0;
+                _v = 0.0;
                 if (orientation == Orientation.Horizontal)
                 {
                     U = width;

--- a/Microsoft.Toolkit.Uwp.UI.Controls/WrapPanel/WrapPanel.Data.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/WrapPanel/WrapPanel.Data.cs
@@ -20,19 +20,19 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls.WrapPanel
     public partial class WrapPanel
     {
         [System.Diagnostics.DebuggerDisplay("U = {U} V = {V}")]
-        internal struct UvMeasure
+        private struct UvMeasure
         {
-            internal const double FACTOR = 10000;
+            private const double FACTOR = 10000;
 
-            private int u, v;
-            internal double U { get { return u / FACTOR; } set { u = (int)(value * FACTOR); } }
+            private double u, v;
+            internal double U { get { return u / FACTOR; } set { u = Math.Floor(value * FACTOR); } }
 
-            internal double V { get { return v / FACTOR; } set { v = (int)(value * FACTOR); } }
+            internal double V { get { return v / FACTOR; } set { v = Math.Floor(value * FACTOR); } }
 
             public UvMeasure(Orientation orientation, double width, double height)
             {
-                this.u = 0;
-                this.v = 0;
+                this.u = 0.0;
+                this.v = 0.0;
                 if (orientation == Orientation.Horizontal)
                 {
                     U = width;
@@ -40,8 +40,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls.WrapPanel
                 }
                 else
                 {
-                    V = width;
                     U = height;
+                    V = width;
                 }
             }
         }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/WrapPanel/WrapPanel.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/WrapPanel/WrapPanel.cs
@@ -100,6 +100,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls.WrapPanel
             totalMeasure.U = Math.Max(lineMeasure.U, totalMeasure.U);
             totalMeasure.V += lineMeasure.V;
 
+            totalMeasure.U = Math.Ceiling(totalMeasure.U);
+
             return Orientation == Orientation.Horizontal ? new Size(totalMeasure.U, totalMeasure.V) : new Size(totalMeasure.V, totalMeasure.U);
         }
 

--- a/Microsoft.Toolkit.Uwp.UI.Controls/WrapPanel/WrapPanel.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/WrapPanel/WrapPanel.cs
@@ -51,9 +51,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls.WrapPanel
         /// <inheritdoc />
         protected override Size MeasureOverride(Size availableSize)
         {
-            var totalMeasure = new UvMeasure();
+            var totalMeasure = UvMeasure.Zero;
             var parentMeasure = new UvMeasure(Orientation, availableSize.Width, availableSize.Height);
-            var lineMeasure = new UvMeasure();
+            var lineMeasure = UvMeasure.Zero;
             foreach (var child in Children)
             {
                 child.Measure(availableSize);
@@ -87,7 +87,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls.WrapPanel
                         totalMeasure.V += currentMeasure.V;
 
                         // add new empty line
-                        lineMeasure = new UvMeasure();
+                        lineMeasure = UvMeasure.Zero;
                     }
                 }
             }
@@ -107,7 +107,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls.WrapPanel
         protected override Size ArrangeOverride(Size finalSize)
         {
             var parentMeasure = new UvMeasure(Orientation, finalSize.Width, finalSize.Height);
-            var position = new UvMeasure();
+            var position = UvMeasure.Zero;
 
             double currentV = 0;
             foreach (var child in Children)


### PR DESCRIPTION
Use `int` as backing field of `U` and `V`, see #1085