### PR TITLE
Remove Stretch overrides in RoundImageEx constructor

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/ImageEx/RoundImageEx.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/ImageEx/RoundImageEx.cs
@@ -35,10 +35,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             : base()
         {
             DefaultStyleKey = typeof(RoundImageEx);
-
-            // Changes default Stretching as Uniform doesn't work well for ImageBrush
-            Stretch = Stretch.UniformToFill;
-            PlaceholderStretch = Stretch.UniformToFill;
         }
 
         /// <summary>


### PR DESCRIPTION
Addressing #1273 
Removed Stretch defaults set in constructor