### PR TITLE
Ensure HeaderedTextBox Visual State Orientation is set to Initial Orientation

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/HeaderedTextBlock/HeaderedTextBlock.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/HeaderedTextBlock/HeaderedTextBlock.cs
@@ -43,6 +43,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             _textContent = GetTemplateChild("TextContent") as TextBlock;
 
             UpdateVisibility();
+            UpdateForOrientation(this.Orientation);
         }
 
         private void UpdateVisibility()


### PR DESCRIPTION
Noticed that in the sample app if you changed the HeaderedTextBox to Horizontal and then switched back to the same page it wouldn't re-initialize the margin from the Visual State when the control was retemplated:

![image](https://user-images.githubusercontent.com/24302614/29349085-bf90e4d0-820c-11e7-8253-9a750d80bdc4.png)

This fix calls the Visual State Manager update function to adjust to the current orientation on templating.