### PR TITLE
Use WebAuthenticationBroker instead of simple WebView for Facebook Signin

### DIFF
--- a/Microsoft.Toolkit.Uwp.Services/Services/Facebook/FacebookService.cs
+++ b/Microsoft.Toolkit.Uwp.Services/Services/Facebook/FacebookService.cs
@@ -167,7 +167,7 @@ namespace Microsoft.Toolkit.Uwp.Services.Facebook
         {
             if (Provider != null)
             {
-                var result = await Provider.LoginAsync(permissions, SessionLoginBehavior.WebView);
+                var result = await Provider.LoginAsync(permissions, SessionLoginBehavior.WebAuth);
 
                 if (result.Succeeded)
                 {


### PR DESCRIPTION
Using `WebAuthenticationBroker` gives consistency across the platform, like Twitter.