### PR TITLE
HamburgerMenu: update template to keep options visible

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/HamburgerMenu/HamburgerMenu.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/HamburgerMenu/HamburgerMenu.xaml
@@ -6,8 +6,10 @@
         <Setter Property="HamburgerMenuTemplate">
             <Setter.Value>
                 <DataTemplate>
-                    <FontIcon FontFamily="Segoe MDL2 Assets"
-                              Glyph="&#xE700;" />
+                    <FontIcon
+                            FontFamily="Segoe MDL2 Assets"
+                            FontSize="16"
+                            Glyph="&#xE700;" />
                 </DataTemplate>
             </Setter.Value>
         </Setter>
@@ -16,92 +18,88 @@
             <Setter.Value>
                 <ControlTemplate TargetType="local:HamburgerMenu">
                     <Grid>
-                        <SplitView x:Name="MainSplitView"
-                                   CompactPaneLength="{TemplateBinding CompactPaneLength}"
-                                   DisplayMode="{TemplateBinding DisplayMode}"
-                                   IsPaneOpen="{Binding IsPaneOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
-                                   IsTabStop="False"
-                                   OpenPaneLength="{TemplateBinding OpenPaneLength}"
-                                   PaneBackground="{TemplateBinding PaneBackground}"
-                                   PanePlacement="{TemplateBinding PanePlacement}">
+                        <SplitView
+                                x:Name="MainSplitView"
+                                CompactPaneLength="{TemplateBinding CompactPaneLength}"
+                                DisplayMode="{TemplateBinding DisplayMode}"
+                                IsPaneOpen="{Binding IsPaneOpen, Mode=TwoWay, RelativeSource={RelativeSource Mode=TemplatedParent}}"
+                                IsTabStop="False"
+                                OpenPaneLength="{TemplateBinding OpenPaneLength}"
+                                PaneBackground="{TemplateBinding PaneBackground}"
+                                PanePlacement="{TemplateBinding PanePlacement}">
                             <SplitView.Pane>
-                                <Grid x:Name="PaneGrid"
-                                      FlowDirection="LeftToRight">
+                                <Grid x:Name="PaneGrid" FlowDirection="LeftToRight">
                                     <Grid.RowDefinitions>
                                         <RowDefinition Height="Auto" />
-                                        <RowDefinition />
+                                        <RowDefinition Height="*" />
+                                        <RowDefinition Height="Auto" />
                                     </Grid.RowDefinitions>
-                                    <Grid Grid.Row="0"
-                                          Height="{TemplateBinding HamburgerHeight}" />
-                                    <ScrollViewer Grid.Row="1"
-                                                  HorizontalAlignment="Stretch"
-                                                  VerticalAlignment="Stretch"
-                                                  FlowDirection="RightToLeft"
-                                                  VerticalScrollBarVisibility="Auto">
-                                        <Grid FlowDirection="LeftToRight">
-                                            <Grid.RowDefinitions>
-                                                <RowDefinition Height="Auto" />
-                                                <RowDefinition />
-                                                <RowDefinition Height="Auto " />
-                                            </Grid.RowDefinitions>
-                                            <ListView Name="ButtonsListView"
-                                                      Grid.Row="0"
-                                                      Width="{TemplateBinding OpenPaneLength}"
-                                                      AutomationProperties.Name="Menu items"
-                                                      IsItemClickEnabled="True"
-                                                      ItemTemplate="{TemplateBinding ItemTemplate}"
-                                                      ItemTemplateSelector="{TemplateBinding ItemTemplateSelector}"
-                                                      ItemsSource="{TemplateBinding ItemsSource}"
-                                                      SelectedIndex="{Binding SelectedIndex, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay}"
-                                                      SelectedItem="{Binding SelectedItem, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay}"
-                                                      SelectionMode="Single"
-                                                      TabIndex="1">
-                                                <ListView.ItemContainerStyle>
-                                                    <Style TargetType="ListViewItem">
-                                                        <Setter Property="Padding" Value="0" />
-                                                    </Style>
-                                                </ListView.ItemContainerStyle>
-                                            </ListView>
-                                            <ListView Name="OptionsListView"
-                                                      Grid.Row="2"
-                                                      Width="{TemplateBinding OpenPaneLength}"
-                                                      VerticalAlignment="Bottom"
-                                                      AutomationProperties.Name="Option items"
-                                                      IsItemClickEnabled="True"
-                                                      ItemTemplate="{TemplateBinding OptionsItemTemplate}"
-                                                      ItemTemplateSelector="{TemplateBinding OptionsItemTemplateSelector}"
-                                                      ItemsSource="{TemplateBinding OptionsItemsSource}"
-                                                      SelectedIndex="{Binding SelectedOptionsIndex, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay}"
-                                                      SelectedItem="{Binding SelectedOptionsItem, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay}"
-                                                      TabIndex="2">
-                                                <ListView.ItemContainerStyle>
-                                                    <Style TargetType="ListViewItem">
-                                                        <Setter Property="Padding" Value="0" />
-                                                    </Style>
-                                                </ListView.ItemContainerStyle>
-                                            </ListView>
-                                        </Grid>
-                                    </ScrollViewer>
+                                    <Grid
+                                            Grid.Row="0"
+                                            Height="{TemplateBinding HamburgerHeight}"
+                                            Margin="0,0,0,8" />
+
+                                    <ListView
+                                            x:Name="ButtonsListView"
+                                            Grid.Row="1"
+                                            Width="{TemplateBinding OpenPaneLength}"
+                                            IsItemClickEnabled="True"
+                                            ItemTemplate="{TemplateBinding ItemTemplate}"
+                                            ItemTemplateSelector="{TemplateBinding ItemTemplateSelector}"
+                                            ItemsSource="{TemplateBinding ItemsSource}"
+                                            ScrollViewer.VerticalScrollBarVisibility="Auto"
+                                            SelectedIndex="{Binding SelectedIndex, Mode=TwoWay, RelativeSource={RelativeSource Mode=TemplatedParent}}"
+                                            SelectedItem="{Binding SelectedItem, Mode=TwoWay, RelativeSource={RelativeSource Mode=TemplatedParent}}"
+                                            SelectionMode="None"
+                                            TabIndex="1">
+                                        <ListView.ItemContainerStyle>
+                                            <Style TargetType="ListViewItem">
+                                                <Setter Property="Padding" Value="0" />
+                                            </Style>
+                                        </ListView.ItemContainerStyle>
+                                    </ListView>
+                                    <ListView
+                                            x:Name="OptionsListView"
+                                            Grid.Row="2"
+                                            Width="{TemplateBinding OpenPaneLength}"
+                                            IsItemClickEnabled="True"
+                                            Margin="0,20,0,8"
+                                            VerticalAlignment="Bottom"
+                                            ItemTemplate="{TemplateBinding OptionsItemTemplate}"
+                                            ItemTemplateSelector="{TemplateBinding ItemTemplateSelector}"
+                                            ItemsSource="{TemplateBinding OptionsItemsSource}"
+                                            ScrollViewer.VerticalScrollBarVisibility="Disabled"
+                                            SelectedIndex="{Binding SelectedOptionsIndex, Mode=TwoWay, RelativeSource={RelativeSource Mode=TemplatedParent}}"
+                                            SelectedItem="{Binding SelectedOptionsItem, Mode=TwoWay, RelativeSource={RelativeSource Mode=TemplatedParent}}"
+                                            SelectionMode="None"
+                                            TabIndex="2">
+                                        <ListView.ItemContainerStyle>
+                                            <Style TargetType="ListViewItem">
+                                                <Setter Property="Padding" Value="0" />
+                                            </Style>
+                                        </ListView.ItemContainerStyle>
+                                    </ListView>
                                 </Grid>
                             </SplitView.Pane>
-                            <ContentPresenter x:Name="ContentPart"
-                                              AutomationProperties.Name="Content"
-                                              Content="{TemplateBinding Content}" />
+                            <ContentPresenter
+                                    x:Name="ContentPart"
+                                    Content="{TemplateBinding Content}" />
                         </SplitView>
-                        <Button Name="HamburgerButton"
+                        <Button
+                                x:Name="HamburgerButton"
                                 Width="{TemplateBinding HamburgerWidth}"
                                 Height="{TemplateBinding HamburgerHeight}"
-                                Visibility="{TemplateBinding HamburgerVisibility}"
+                                Margin="0,8"
                                 Padding="0"
                                 VerticalAlignment="Top"
-                                AutomationProperties.Name="Main button"
                                 Background="Transparent"
                                 BorderThickness="0"
-                                TabIndex="0">
-                            <ContentControl Margin="{TemplateBinding HamburgerMargin}"
-                                            ContentTemplate="{TemplateBinding HamburgerMenuTemplate}"
-                                            Foreground="{TemplateBinding PaneForeground}"
-                                            IsTabStop="False" />
+                                TabIndex="0"
+                                Visibility="{TemplateBinding HamburgerVisibility}">
+                            <ContentControl
+                                    ContentTemplate="{TemplateBinding HamburgerMenuTemplate}"
+                                    Foreground="{TemplateBinding PaneForeground}"
+                                    IsTabStop="False" />
                         </Button>
                     </Grid>
                 </ControlTemplate>

--- a/Microsoft.Toolkit.Uwp.UI.Controls/HamburgerMenu/HamburgerMenu.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/HamburgerMenu/HamburgerMenu.xaml
@@ -26,7 +26,7 @@
                                    PaneBackground="{TemplateBinding PaneBackground}"
                                    PanePlacement="{TemplateBinding PanePlacement}">
                             <SplitView.Pane>
-                                <Grid x:Name="PaneGrid" 
+                                <Grid x:Name="PaneGrid"
                                       FlowDirection="LeftToRight">
                                     <Grid.RowDefinitions>
                                         <RowDefinition Height="Auto" />

--- a/Microsoft.Toolkit.Uwp.UI.Controls/HamburgerMenu/HamburgerMenu.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/HamburgerMenu/HamburgerMenu.xaml
@@ -6,10 +6,9 @@
         <Setter Property="HamburgerMenuTemplate">
             <Setter.Value>
                 <DataTemplate>
-                    <FontIcon
-                            FontFamily="Segoe MDL2 Assets"
-                            FontSize="16"
-                            Glyph="&#xE700;" />
+                    <FontIcon FontFamily="Segoe MDL2 Assets"
+                              FontSize="16"
+                              Glyph="&#xE700;" />
                 </DataTemplate>
             </Setter.Value>
         </Setter>
@@ -18,61 +17,58 @@
             <Setter.Value>
                 <ControlTemplate TargetType="local:HamburgerMenu">
                     <Grid>
-                        <SplitView
-                                x:Name="MainSplitView"
-                                CompactPaneLength="{TemplateBinding CompactPaneLength}"
-                                DisplayMode="{TemplateBinding DisplayMode}"
-                                IsPaneOpen="{Binding IsPaneOpen, Mode=TwoWay, RelativeSource={RelativeSource Mode=TemplatedParent}}"
-                                IsTabStop="False"
-                                OpenPaneLength="{TemplateBinding OpenPaneLength}"
-                                PaneBackground="{TemplateBinding PaneBackground}"
-                                PanePlacement="{TemplateBinding PanePlacement}">
+                        <SplitView x:Name="MainSplitView"
+                                   CompactPaneLength="{TemplateBinding CompactPaneLength}"
+                                   DisplayMode="{TemplateBinding DisplayMode}"
+                                   IsPaneOpen="{Binding IsPaneOpen, Mode=TwoWay, RelativeSource={RelativeSource Mode=TemplatedParent}}"
+                                   IsTabStop="False"
+                                   OpenPaneLength="{TemplateBinding OpenPaneLength}"
+                                   PaneBackground="{TemplateBinding PaneBackground}"
+                                   PanePlacement="{TemplateBinding PanePlacement}">
                             <SplitView.Pane>
-                                <Grid x:Name="PaneGrid" FlowDirection="LeftToRight">
+                                <Grid x:Name="PaneGrid" 
+                                      FlowDirection="LeftToRight">
                                     <Grid.RowDefinitions>
                                         <RowDefinition Height="Auto" />
                                         <RowDefinition Height="*" />
                                         <RowDefinition Height="Auto" />
                                     </Grid.RowDefinitions>
-                                    <Grid
-                                            Grid.Row="0"
-                                            Height="{TemplateBinding HamburgerHeight}"
-                                            Margin="0,0,0,8" />
+                                    <Grid Grid.Row="0"
+                                          Height="{TemplateBinding HamburgerHeight}"
+                                          Margin="0,0,0,8" />
 
-                                    <ListView
-                                            x:Name="ButtonsListView"
-                                            Grid.Row="1"
-                                            Width="{TemplateBinding OpenPaneLength}"
-                                            IsItemClickEnabled="True"
-                                            ItemTemplate="{TemplateBinding ItemTemplate}"
-                                            ItemTemplateSelector="{TemplateBinding ItemTemplateSelector}"
-                                            ItemsSource="{TemplateBinding ItemsSource}"
-                                            ScrollViewer.VerticalScrollBarVisibility="Auto"
-                                            SelectedIndex="{Binding SelectedIndex, Mode=TwoWay, RelativeSource={RelativeSource Mode=TemplatedParent}}"
-                                            SelectedItem="{Binding SelectedItem, Mode=TwoWay, RelativeSource={RelativeSource Mode=TemplatedParent}}"
-                                            SelectionMode="None"
-                                            TabIndex="1">
+                                    <ListView x:Name="ButtonsListView"
+                                              Grid.Row="1"
+                                              Width="{TemplateBinding OpenPaneLength}"
+                                              IsItemClickEnabled="True"
+                                              ItemTemplate="{TemplateBinding ItemTemplate}"
+                                              ItemTemplateSelector="{TemplateBinding ItemTemplateSelector}"
+                                              ItemsSource="{TemplateBinding ItemsSource}"
+                                              ScrollViewer.VerticalScrollBarVisibility="Auto"
+                                              SelectedIndex="{Binding SelectedIndex, Mode=TwoWay, RelativeSource={RelativeSource Mode=TemplatedParent}}"
+                                              SelectedItem="{Binding SelectedItem, Mode=TwoWay, RelativeSource={RelativeSource Mode=TemplatedParent}}"
+                                              SelectionMode="None"
+                                              TabIndex="1">
                                         <ListView.ItemContainerStyle>
                                             <Style TargetType="ListViewItem">
                                                 <Setter Property="Padding" Value="0" />
                                             </Style>
                                         </ListView.ItemContainerStyle>
                                     </ListView>
-                                    <ListView
-                                            x:Name="OptionsListView"
-                                            Grid.Row="2"
-                                            Width="{TemplateBinding OpenPaneLength}"
-                                            IsItemClickEnabled="True"
-                                            Margin="0,20,0,8"
-                                            VerticalAlignment="Bottom"
-                                            ItemTemplate="{TemplateBinding OptionsItemTemplate}"
-                                            ItemTemplateSelector="{TemplateBinding ItemTemplateSelector}"
-                                            ItemsSource="{TemplateBinding OptionsItemsSource}"
-                                            ScrollViewer.VerticalScrollBarVisibility="Disabled"
-                                            SelectedIndex="{Binding SelectedOptionsIndex, Mode=TwoWay, RelativeSource={RelativeSource Mode=TemplatedParent}}"
-                                            SelectedItem="{Binding SelectedOptionsItem, Mode=TwoWay, RelativeSource={RelativeSource Mode=TemplatedParent}}"
-                                            SelectionMode="None"
-                                            TabIndex="2">
+                                    <ListView x:Name="OptionsListView"
+                                              Grid.Row="2"
+                                              Width="{TemplateBinding OpenPaneLength}"
+                                              IsItemClickEnabled="True"
+                                              Margin="0,20,0,8"
+                                              VerticalAlignment="Bottom"
+                                              ItemTemplate="{TemplateBinding OptionsItemTemplate}"
+                                              ItemTemplateSelector="{TemplateBinding ItemTemplateSelector}"
+                                              ItemsSource="{TemplateBinding OptionsItemsSource}"
+                                              ScrollViewer.VerticalScrollBarVisibility="Disabled"
+                                              SelectedIndex="{Binding SelectedOptionsIndex, Mode=TwoWay, RelativeSource={RelativeSource Mode=TemplatedParent}}"
+                                              SelectedItem="{Binding SelectedOptionsItem, Mode=TwoWay, RelativeSource={RelativeSource Mode=TemplatedParent}}"
+                                              SelectionMode="None"
+                                              TabIndex="2">
                                         <ListView.ItemContainerStyle>
                                             <Style TargetType="ListViewItem">
                                                 <Setter Property="Padding" Value="0" />
@@ -81,12 +77,11 @@
                                     </ListView>
                                 </Grid>
                             </SplitView.Pane>
-                            <ContentPresenter
-                                    x:Name="ContentPart"
-                                    Content="{TemplateBinding Content}" />
+                            <ContentPresenter x:Name="ContentPart"
+                                              AutomationProperties.Name="Content"
+                                              Content="{TemplateBinding Content}" />
                         </SplitView>
-                        <Button
-                                x:Name="HamburgerButton"
+                        <Button x:Name="HamburgerButton"
                                 Width="{TemplateBinding HamburgerWidth}"
                                 Height="{TemplateBinding HamburgerHeight}"
                                 Margin="0,8"
@@ -96,10 +91,9 @@
                                 BorderThickness="0"
                                 TabIndex="0"
                                 Visibility="{TemplateBinding HamburgerVisibility}">
-                            <ContentControl
-                                    ContentTemplate="{TemplateBinding HamburgerMenuTemplate}"
-                                    Foreground="{TemplateBinding PaneForeground}"
-                                    IsTabStop="False" />
+                            <ContentControl ContentTemplate="{TemplateBinding HamburgerMenuTemplate}"
+                                            Foreground="{TemplateBinding PaneForeground}"
+                                            IsTabStop="False" />
                         </Button>
                     </Grid>
                 </ControlTemplate>

--- a/Microsoft.Toolkit.Uwp.UI.Controls/HamburgerMenu/HamburgerMenu.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/HamburgerMenu/HamburgerMenu.xaml
@@ -40,6 +40,7 @@
                                     <ListView x:Name="ButtonsListView"
                                               Grid.Row="1"
                                               Width="{TemplateBinding OpenPaneLength}"
+                                              AutomationProperties.Name="Menu items"
                                               IsItemClickEnabled="True"
                                               ItemTemplate="{TemplateBinding ItemTemplate}"
                                               ItemTemplateSelector="{TemplateBinding ItemTemplateSelector}"
@@ -61,6 +62,7 @@
                                               IsItemClickEnabled="True"
                                               Margin="0,20,0,8"
                                               VerticalAlignment="Bottom"
+                                              AutomationProperties.Name="Option items"
                                               ItemTemplate="{TemplateBinding OptionsItemTemplate}"
                                               ItemTemplateSelector="{TemplateBinding ItemTemplateSelector}"
                                               ItemsSource="{TemplateBinding OptionsItemsSource}"
@@ -84,13 +86,14 @@
                         <Button x:Name="HamburgerButton"
                                 Width="{TemplateBinding HamburgerWidth}"
                                 Height="{TemplateBinding HamburgerHeight}"
+                                Visibility="{TemplateBinding HamburgerVisibility}"
                                 Margin="0,8"
                                 Padding="0"
                                 VerticalAlignment="Top"
+                                AutomationProperties.Name="Main button"
                                 Background="Transparent"
                                 BorderThickness="0"
-                                TabIndex="0"
-                                Visibility="{TemplateBinding HamburgerVisibility}">
+                                TabIndex="0">
                             <ContentControl ContentTemplate="{TemplateBinding HamburgerMenuTemplate}"
                                             Foreground="{TemplateBinding PaneForeground}"
                                             IsTabStop="False" />

--- a/Microsoft.Toolkit.Uwp.UI.Controls/HamburgerMenu/HamburgerMenu.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/HamburgerMenu/HamburgerMenu.xaml
@@ -20,7 +20,7 @@
                         <SplitView x:Name="MainSplitView"
                                    CompactPaneLength="{TemplateBinding CompactPaneLength}"
                                    DisplayMode="{TemplateBinding DisplayMode}"
-                                   IsPaneOpen="{Binding IsPaneOpen, Mode=TwoWay, RelativeSource={RelativeSource Mode=TemplatedParent}}"
+                                   IsPaneOpen="{Binding IsPaneOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
                                    IsTabStop="False"
                                    OpenPaneLength="{TemplateBinding OpenPaneLength}"
                                    PaneBackground="{TemplateBinding PaneBackground}"
@@ -48,7 +48,7 @@
                                               ScrollViewer.VerticalScrollBarVisibility="Auto"
                                               SelectedIndex="{Binding SelectedIndex, Mode=TwoWay, RelativeSource={RelativeSource Mode=TemplatedParent}}"
                                               SelectedItem="{Binding SelectedItem, Mode=TwoWay, RelativeSource={RelativeSource Mode=TemplatedParent}}"
-                                              SelectionMode="None"
+                                              SelectionMode="Single"
                                               TabIndex="1">
                                         <ListView.ItemContainerStyle>
                                             <Style TargetType="ListViewItem">
@@ -64,12 +64,12 @@
                                               VerticalAlignment="Bottom"
                                               AutomationProperties.Name="Option items"
                                               ItemTemplate="{TemplateBinding OptionsItemTemplate}"
-                                              ItemTemplateSelector="{TemplateBinding ItemTemplateSelector}"
+                                              ItemTemplateSelector="{TemplateBinding OptionsItemTemplateSelector}"
                                               ItemsSource="{TemplateBinding OptionsItemsSource}"
                                               ScrollViewer.VerticalScrollBarVisibility="Disabled"
                                               SelectedIndex="{Binding SelectedOptionsIndex, Mode=TwoWay, RelativeSource={RelativeSource Mode=TemplatedParent}}"
                                               SelectedItem="{Binding SelectedOptionsItem, Mode=TwoWay, RelativeSource={RelativeSource Mode=TemplatedParent}}"
-                                              SelectionMode="None"
+                                              SelectionMode="Single"
                                               TabIndex="2">
                                         <ListView.ItemContainerStyle>
                                             <Style TargetType="ListViewItem">
@@ -94,7 +94,8 @@
                                 Background="Transparent"
                                 BorderThickness="0"
                                 TabIndex="0">
-                            <ContentControl ContentTemplate="{TemplateBinding HamburgerMenuTemplate}"
+                            <ContentControl Margin="{TemplateBinding HamburgerMargin}"
+                                            ContentTemplate="{TemplateBinding HamburgerMenuTemplate}"
                                             Foreground="{TemplateBinding PaneForeground}"
                                             IsTabStop="False" />
                         </Button>

--- a/Microsoft.Toolkit.Uwp.UI.Controls/HamburgerMenu/HamburgerMenu.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/HamburgerMenu/HamburgerMenu.xaml
@@ -36,7 +36,6 @@
                                     <Grid Grid.Row="0"
                                           Height="{TemplateBinding HamburgerHeight}"
                                           Margin="0,0,0,8" />
-
                                     <ListView x:Name="ButtonsListView"
                                               Grid.Row="1"
                                               Width="{TemplateBinding OpenPaneLength}"
@@ -46,8 +45,8 @@
                                               ItemTemplateSelector="{TemplateBinding ItemTemplateSelector}"
                                               ItemsSource="{TemplateBinding ItemsSource}"
                                               ScrollViewer.VerticalScrollBarVisibility="Auto"
-                                              SelectedIndex="{Binding SelectedIndex, Mode=TwoWay, RelativeSource={RelativeSource Mode=TemplatedParent}}"
-                                              SelectedItem="{Binding SelectedItem, Mode=TwoWay, RelativeSource={RelativeSource Mode=TemplatedParent}}"
+                                              SelectedIndex="{Binding SelectedIndex, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
+                                              SelectedItem="{Binding SelectedItem, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
                                               SelectionMode="Single"
                                               TabIndex="1">
                                         <ListView.ItemContainerStyle>
@@ -59,18 +58,18 @@
                                     <ListView x:Name="OptionsListView"
                                               Grid.Row="2"
                                               Width="{TemplateBinding OpenPaneLength}"
-                                              IsItemClickEnabled="True"
-                                              Margin="0,20,0,8"
                                               VerticalAlignment="Bottom"
                                               AutomationProperties.Name="Option items"
+                                              IsItemClickEnabled="True"
                                               ItemTemplate="{TemplateBinding OptionsItemTemplate}"
                                               ItemTemplateSelector="{TemplateBinding OptionsItemTemplateSelector}"
                                               ItemsSource="{TemplateBinding OptionsItemsSource}"
                                               ScrollViewer.VerticalScrollBarVisibility="Disabled"
-                                              SelectedIndex="{Binding SelectedOptionsIndex, Mode=TwoWay, RelativeSource={RelativeSource Mode=TemplatedParent}}"
-                                              SelectedItem="{Binding SelectedOptionsItem, Mode=TwoWay, RelativeSource={RelativeSource Mode=TemplatedParent}}"
+                                              SelectedIndex="{Binding SelectedOptionsIndex, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
+                                              SelectedItem="{Binding SelectedOptionsItem, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
                                               SelectionMode="Single"
-                                              TabIndex="2">
+                                              TabIndex="2"
+                                              Margin="0,20,0,8">
                                         <ListView.ItemContainerStyle>
                                             <Style TargetType="ListViewItem">
                                                 <Setter Property="Padding" Value="0" />


### PR DESCRIPTION
This allows the HamburgerMenu to act more closer to the new [NavigationView](https://docs.microsoft.com/en-us/windows/uwp/controls-and-patterns/navigationview) in the Fall Creators Update. 