### PR TITLE
Opening/Opened/Dismissed events support for InAppNotification.

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/InAppNotification.Events.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/InAppNotification.Events.cs
@@ -21,9 +21,19 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
     public partial class InAppNotification
     {
         /// <summary>
-        /// Event raised when the notification is dismissed
+        /// Event raised when the notification is dismissed.
         /// </summary>
-        public event EventHandler Dismissed;
+        public event EventHandler<InAppNotificationDismissedEventArgs> Dismissed;
+
+        /// <summary>
+        /// Event raised when the notification is about to be visible.
+        /// </summary>
+        public event EventHandler Opening;
+
+        /// <summary>
+        /// Event raised when the notification is appeared on the screen.
+        /// </summary>
+        public event EventHandler Opened;
 
         private void DismissButton_Click(object sender, RoutedEventArgs e)
         {

--- a/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/InAppNotification.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/InAppNotification.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
     {
         private DispatcherTimer _timer = new DispatcherTimer();
         private Button _dismissButton;
+        private InAppNotificationDismissedEventArgs _dismissedEventArgs;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="InAppNotification"/> class.
@@ -76,8 +77,17 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         {
             _timer.Stop();
 
+            _dismissedEventArgs = new InAppNotificationDismissedEventArgs()
+            {
+                OpenedTime = DateTime.Now
+            };
+
+            Opening?.Invoke(this, EventArgs.Empty);
+
             Visibility = Visibility.Visible;
             VisualStateManager.GoToState(this, StateContentVisible, true);
+
+            Opened?.Invoke(this, EventArgs.Empty);
 
             if (duration > 0)
             {
@@ -129,8 +139,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         {
             if (Visibility == Visibility.Visible)
             {
+                _dismissedEventArgs.DismissedTime = DateTime.Now;
                 VisualStateManager.GoToState(this, StateContentCollapsed, true);
-                Dismissed?.Invoke(this, EventArgs.Empty);
+                Dismissed?.Invoke(this, _dismissedEventArgs);
             }
         }
     }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/InAppNotificationDismissedEventArgs.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/InAppNotification/InAppNotificationDismissedEventArgs.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Toolkit.Uwp.UI.Controls
+{
+    /// <summary>
+    /// EventArgs class for InAppNotification's dismissed event.
+    /// </summary>
+    public class InAppNotificationDismissedEventArgs : EventArgs
+    {
+        public DateTime OpenedTime { get; set; }
+
+        public DateTime DismissedTime { get; set; }
+    }
+}

--- a/Microsoft.Toolkit.Uwp.UI.Controls/Microsoft.Toolkit.Uwp.UI.Controls.csproj
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/Microsoft.Toolkit.Uwp.UI.Controls.csproj
@@ -74,6 +74,7 @@
     <Compile Include="InAppNotification\InAppNotification.cs" />
     <Compile Include="InAppNotification\InAppNotification.Events.cs" />
     <Compile Include="InAppNotification\InAppNotification.Properties.cs" />
+    <Compile Include="InAppNotification\InAppNotificationDismissedEventArgs.cs" />
     <Compile Include="Menu\Menu.Logic.cs" />
     <Compile Include="Expander\ExpandDirection.cs" />
     <Compile Include="LayoutTransformControl\LayoutTransformControl.cs" />


### PR DESCRIPTION
This will give developers more control over InAppNotification management. Dismissed event has its own EventArgs with OpenedTime/DismissedTime props.

Listed in #1430 