### PR TITLE
Add SIP Schema support for MarkDownLink

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/Parse/Inlines/HyperlinkInline.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/Parse/Inlines/HyperlinkInline.cs
@@ -109,6 +109,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls.Markdown.Parse
             "mumble://",
             "ssh://",
             "ms-windows-store://",
+            "sip:"
         };
 
         /// <summary>

--- a/UnitTests/UnitTests.MarkdownTextBlock/Parse/MarkdownLinkTests.cs
+++ b/UnitTests/UnitTests.MarkdownTextBlock/Parse/MarkdownLinkTests.cs
@@ -166,6 +166,8 @@ namespace UnitTests.Markdown.Parse
 
                 [text](mumble://reddit.com)
 
+                [text](sip:1-999-123-4567@voip-provider.example.net)
+
                 [text](ssh://reddit.com)"),
                 new ParagraphBlock().AddChildren(new MarkdownLinkInline { Url = "http://reddit.com" }.AddChildren(new TextRunInline { Text = "text" })),
                 new ParagraphBlock().AddChildren(new MarkdownLinkInline { Url = "https://reddit.com" }.AddChildren(new TextRunInline { Text = "text" })),
@@ -174,6 +176,7 @@ namespace UnitTests.Markdown.Parse
                 new ParagraphBlock().AddChildren(new MarkdownLinkInline { Url = "irc://reddit.com" }.AddChildren(new TextRunInline { Text = "text" })),
                 new ParagraphBlock().AddChildren(new MarkdownLinkInline { Url = "news://reddit.com" }.AddChildren(new TextRunInline { Text = "text" })),
                 new ParagraphBlock().AddChildren(new MarkdownLinkInline { Url = "mumble://reddit.com" }.AddChildren(new TextRunInline { Text = "text" })),
+                new ParagraphBlock().AddChildren(new MarkdownLinkInline { Url = "sip:1-999-123-4567@voip-provider.example.net" }.AddChildren(new TextRunInline { Text = "text" })),
                 new ParagraphBlock().AddChildren(new MarkdownLinkInline { Url = "ssh://reddit.com" }.AddChildren(new TextRunInline { Text = "text" })));
         }
 


### PR DESCRIPTION
Markdown Hyperlink Inline parser respects SIP formatted Schema links. 