### PR TITLE
fix(InAppNotifications): use timer to detect notification dismiss event after timeout

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/InAppNotification/InAppNotificationCode.bind
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/InAppNotification/InAppNotificationCode.bind
@@ -35,7 +35,7 @@
 
 // Show notification with simple text (and a duration of 2 seconds)
 int duration = 2000;
-await ExampleInAppNotification.ShowAsync("Some text.", duration);
+ExampleInAppNotification.Show("Some text.", duration);
 
 // Show notification using a DataTemplate
 object inAppNotificationWithButtonsTemplate;
@@ -43,7 +43,7 @@ bool isTemplatePresent = Resources.TryGetValue("InAppNotificationWithButtonsTemp
 
 if (isTemplatePresent && inAppNotificationWithButtonsTemplate is DataTemplate)
 {
-    await ExampleInAppNotification.ShowAsync(inAppNotificationWithButtonsTemplate as DataTemplate);
+    ExampleInAppNotification.Show(inAppNotificationWithButtonsTemplate as DataTemplate);
 }
 
 // Dismiss notification

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/InAppNotification/InAppNotificationPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/InAppNotification/InAppNotificationPage.xaml.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
         {
             base.OnNavigatedTo(e);
 
-            Shell.Current.RegisterNewCommand("Show notification with random text", async (sender, args) =>
+            Shell.Current.RegisterNewCommand("Show notification with random text", (sender, args) =>
             {
                 _exampleVSCodeInAppNotification?.Dismiss();
                 SetDefaultControlTemplate();
@@ -66,21 +66,21 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
 
                 if (result == 1)
                 {
-                    await _exampleInAppNotification?.ShowAsync("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec sollicitudin bibendum enim at tincidunt. Praesent egestas ipsum ligula, nec tincidunt lacus semper non.", NotificationDuration);
+                    _exampleInAppNotification?.Show("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec sollicitudin bibendum enim at tincidunt. Praesent egestas ipsum ligula, nec tincidunt lacus semper non.", NotificationDuration);
                 }
 
                 if (result == 2)
                 {
-                    await _exampleInAppNotification?.ShowAsync("Pellentesque in risus eget leo rhoncus ultricies nec id ante.", NotificationDuration);
+                    _exampleInAppNotification?.Show("Pellentesque in risus eget leo rhoncus ultricies nec id ante.", NotificationDuration);
                 }
 
                 if (result == 3)
                 {
-                    await _exampleInAppNotification?.ShowAsync("Sed quis nisi quis nunc condimentum varius id consectetur metus. Duis mauris sapien, commodo eget erat ac, efficitur iaculis magna. Morbi eu velit nec massa pharetra cursus. Fusce non quam egestas leo finibus interdum eu ac massa. Quisque nec justo leo. Aenean scelerisque placerat ultrices. Sed accumsan lorem at arcu commodo tristique.", NotificationDuration);
+                    _exampleInAppNotification?.Show("Sed quis nisi quis nunc condimentum varius id consectetur metus. Duis mauris sapien, commodo eget erat ac, efficitur iaculis magna. Morbi eu velit nec massa pharetra cursus. Fusce non quam egestas leo finibus interdum eu ac massa. Quisque nec justo leo. Aenean scelerisque placerat ultrices. Sed accumsan lorem at arcu commodo tristique.", NotificationDuration);
                 }
             });
 
-            Shell.Current.RegisterNewCommand("Show notification with buttons (without DataTemplate)", async (sender, args) =>
+            Shell.Current.RegisterNewCommand("Show notification with buttons (without DataTemplate)", (sender, args) =>
             {
                 _exampleVSCodeInAppNotification?.Dismiss();
                 SetDefaultControlTemplate();
@@ -127,10 +127,10 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
                 Grid.SetColumn(stackPanel, 1);
                 grid.Children.Add(stackPanel);
 
-                await _exampleInAppNotification?.ShowAsync(grid, NotificationDuration);
+                _exampleInAppNotification?.Show(grid, NotificationDuration);
             });
 
-            Shell.Current.RegisterNewCommand("Show notification with buttons (with DataTemplate)", async (sender, args) =>
+            Shell.Current.RegisterNewCommand("Show notification with buttons (with DataTemplate)", (sender, args) =>
             {
                 _exampleVSCodeInAppNotification?.Dismiss();
                 SetDefaultControlTemplate();
@@ -140,11 +140,11 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
 
                 if (isTemplatePresent == true && inAppNotificationWithButtonsTemplate is DataTemplate template)
                 {
-                    await _exampleInAppNotification.ShowAsync(template, NotificationDuration);
+                    _exampleInAppNotification.Show(template, NotificationDuration);
                 }
             });
 
-            Shell.Current.RegisterNewCommand("Show notification with Drop Shadow (based on default template)", async (sender, args) =>
+            Shell.Current.RegisterNewCommand("Show notification with Drop Shadow (based on default template)", (sender, args) =>
             {
                 _exampleVSCodeInAppNotification.Dismiss();
 
@@ -157,13 +157,13 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
                     _exampleInAppNotification.Template = template;
                 }
 
-                await _exampleInAppNotification.ShowAsync(NotificationDuration);
+                _exampleInAppNotification.Show(NotificationDuration);
             });
 
-            Shell.Current.RegisterNewCommand("Show notification with Visual Studio Code template (info notification)", async (sender, args) =>
+            Shell.Current.RegisterNewCommand("Show notification with Visual Studio Code template (info notification)", (sender, args) =>
             {
                 _exampleInAppNotification.Dismiss();
-                await _exampleVSCodeInAppNotification.ShowAsync(NotificationDuration);
+                _exampleVSCodeInAppNotification.Show(NotificationDuration);
             });
 
             Shell.Current.RegisterNewCommand("Dismiss", (sender, args) =>

--- a/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/InAppNotification.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/InAppNotification.cs
@@ -74,18 +74,15 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// <param name="duration">Displayed duration of the notification in ms (less or equal 0 means infinite duration)</param>
         public void Show(int duration = 0)
         {
+            _timer.Stop();
+
             Visibility = Visibility.Visible;
             VisualStateManager.GoToState(this, StateContentVisible, true);
 
             if (duration > 0)
             {
-                _timer.Stop();
                 _timer.Interval = TimeSpan.FromMilliseconds(duration);
                 _timer.Start();
-            }
-            else
-            {
-                _timer.Stop();
             }
         }
 

--- a/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/InAppNotification.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/InAppNotification.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
     [TemplatePart(Name = DismissButtonPart, Type = typeof(Button))]
     public sealed partial class InAppNotification : ContentControl
     {
+        private string _id;
         private Button _dismissButton;
 
         /// <summary>
@@ -70,13 +71,20 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public async Task ShowAsync(int duration = 0)
         {
+            var newId = Guid.NewGuid().ToString();
+            _id = newId;
+
             Visibility = Visibility.Visible;
             VisualStateManager.GoToState(this, StateContentVisible, true);
 
             if (duration > 0)
             {
                 await Task.Delay(duration);
-                Dismiss();
+
+                if (_id == newId)
+                {
+                    Dismiss();
+                }
             }
         }
 

--- a/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/InAppNotification.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/InAppNotification.cs
@@ -11,7 +11,6 @@
 // ******************************************************************
 
 using System;
-using System.Threading.Tasks;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 
@@ -25,7 +24,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
     [TemplatePart(Name = DismissButtonPart, Type = typeof(Button))]
     public sealed partial class InAppNotification : ContentControl
     {
-        private string _id;
+        private DispatcherTimer _timer = new DispatcherTimer();
         private Button _dismissButton;
 
         /// <summary>
@@ -34,6 +33,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         public InAppNotification()
         {
             DefaultStyleKey = typeof(InAppNotification);
+
+            _timer.Tick += (sender, e) =>
+            {
+                Dismiss();
+            };
         }
 
         /// <inheritdoc />
@@ -68,23 +72,20 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// Show notification using the current template
         /// </summary>
         /// <param name="duration">Displayed duration of the notification in ms (less or equal 0 means infinite duration)</param>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task ShowAsync(int duration = 0)
+        public void Show(int duration = 0)
         {
-            var newId = Guid.NewGuid().ToString();
-            _id = newId;
-
             Visibility = Visibility.Visible;
             VisualStateManager.GoToState(this, StateContentVisible, true);
 
             if (duration > 0)
             {
-                await Task.Delay(duration);
-
-                if (_id == newId)
-                {
-                    Dismiss();
-                }
+                _timer.Stop();
+                _timer.Interval = TimeSpan.FromMilliseconds(duration);
+                _timer.Start();
+            }
+            else
+            {
+                _timer.Stop();
             }
         }
 
@@ -93,12 +94,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// </summary>
         /// <param name="text">Text used as the content of the notification</param>
         /// <param name="duration">Displayed duration of the notification in ms (less or equal 0 means infinite duration)</param>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public Task ShowAsync(string text, int duration = 0)
+        public void Show(string text, int duration = 0)
         {
             ContentTemplate = null;
             Content = text;
-            return ShowAsync(duration);
+            Show(duration);
         }
 
         /// <summary>
@@ -106,12 +106,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// </summary>
         /// <param name="element">UIElement used as the content of the notification</param>
         /// <param name="duration">Displayed duration of the notification in ms (less or equal 0 means infinite duration)</param>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public Task ShowAsync(UIElement element, int duration = 0)
+        public void Show(UIElement element, int duration = 0)
         {
             ContentTemplate = null;
             Content = element;
-            return ShowAsync(duration);
+            Show(duration);
         }
 
         /// <summary>
@@ -119,12 +118,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// </summary>
         /// <param name="dataTemplate">DataTemplate used as the content of the notification</param>
         /// <param name="duration">Displayed duration of the notification in ms (less or equal 0 means infinite duration)</param>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public Task ShowAsync(DataTemplate dataTemplate, int duration = 0)
+        public void Show(DataTemplate dataTemplate, int duration = 0)
         {
             ContentTemplate = dataTemplate;
             Content = null;
-            return ShowAsync(duration);
+            Show(duration);
         }
 
         /// <summary>

--- a/docs/controls/InAppNotification.md
+++ b/docs/controls/InAppNotification.md
@@ -30,13 +30,13 @@ You have multiple options to show an in-app notification.
 1. By simply displaying the notification using the current template
 
 ```c#
-await ExampleInAppNotification.ShowAsync();
+await ExampleInAppNotification.Show();
 ```
 
 2. By using a simple text content.
 
 ```c#
-await ExampleInAppNotification.ShowAsync("Some text.");
+await ExampleInAppNotification.Show("Some text.");
 ```
 
 3. By using a UIElement (with a container as parent, ex: Grid)
@@ -46,7 +46,7 @@ var grid = new Grid();
 
 // TODO : Construct the Grid in C#
 
-await ExampleInAppNotification.ShowAsync(grid);
+await ExampleInAppNotification.Show(grid);
 ```
 
 4. By using a DataTemplate
@@ -57,16 +57,16 @@ bool isTemplatePresent = Resources.TryGetValue("InAppNotificationWithButtonsTemp
 
 if (isTemplatePresent && inAppNotificationWithButtonsTemplate is DataTemplate)
 {
-    await ExampleInAppNotification.ShowAsync(inAppNotificationWithButtonsTemplate as DataTemplate);
+    await ExampleInAppNotification.Show(inAppNotificationWithButtonsTemplate as DataTemplate);
 }
 ```
 
 ### Notification duration
 
-By passing a second argument to the `ShowAsync()` method, you can set the duration of the notification (in milliseconds).
+By passing a second argument to the `Show()` method, you can set the duration of the notification (in milliseconds).
 
 ```c#
-await ExampleInAppNotification.ShowAsync("Some text.", 2000); // the notification will appear for 2 seconds
+await ExampleInAppNotification.Show("Some text.", 2000); // the notification will appear for 2 seconds
 ```
 
 ### Dismiss notification

--- a/docs/controls/InAppNotification.md
+++ b/docs/controls/InAppNotification.md
@@ -30,13 +30,13 @@ You have multiple options to show an in-app notification.
 1. By simply displaying the notification using the current template
 
 ```c#
-await ExampleInAppNotification.Show();
+ExampleInAppNotification.Show();
 ```
 
 2. By using a simple text content.
 
 ```c#
-await ExampleInAppNotification.Show("Some text.");
+ExampleInAppNotification.Show("Some text.");
 ```
 
 3. By using a UIElement (with a container as parent, ex: Grid)
@@ -46,7 +46,7 @@ var grid = new Grid();
 
 // TODO : Construct the Grid in C#
 
-await ExampleInAppNotification.Show(grid);
+ExampleInAppNotification.Show(grid);
 ```
 
 4. By using a DataTemplate
@@ -57,7 +57,7 @@ bool isTemplatePresent = Resources.TryGetValue("InAppNotificationWithButtonsTemp
 
 if (isTemplatePresent && inAppNotificationWithButtonsTemplate is DataTemplate)
 {
-    await ExampleInAppNotification.Show(inAppNotificationWithButtonsTemplate as DataTemplate);
+    ExampleInAppNotification.Show(inAppNotificationWithButtonsTemplate as DataTemplate);
 }
 ```
 
@@ -66,7 +66,7 @@ if (isTemplatePresent && inAppNotificationWithButtonsTemplate is DataTemplate)
 By passing a second argument to the `Show()` method, you can set the duration of the notification (in milliseconds).
 
 ```c#
-await ExampleInAppNotification.Show("Some text.", 2000); // the notification will appear for 2 seconds
+ExampleInAppNotification.Show("Some text.", 2000); // the notification will appear for 2 seconds
 ```
 
 ### Dismiss notification


### PR DESCRIPTION
fix #1415 

@bkaankose I tried to use CancellationToken but it added so much code and it is seemed a little messy to me. The unique id do the trick but yes the Task.Delay is not cancelled immediately...