### PR TITLE
Revert "Removes all .AsTask().ConfigureAwait(false) calls"

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI/Cache/CacheBase.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Cache/CacheBase.cs
@@ -133,7 +133,7 @@ namespace Microsoft.Toolkit.Uwp.UI
         public async Task ClearAsync()
         {
             var folder = await GetCacheFolderAsync().ConfigureAwait(false);
-            var files = await folder.GetFilesAsync();
+            var files = await folder.GetFilesAsync().AsTask().ConfigureAwait(false);
 
             await InternalClearAsync(files).ConfigureAwait(false);
 
@@ -160,7 +160,7 @@ namespace Microsoft.Toolkit.Uwp.UI
             TimeSpan expiryDuration = duration.HasValue ? duration.Value : CacheDuration;
 
             var folder = await GetCacheFolderAsync().ConfigureAwait(false);
-            var files = await folder.GetFilesAsync();
+            var files = await folder.GetFilesAsync().AsTask().ConfigureAwait(false);
 
             var filesToDelete = new List<StorageFile>();
 
@@ -195,7 +195,7 @@ namespace Microsoft.Toolkit.Uwp.UI
             }
 
             var folder = await GetCacheFolderAsync().ConfigureAwait(false);
-            var files = await folder.GetFilesAsync();
+            var files = await folder.GetFilesAsync().AsTask().ConfigureAwait(false);
 
             var filesToDelete = new List<StorageFile>();
             var keys = new List<string>();
@@ -262,7 +262,7 @@ namespace Microsoft.Toolkit.Uwp.UI
 
             string fileName = GetCacheFileName(uri);
 
-            var item = await folder.TryGetItemAsync(fileName);
+            var item = await folder.TryGetItemAsync(fileName).AsTask().ConfigureAwait(false);
 
             return item as StorageFile;
         }
@@ -320,7 +320,7 @@ namespace Microsoft.Toolkit.Uwp.UI
                 return treatNullFileAsOutOfDate;
             }
 
-            var properties = await file.GetBasicPropertiesAsync();
+            var properties = await file.GetBasicPropertiesAsync().AsTask().ConfigureAwait(false);
 
             return properties.Size == 0 || DateTime.Now.Subtract(properties.DateModified.DateTime) > duration;
         }
@@ -412,11 +412,11 @@ namespace Microsoft.Toolkit.Uwp.UI
             }
 
             var folder = await GetCacheFolderAsync().ConfigureAwait(MaintainContext);
-            baseFile = await folder.TryGetItemAsync(fileName) as StorageFile;
+            baseFile = await folder.TryGetItemAsync(fileName).AsTask().ConfigureAwait(MaintainContext) as StorageFile;
 
             if (baseFile == null || await IsFileOutOfDateAsync(baseFile, CacheDuration).ConfigureAwait(MaintainContext))
             {
-                baseFile = await folder.CreateFileAsync(fileName, CreationCollisionOption.ReplaceExisting);
+                baseFile = await folder.CreateFileAsync(fileName, CreationCollisionOption.ReplaceExisting).AsTask().ConfigureAwait(MaintainContext);
 
                 uint retries = 0;
                 try
@@ -441,7 +441,7 @@ namespace Microsoft.Toolkit.Uwp.UI
                 }
                 catch (Exception)
                 {
-                    await baseFile.DeleteAsync();
+                    await baseFile.DeleteAsync().AsTask().ConfigureAwait(false);
                     throw; // re-throwing the exception changes the stack trace. just throw
                 }
             }
@@ -452,7 +452,7 @@ namespace Microsoft.Toolkit.Uwp.UI
 
                 if (_inMemoryFileStorage.MaxItemCount > 0)
                 {
-                    var properties = await baseFile.GetBasicPropertiesAsync();
+                    var properties = await baseFile.GetBasicPropertiesAsync().AsTask().ConfigureAwait(false);
 
                     var msi = new InMemoryStorageItem<T>(fileName, properties.DateModified.DateTime, instance);
                     _inMemoryFileStorage.SetItem(msi);
@@ -501,7 +501,7 @@ namespace Microsoft.Toolkit.Uwp.UI
             {
                 try
                 {
-                    await file.DeleteAsync();
+                    await file.DeleteAsync().AsTask().ConfigureAwait(false);
                 }
                 catch
                 {
@@ -537,7 +537,7 @@ namespace Microsoft.Toolkit.Uwp.UI
 
             try
             {
-                _cacheFolder = await _baseFolder.CreateFolderAsync(_cacheFolderName, CreationCollisionOption.OpenIfExists);
+                _cacheFolder = await _baseFolder.CreateFolderAsync(_cacheFolderName, CreationCollisionOption.OpenIfExists).AsTask().ConfigureAwait(false);
             }
             finally
             {

--- a/Microsoft.Toolkit.Uwp.UI/Cache/ImageCache.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Cache/ImageCache.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Toolkit.Uwp.UI
                 }
             }
 
-            await image.SetSourceAsync(stream.AsRandomAccessStream());
+            await image.SetSourceAsync(stream.AsRandomAccessStream()).AsTask().ConfigureAwait(false);
 
             return image;
         }
@@ -96,7 +96,7 @@ namespace Microsoft.Toolkit.Uwp.UI
         /// <returns>awaitable task</returns>
         protected override async Task<BitmapImage> InitializeTypeAsync(StorageFile baseFile, List<KeyValuePair<string, object>> initializerKeyValues = null)
         {
-            using (var stream = await baseFile.OpenStreamForReadAsync())
+            using (var stream = await baseFile.OpenStreamForReadAsync().ConfigureAwait(MaintainContext))
             {
                 return await InitializeTypeAsync(stream, initializerKeyValues).ConfigureAwait(MaintainContext);
             }
@@ -118,7 +118,7 @@ namespace Microsoft.Toolkit.Uwp.UI
 
             // Get extended properties.
             IDictionary<string, object> extraProperties =
-                await file.Properties.RetrievePropertiesAsync(_extendedPropertyNames);
+                await file.Properties.RetrievePropertiesAsync(_extendedPropertyNames).AsTask().ConfigureAwait(false);
 
             // Get date-accessed property.
             var propValue = extraProperties[DateAccessedProperty];
@@ -133,7 +133,7 @@ namespace Microsoft.Toolkit.Uwp.UI
                 }
             }
 
-            var properties = await file.GetBasicPropertiesAsync();
+            var properties = await file.GetBasicPropertiesAsync().AsTask().ConfigureAwait(false);
 
             return properties.Size == 0 || DateTime.Now.Subtract(properties.DateModified.DateTime) > duration;
         }

--- a/Microsoft.Toolkit.Uwp/Helpers/StorageFileHelper.cs
+++ b/Microsoft.Toolkit.Uwp/Helpers/StorageFileHelper.cs
@@ -558,7 +558,7 @@ namespace Microsoft.Toolkit.Uwp.Helpers
                 throw new ArgumentNullException(nameof(fileName));
             }
 
-            var file = await fileLocation.GetFileAsync(fileName);
+            var file = await fileLocation.GetFileAsync(fileName).AsTask().ConfigureAwait(false);
             return await file.ReadBytesAsync();
         }
 
@@ -646,7 +646,7 @@ namespace Microsoft.Toolkit.Uwp.Helpers
         /// </returns>
         internal static async Task<bool> FileExistsInFolderAsync(StorageFolder folder, string fileName)
         {
-            var item = await folder.TryGetItemAsync(fileName);
+            var item = await folder.TryGetItemAsync(fileName).AsTask().ConfigureAwait(false);
             return (item != null) && item.IsOfType(StorageItemTypes.File);
         }
 
@@ -678,7 +678,7 @@ namespace Microsoft.Toolkit.Uwp.Helpers
                 UserSearchFilter = $"filename:=\"{fileName}\"" // “:=” is the exact-match operator
             };
 
-            var files = await rootFolder.CreateFileQueryWithOptions(options).GetFilesAsync();
+            var files = await rootFolder.CreateFileQueryWithOptions(options).GetFilesAsync().AsTask().ConfigureAwait(false);
             return files.Count > 0;
         }
 

--- a/Microsoft.Toolkit.Uwp/Helpers/StreamHelper.cs
+++ b/Microsoft.Toolkit.Uwp/Helpers/StreamHelper.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Toolkit.Uwp.Helpers
                 {
                     if (response.IsSuccessStatusCode)
                     {
-                        await response.Content.CopyToAsync(outputStream.AsStreamForWrite());
+                        await response.Content.CopyToAsync(outputStream.AsStreamForWrite()).ConfigureAwait(false);
                         outputStream.Seek(0);
                     }
                 }
@@ -64,7 +64,7 @@ namespace Microsoft.Toolkit.Uwp.Helpers
             this Uri uri,
             StorageFile targetFile)
         {
-            using (var fileStream = await targetFile.OpenAsync(FileAccessMode.ReadWrite))
+            using (var fileStream = await targetFile.OpenAsync(FileAccessMode.ReadWrite).AsTask().ConfigureAwait(false))
             {
                 using (var request = new HttpRequestMessage(HttpMethod.Get, uri))
                 {
@@ -72,7 +72,7 @@ namespace Microsoft.Toolkit.Uwp.Helpers
                     {
                         if (response.IsSuccessStatusCode)
                         {
-                            await response.Content.CopyToAsync(fileStream.AsStreamForWrite());
+                            await response.Content.CopyToAsync(fileStream.AsStreamForWrite()).ConfigureAwait(false);
                         }
                     }
                 }


### PR DESCRIPTION
This reverts commit 4413914f554c6c68224515c6b834c330f8770b7b.

I was wrong when I made this change in the first place, so I'm now reverting these changes. Please check [here](https://github.com/Microsoft/UWPCommunityToolkit/pull/1327#issuecomment-326114913) for more information.

These changes are based on the `staging` branch.