### PR TITLE
Crash in getter HamburgerMenu.OpenPaneLength with default value

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/HamburgerMenu/HamburgerMenu.Properties.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/HamburgerMenu/HamburgerMenu.Properties.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// <summary>
         /// Identifies the <see cref="OpenPaneLength"/> dependency property.
         /// </summary>
-        public static readonly DependencyProperty OpenPaneLengthProperty = DependencyProperty.Register(nameof(OpenPaneLength), typeof(double), typeof(HamburgerMenu), new PropertyMetadata(320));
+        public static readonly DependencyProperty OpenPaneLengthProperty = DependencyProperty.Register(nameof(OpenPaneLength), typeof(double), typeof(HamburgerMenu), new PropertyMetadata(320.0));
 
         /// <summary>
         /// Identifies the <see cref="PanePlacement"/> dependency property.


### PR DESCRIPTION
`<Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
        <toolkit:HamburgerMenu x:Name="HamburgerMenu"/>
    </Grid>`

`public MainPage()
        {
            this.InitializeComponent();
            var m = HamburgerMenu.OpenPaneLength;
        }`

This code in empty project with toolkit 1.5 will throw an exception.
System.InvalidCastException: 'Unable to cast object of type 'System.Int32' to type 'System.Double'.'