### PR TITLE
Using EventArgs.Empty instead of creating new EventArgs empty instances.

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/Expander/Expander.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/Expander/Expander.cs
@@ -73,13 +73,13 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         private void ExpandControl()
         {
             VisualStateManager.GoToState(this, StateContentExpanded, true);
-            Expanded?.Invoke(this, new EventArgs());
+            Expanded?.Invoke(this, EventArgs.Empty);
         }
 
         private void CollapseControl()
         {
             VisualStateManager.GoToState(this, StateContentCollapsed, true);
-            Collapsed?.Invoke(this, new EventArgs());
+            Collapsed?.Invoke(this, EventArgs.Empty);
         }
     }
 }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/ImageEx/ImageExBase.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/ImageEx/ImageExBase.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
             IsInitialized = true;
 
-            ImageExInitialized?.Invoke(this, new EventArgs());
+            ImageExInitialized?.Invoke(this, EventArgs.Empty);
 
             SetSource(Source);
 

--- a/Microsoft.Toolkit.Uwp.UI.Controls/PullToRefreshListView/PullToRefreshListView.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/PullToRefreshListView/PullToRefreshListView.cs
@@ -365,7 +365,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
             if (_refreshActivated)
             {
-                RefreshRequested?.Invoke(this, new EventArgs());
+                RefreshRequested?.Invoke(this, EventArgs.Empty);
                 if (RefreshCommand != null && RefreshCommand.CanExecute(null))
                 {
                     RefreshCommand.Execute(null);
@@ -373,7 +373,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             }
             else if (_refreshIntentCanceled)
             {
-                RefreshIntentCanceled?.Invoke(this, new EventArgs());
+                RefreshIntentCanceled?.Invoke(this, EventArgs.Empty);
                 if (RefreshIntentCanceledCommand != null && RefreshIntentCanceledCommand.CanExecute(null))
                 {
                     RefreshIntentCanceledCommand.Execute(null);

--- a/Microsoft.Toolkit.Uwp.UI.Controls/SlidableListItem/SlidableListItem.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/SlidableListItem/SlidableListItem.cs
@@ -338,12 +338,12 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
             if (SwipeStatus == SwipeStatus.SwipingPassedLeftThreshold)
             {
-                RightCommandRequested?.Invoke(this, new EventArgs());
+                RightCommandRequested?.Invoke(this, EventArgs.Empty);
                 RightCommand?.Execute(RightCommandParameter);
             }
             else if (SwipeStatus == SwipeStatus.SwipingPassedRightThreshold)
             {
-                LeftCommandRequested?.Invoke(this, new EventArgs());
+                LeftCommandRequested?.Invoke(this, EventArgs.Empty);
                 LeftCommand?.Execute(LeftCommandParameter);
             }
 

--- a/Microsoft.Toolkit.Uwp/Helpers/Network/NetworkHelper.cs
+++ b/Microsoft.Toolkit.Uwp/Helpers/Network/NetworkHelper.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Toolkit.Uwp
 
             ConnectionInformation.UpdateConnectionInformation(profile);
 
-            NetworkChanged?.Invoke(this, new EventArgs());
+            NetworkChanged?.Invoke(this, EventArgs.Empty);
         }
     }
 }

--- a/UnitTests/Helpers/Test_WeakEventListener.cs
+++ b/UnitTests/Helpers/Test_WeakEventListener.cs
@@ -30,7 +30,7 @@ namespace UnitTests.Helpers
 
             protected virtual void OnRaiseEvent()
             {
-                Raisevent?.Invoke(this, new EventArgs());
+                Raisevent?.Invoke(this, EventArgs.Empty);
             }
         }
 


### PR DESCRIPTION
The cleaner the better.