### PR TITLE
ImageCache - mark _instance field as ThreadStatic

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI/Cache/ImageCache.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Cache/ImageCache.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Toolkit.Uwp.UI
         /// <summary>
         /// Private singleton field.
         /// </summary>
+        [ThreadStatic]
         private static ImageCache _instance;
 
         private List<string> _extendedPropertyNames = new List<string>();


### PR DESCRIPTION
ImageCache - mark _instance field as ThreadStatic

**Underlying issue.**

0 | kernelbase | RaiseFailFastException | 0x74
-- | -- | -- | --
1 | dcomp | Microsoft::WRL2::FailFast::Do | 0x2E
2 | dcomp | Microsoft::WRL2::FailFast::ForHR | 0x6A
3 | dcomp | Windows::UI::Composition::SurfaceBindPoint::AttachSurface | 0x28D37
4 | dcomp | Windows::UI::Composition::CompositionSurfaceBrush::Api::put_Surface | 0x15A
5 | windows_ui_xaml | WUCBrushManager::GetSurfaceBrush | 0x152
6 | windows_ui_xaml | VisualContentRenderer::RenderPrimitive | 0x335
7 | windows_ui_xaml | VisualContentRenderer::GeneralImageRenderContent | 0x236
8 | windows_ui_xaml | BaseContentRenderer::ImageRenderContent | 0xCD

_ACCESSDENIED_FAIL_FAST_EXCEPTION_80070005_dcomp.dll!Windows::UI::Composition::CompositionSurfaceBrush::Api::put_Surface

Michael Crider in an email chain mentioned ImageCache instance being a potential cause as it should be ThreadStatic as multiple UI threads / shared Bitmaps might be the cause of this issue.

