### PR TITLE
Poke UIElement Z-Index when a container is being recycled in ReorderGridAnimation

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Animations/ReorderGridAnimation.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Animations/ReorderGridAnimation.cs
@@ -77,6 +77,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
 
                 view.ContainerContentChanging -= OnContainerContentChanging;
                 view.ContainerContentChanging += OnContainerContentChanging;
+
+                view.ChoosingItemContainer -= OnChoosingItemContainer;
+                view.ChoosingItemContainer += OnChoosingItemContainer;
             }
         }
 
@@ -99,12 +102,20 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
             var elementVisual = ElementCompositionPreview.GetElementVisual(args.ItemContainer);
             if (args.InRecycleQueue)
             {
-                elementVisual.ImplicitAnimations = null;
+                PokeUIElementZIndex(args.ItemContainer);
             }
             else
             {
                 var elementImplicitAnimation = sender.GetValue(ReorderAnimationProperty) as ImplicitAnimationCollection;
                 elementVisual.ImplicitAnimations = elementImplicitAnimation;
+            }
+        }
+
+        private static void OnChoosingItemContainer(ListViewBase sender, ChoosingItemContainerEventArgs args)
+        {
+            if (args.ItemContainer != null)
+            {
+                PokeUIElementZIndex(args.ItemContainer);
             }
         }
 
@@ -119,6 +130,13 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
             animationGroup.Add(offsetAnimation);
 
             return animationGroup;
+        }
+
+        private static void PokeUIElementZIndex(UIElement element)
+        {
+            var oldZIndex = Canvas.GetZIndex(element);
+            Canvas.SetZIndex(element, oldZIndex + 1);
+            Canvas.SetZIndex(element, oldZIndex);
         }
     }
 }


### PR DESCRIPTION
Due to the way XAML handles item container recycling in virtualized lists, simply setting the ImplicitAnimations property on the backing visual to null in the recycled case produces undesirable behavior when adding and removing items. Without getting too into XAML implementation details, containers that will be recycled are stored off screen and when they are reused for a new item the item will fly into their new position from the upper left. The solution is to force XAML to disable the implicit animations for that commit by poking the UIElement's Z-Index. We planned to fix the sample in the WindowUIDevLabs that also has this issue but that hasn't made it to the repo yet.