### PR TITLE
Fixes for DropShadowPanel and RadialGuage in the VS designer

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/DropShadowPanel/DropShadowPanel.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/DropShadowPanel/DropShadowPanel.cs
@@ -102,14 +102,20 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
         private void OnSizeChanged(object sender, SizeChangedEventArgs e)
         {
-            UpdateShadowSize();
+            if (IsSupported)
+            {
+                UpdateShadowSize();
+            }
         }
 
         private void ConfigureShadowVisualForCastingElement()
         {
             UpdateShadowMask();
 
-            UpdateShadowSize();
+            if (IsSupported)
+            {
+                UpdateShadowSize();
+            }
         }
 
         private void OnBlurRadiusChanged(double newValue)
@@ -130,7 +136,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
         private void OnOffsetXChanged(double newValue)
         {
-            if (_dropShadow != null)
+            if (IsSupported && _dropShadow != null)
             {
                 UpdateShadowOffset((float)newValue, _dropShadow.Offset.Y, _dropShadow.Offset.Z);
             }
@@ -138,7 +144,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
         private void OnOffsetYChanged(double newValue)
         {
-            if (_dropShadow != null)
+            if (IsSupported && _dropShadow != null)
             {
                 UpdateShadowOffset(_dropShadow.Offset.X, (float)newValue, _dropShadow.Offset.Z);
             }
@@ -146,7 +152,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
         private void OnOffsetZChanged(double newValue)
         {
-            if (_dropShadow != null)
+            if (IsSupported && _dropShadow != null)
             {
                 UpdateShadowOffset(_dropShadow.Offset.X, _dropShadow.Offset.Y, (float)newValue);
             }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/RadialGauge/RadialGauge.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/RadialGauge/RadialGauge.cs
@@ -619,13 +619,19 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                     scale.Data = pg;
                 }
 
-                OnFaceChanged(radialGauge);
+                if (!DesignMode.DesignModeEnabled)
+                {
+                    OnFaceChanged(radialGauge);
+                }
             }
         }
 
         private static void OnFaceChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
-            OnFaceChanged(d);
+            if (!DesignMode.DesignModeEnabled)
+            {
+                OnFaceChanged(d);
+            }
         }
 
         private static void OnFaceChanged(DependencyObject d)


### PR DESCRIPTION
We already had checks for the Visual Studio Designer, but it turns out, they didn't work. Moving the checks up one level to wrap the methods calling the Composition APIs seems to work.