### PR TITLE
Re-enable toast AfterActivationBehavior

### DIFF
--- a/Notifications/Microsoft.Toolkit.Uwp.Notifications.Shared/Toasts/ToastActivationOptions.cs
+++ b/Notifications/Microsoft.Toolkit.Uwp.Notifications.Shared/Toasts/ToastActivationOptions.cs
@@ -25,9 +25,8 @@ namespace Microsoft.Toolkit.Uwp.Notifications
         public string ProtocolActivationTargetApplicationPfn { get; set; }
 
         /// <summary>
-        /// Not supported on Windows: Specifies the behavior that the toast should use when the user invokes this action. Note that this option only works on <see cref="ToastButton"/> and <see cref="ToastContextMenuItem"/>.
+        /// New in Fall Creators Update: Specifies the behavior that the toast should use when the user invokes this action. Note that this option only works on <see cref="ToastButton"/> and <see cref="ToastContextMenuItem"/>. Desktop-only, supported in builds 16251 or higher.
         /// </summary>
-        [Obsolete("Windows does not support AfterActivationBehavior. If a future version of Windows supports this, we will undeprecate the property when support is added.")]
         public ToastAfterActivationBehavior AfterActivationBehavior { get; set; } = ToastAfterActivationBehavior.Default;
 
         internal void PopulateElement(IElement_ToastActivatable el)
@@ -39,9 +38,7 @@ namespace Microsoft.Toolkit.Uwp.Notifications
             }
 
             el.ProtocolActivationTargetApplicationPfn = ProtocolActivationTargetApplicationPfn;
-#pragma warning disable 618
             el.AfterActivationBehavior = AfterActivationBehavior;
-#pragma warning restore 618
         }
     }
 }

--- a/Notifications/Microsoft.Toolkit.Uwp.Notifications.Shared/Toasts/ToastContent.cs
+++ b/Notifications/Microsoft.Toolkit.Uwp.Notifications.Shared/Toasts/ToastContent.cs
@@ -102,9 +102,7 @@ namespace Microsoft.Toolkit.Uwp.Notifications
         {
             if (ActivationOptions != null)
             {
-#pragma warning disable 618
                 if (ActivationOptions.AfterActivationBehavior != ToastAfterActivationBehavior.Default)
-#pragma warning restore 618
                 {
                     throw new InvalidOperationException("ToastContent does not support a custom AfterActivationBehavior. Please ensure ActivationOptions.AfterActivationBehavior is set to Default.");
                 }

--- a/Notifications/Microsoft.Toolkit.Uwp.Notifications.Shared/Toasts/ToastHeader.cs
+++ b/Notifications/Microsoft.Toolkit.Uwp.Notifications.Shared/Toasts/ToastHeader.cs
@@ -101,9 +101,7 @@ namespace Microsoft.Toolkit.Uwp.Notifications
         {
             if (ActivationOptions != null)
             {
-#pragma warning disable 618
                 if (ActivationOptions.AfterActivationBehavior != ToastAfterActivationBehavior.Default)
-#pragma warning restore 618
                 {
                     throw new InvalidOperationException("ToastHeader does not support a custom AfterActivationBehavior. Please ensure ActivationOptions.AfterActivationBehavior is set to Default.");
                 }

--- a/UnitTests/UnitTests.Notifications.Shared/Test_Toast_Xml.cs
+++ b/UnitTests/UnitTests.Notifications.Shared/Test_Toast_Xml.cs
@@ -1351,9 +1351,7 @@ namespace UnitTests.Notifications
                 ActivationType = ToastActivationType.Protocol,
                 ActivationOptions = new ToastActivationOptions()
                 {
-#pragma warning disable 618
                     AfterActivationBehavior = ToastAfterActivationBehavior.PendingUpdate,
-#pragma warning restore 618
                     ProtocolActivationTargetApplicationPfn = "Microsoft.Settings"
                 }
             });
@@ -1371,9 +1369,7 @@ namespace UnitTests.Notifications
                 ActivationType = ToastActivationType.Background,
                 ActivationOptions = new ToastActivationOptions()
                 {
-#pragma warning disable 618
                     AfterActivationBehavior = ToastAfterActivationBehavior.Default
-#pragma warning restore 618
                 }
             });
 
@@ -1403,9 +1399,7 @@ namespace UnitTests.Notifications
                 ActivationType = ToastActivationType.Protocol,
                 ActivationOptions = new ToastActivationOptions()
                 {
-#pragma warning disable 618
                     AfterActivationBehavior = ToastAfterActivationBehavior.PendingUpdate,
-#pragma warning restore 618
                     ProtocolActivationTargetApplicationPfn = "Microsoft.Settings"
                 }
             };
@@ -1418,9 +1412,7 @@ namespace UnitTests.Notifications
             AssertContextMenuItemPayload("<action placement='contextMenu' content='My content' arguments='myArgs' activationType='protocol' />", item);
 
             // Default should be ignored
-#pragma warning disable 618
             item.ActivationOptions.AfterActivationBehavior = ToastAfterActivationBehavior.Default;
-#pragma warning restore 618
 
             AssertContextMenuItemPayload("<action placement='contextMenu' content='My content' arguments='myArgs' activationType='protocol' />", item);
 
@@ -1470,9 +1462,7 @@ namespace UnitTests.Notifications
                 ActivationType = ToastActivationType.Background,
                 ActivationOptions = new ToastActivationOptions()
                 {
-#pragma warning disable 618
                     AfterActivationBehavior = ToastAfterActivationBehavior.Default
-#pragma warning restore 618
                 }
             });
 
@@ -1484,9 +1474,7 @@ namespace UnitTests.Notifications
                     Launch = "myArgs",
                     ActivationOptions = new ToastActivationOptions()
                     {
-#pragma warning disable 618
                         AfterActivationBehavior = ToastAfterActivationBehavior.PendingUpdate
-#pragma warning restore 618
                     }
                 });
                 Assert.Fail("InvalidOperationException should have been thrown.");
@@ -1533,17 +1521,13 @@ namespace UnitTests.Notifications
             AssertHeaderPayload("<header id='myId' title='My title' arguments='settings:about' activationType='protocol' />", header);
 
             // Default should be ignored
-#pragma warning disable 618
             header.ActivationOptions.AfterActivationBehavior = ToastAfterActivationBehavior.Default;
-#pragma warning restore 618
             AssertHeaderPayload("<header id='myId' title='My title' arguments='settings:about' activationType='protocol' />", header);
 
             // Using anything other than default should throw exception
             try
             {
-#pragma warning disable 618
                 header.ActivationOptions.AfterActivationBehavior = ToastAfterActivationBehavior.PendingUpdate;
-#pragma warning restore 618
                 AssertHeaderPayload("Exception should be thrown", header);
                 Assert.Fail("InvalidOperationException should have been thrown.");
             }


### PR DESCRIPTION
Toast AfterActivationBehavior is now available in Insider builds 16251 and higher for the Fall Creators Update! You can use AfterActivationBehavior to keep your toast around in a "pending update" state while a background task gets fired off, and then your background task should update the toast when the operation is complete. Great for things like Pause/Resume buttons on toast download progress.

This pull request simply removes the Obsolete tags we had to add. We previously accidentally added this API before it was available, hence we added Obsolete tags previously.