### PR TITLE
CacheBase tweak

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI/Cache/CacheBase.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Cache/CacheBase.cs
@@ -470,19 +470,15 @@ namespace Microsoft.Toolkit.Uwp.UI
             {
                 var dataStream = randomAccessStream.AsStreamForWrite();
 
-                using (var response = await HttpClient.GetAsync(uri, cancellationToken))
+                using (var stream = await HttpClient.GetStreamAsync(uri))
                 {
-                    using (var stream = await response.Content.ReadAsStreamAsync())
+                    stream.CopyTo(dataStream);
+
+                    using (var fs = await baseFile.OpenStreamForWriteAsync())
                     {
-                        stream.CopyTo(dataStream);
-                        stream.Position = 0;
+                        stream.CopyTo(fs);
 
-                        using (var fs = await baseFile.OpenStreamForWriteAsync())
-                        {
-                            stream.CopyTo(fs);
-
-                            fs.Flush();
-                        }
+                        fs.Flush();
                     }
                 }
 


### PR DESCRIPTION
Use HttpClient GetStreamAsync instead of GetAsync to fix issue with artefacts on images when caching is enabled with ImageEx