### PR TITLE
Removes all .AsTask().ConfigureAwait(false) calls

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI/Cache/CacheBase.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Cache/CacheBase.cs
@@ -133,7 +133,7 @@ namespace Microsoft.Toolkit.Uwp.UI
         public async Task ClearAsync()
         {
             var folder = await GetCacheFolderAsync().ConfigureAwait(false);
-            var files = await folder.GetFilesAsync().AsTask().ConfigureAwait(false);
+            var files = await folder.GetFilesAsync();
 
             await InternalClearAsync(files).ConfigureAwait(false);
 
@@ -160,7 +160,7 @@ namespace Microsoft.Toolkit.Uwp.UI
             TimeSpan expiryDuration = duration.HasValue ? duration.Value : CacheDuration;
 
             var folder = await GetCacheFolderAsync().ConfigureAwait(false);
-            var files = await folder.GetFilesAsync().AsTask().ConfigureAwait(false);
+            var files = await folder.GetFilesAsync();
 
             var filesToDelete = new List<StorageFile>();
 
@@ -195,7 +195,7 @@ namespace Microsoft.Toolkit.Uwp.UI
             }
 
             var folder = await GetCacheFolderAsync().ConfigureAwait(false);
-            var files = await folder.GetFilesAsync().AsTask().ConfigureAwait(false);
+            var files = await folder.GetFilesAsync();
 
             var filesToDelete = new List<StorageFile>();
             var keys = new List<string>();
@@ -262,7 +262,7 @@ namespace Microsoft.Toolkit.Uwp.UI
 
             string fileName = GetCacheFileName(uri);
 
-            var item = await folder.TryGetItemAsync(fileName).AsTask().ConfigureAwait(false);
+            var item = await folder.TryGetItemAsync(fileName);
 
             return item as StorageFile;
         }
@@ -320,7 +320,7 @@ namespace Microsoft.Toolkit.Uwp.UI
                 return treatNullFileAsOutOfDate;
             }
 
-            var properties = await file.GetBasicPropertiesAsync().AsTask().ConfigureAwait(false);
+            var properties = await file.GetBasicPropertiesAsync();
 
             return properties.Size == 0 || DateTime.Now.Subtract(properties.DateModified.DateTime) > duration;
         }
@@ -412,11 +412,11 @@ namespace Microsoft.Toolkit.Uwp.UI
             }
 
             var folder = await GetCacheFolderAsync().ConfigureAwait(MaintainContext);
-            baseFile = await folder.TryGetItemAsync(fileName).AsTask().ConfigureAwait(MaintainContext) as StorageFile;
+            baseFile = await folder.TryGetItemAsync(fileName) as StorageFile;
 
             if (baseFile == null || await IsFileOutOfDateAsync(baseFile, CacheDuration).ConfigureAwait(MaintainContext))
             {
-                baseFile = await folder.CreateFileAsync(fileName, CreationCollisionOption.ReplaceExisting).AsTask().ConfigureAwait(MaintainContext);
+                baseFile = await folder.CreateFileAsync(fileName, CreationCollisionOption.ReplaceExisting);
 
                 uint retries = 0;
                 try
@@ -441,7 +441,7 @@ namespace Microsoft.Toolkit.Uwp.UI
                 }
                 catch (Exception)
                 {
-                    await baseFile.DeleteAsync().AsTask().ConfigureAwait(false);
+                    await baseFile.DeleteAsync();
                     throw; // re-throwing the exception changes the stack trace. just throw
                 }
             }
@@ -452,7 +452,7 @@ namespace Microsoft.Toolkit.Uwp.UI
 
                 if (_inMemoryFileStorage.MaxItemCount > 0)
                 {
-                    var properties = await baseFile.GetBasicPropertiesAsync().AsTask().ConfigureAwait(false);
+                    var properties = await baseFile.GetBasicPropertiesAsync();
 
                     var msi = new InMemoryStorageItem<T>(fileName, properties.DateModified.DateTime, instance);
                     _inMemoryFileStorage.SetItem(msi);
@@ -506,7 +506,7 @@ namespace Microsoft.Toolkit.Uwp.UI
             {
                 try
                 {
-                    await file.DeleteAsync().AsTask().ConfigureAwait(false);
+                    await file.DeleteAsync();
                 }
                 catch
                 {
@@ -542,7 +542,7 @@ namespace Microsoft.Toolkit.Uwp.UI
 
             try
             {
-                _cacheFolder = await _baseFolder.CreateFolderAsync(_cacheFolderName, CreationCollisionOption.OpenIfExists).AsTask().ConfigureAwait(false);
+                _cacheFolder = await _baseFolder.CreateFolderAsync(_cacheFolderName, CreationCollisionOption.OpenIfExists);
             }
             finally
             {

--- a/Microsoft.Toolkit.Uwp.UI/Cache/ImageCache.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Cache/ImageCache.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Toolkit.Uwp.UI
                 }
             }
 
-            await image.SetSourceAsync(stream).AsTask().ConfigureAwait(false);
+            await image.SetSourceAsync(stream);
 
             return image;
         }
@@ -95,7 +95,7 @@ namespace Microsoft.Toolkit.Uwp.UI
         /// <returns>awaitable task</returns>
         protected override async Task<BitmapImage> InitializeTypeAsync(StorageFile baseFile, List<KeyValuePair<string, object>> initializerKeyValues = null)
         {
-            using (var stream = await baseFile.OpenReadAsync().AsTask().ConfigureAwait(MaintainContext))
+            using (var stream = await baseFile.OpenReadAsync())
             {
                 return await InitializeTypeAsync(stream, initializerKeyValues).ConfigureAwait(MaintainContext);
             }
@@ -117,7 +117,7 @@ namespace Microsoft.Toolkit.Uwp.UI
 
             // Get extended properties.
             IDictionary<string, object> extraProperties =
-                await file.Properties.RetrievePropertiesAsync(_extendedPropertyNames).AsTask().ConfigureAwait(false);
+                await file.Properties.RetrievePropertiesAsync(_extendedPropertyNames);
 
             // Get date-accessed property.
             var propValue = extraProperties[DateAccessedProperty];
@@ -132,7 +132,7 @@ namespace Microsoft.Toolkit.Uwp.UI
                 }
             }
 
-            var properties = await file.GetBasicPropertiesAsync().AsTask().ConfigureAwait(false);
+            var properties = await file.GetBasicPropertiesAsync();
 
             return properties.Size == 0 || DateTime.Now.Subtract(properties.DateModified.DateTime) > duration;
         }

--- a/Microsoft.Toolkit.Uwp/Helpers/StorageFileHelper.cs
+++ b/Microsoft.Toolkit.Uwp/Helpers/StorageFileHelper.cs
@@ -558,7 +558,7 @@ namespace Microsoft.Toolkit.Uwp
                 throw new ArgumentNullException(nameof(fileName));
             }
 
-            var file = await fileLocation.GetFileAsync(fileName).AsTask().ConfigureAwait(false);
+            var file = await fileLocation.GetFileAsync(fileName);
             return await file.ReadBytesAsync();
         }
 
@@ -646,7 +646,7 @@ namespace Microsoft.Toolkit.Uwp
         /// </returns>
         internal static async Task<bool> FileExistsInFolderAsync(StorageFolder folder, string fileName)
         {
-            var item = await folder.TryGetItemAsync(fileName).AsTask().ConfigureAwait(false);
+            var item = await folder.TryGetItemAsync(fileName);
             return (item != null) && item.IsOfType(StorageItemTypes.File);
         }
 
@@ -678,7 +678,7 @@ namespace Microsoft.Toolkit.Uwp
                 UserSearchFilter = $"filename:=\"{fileName}\"" // “:=” is the exact-match operator
             };
 
-            var files = await rootFolder.CreateFileQueryWithOptions(options).GetFilesAsync().AsTask().ConfigureAwait(false);
+            var files = await rootFolder.CreateFileQueryWithOptions(options).GetFilesAsync();
             return files.Count > 0;
         }
 

--- a/Microsoft.Toolkit.Uwp/Helpers/StreamHelper.cs
+++ b/Microsoft.Toolkit.Uwp/Helpers/StreamHelper.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Toolkit.Uwp
                 {
                     if (response.Success)
                     {
-                        await response.Content.WriteToStreamAsync(outputStream).AsTask().ConfigureAwait(false);
+                        await response.Content.WriteToStreamAsync(outputStream);
 
                         outputStream.Seek(0);
                     }
@@ -63,7 +63,7 @@ namespace Microsoft.Toolkit.Uwp
             this Uri uri,
             StorageFile targetFile)
         {
-            using (var fileStream = await targetFile.OpenAsync(FileAccessMode.ReadWrite).AsTask().ConfigureAwait(false))
+            using (var fileStream = await targetFile.OpenAsync(FileAccessMode.ReadWrite))
             {
                 using (var request = new HttpHelperRequest(uri, HttpMethod.Get))
                 {
@@ -71,7 +71,7 @@ namespace Microsoft.Toolkit.Uwp
                     {
                         if (response.Success)
                         {
-                            await response.Content.WriteToStreamAsync(fileStream).AsTask().ConfigureAwait(false);
+                            await response.Content.WriteToStreamAsync(fileStream);
                         }
                     }
                 }


### PR DESCRIPTION
If a method is `IAsync*`, one should not do `.AsTask()` just to call `.ConfigureAwait(false)` on it.

Platform calls are async by nature and will (might?) run on a separate thread that will return to the calling thread, no matter whats the configuration of the await.