### PR TITLE
HeaderedTextBlock does now support Inlines as TextBlock

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/HeaderedTextBlock/HeaderedTextBlock.Properties.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/HeaderedTextBlock/HeaderedTextBlock.Properties.cs
@@ -12,6 +12,7 @@
 
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Documents;
 
 namespace Microsoft.Toolkit.Uwp.UI.Controls
 {
@@ -137,6 +138,14 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 SetValue(TextProperty, value);
             }
         }
+
+        /// <summary>
+        /// Gets the collection of inline text elements within a Windows.UI.Xaml.Controls.TextBlock.
+        /// </summary>
+        /// <returns>
+        /// A collection that holds all inline text elements from the Windows.UI.Xaml.Controls.TextBlock. The default is an empty collection.</returns>
+        // Hack: I need a InlineCollection from a TextBlock since _textContent is null when XAML accesses the properties
+        public InlineCollection Inlines { get; } = new TextBlock().Inlines;
 
         /// <summary>
         /// Gets or sets the orientation.

--- a/Microsoft.Toolkit.Uwp.UI.Controls/HeaderedTextBlock/HeaderedTextBlock.Properties.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/HeaderedTextBlock/HeaderedTextBlock.Properties.cs
@@ -10,6 +10,7 @@
 // THE CODE OR THE USE OR OTHER DEALINGS IN THE CODE.
 // ******************************************************************
 
+using System.Collections.Generic;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Documents;
@@ -144,8 +145,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// </summary>
         /// <returns>
         /// A collection that holds all inline text elements from the Windows.UI.Xaml.Controls.TextBlock. The default is an empty collection.</returns>
-        // Hack: I need a InlineCollection from a TextBlock since _textContent is null when XAML accesses the properties
-        public InlineCollection Inlines { get; } = new TextBlock().Inlines;
+        public List<Inline> Inlines { get; } = new List<Inline>();
 
         /// <summary>
         /// Gets or sets the orientation.

--- a/Microsoft.Toolkit.Uwp.UI.Controls/HeaderedTextBlock/HeaderedTextBlock.Properties.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/HeaderedTextBlock/HeaderedTextBlock.Properties.cs
@@ -10,10 +10,8 @@
 // THE CODE OR THE USE OR OTHER DEALINGS IN THE CODE.
 // ******************************************************************
 
-using System.Collections.Generic;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Documents;
 
 namespace Microsoft.Toolkit.Uwp.UI.Controls
 {
@@ -145,7 +143,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// </summary>
         /// <returns>
         /// A collection that holds all inline text elements from the Windows.UI.Xaml.Controls.TextBlock. The default is an empty collection.</returns>
-        public List<Inline> Inlines { get; } = new List<Inline>();
+        public InlineCollectionWrapper Inlines { get; } = new InlineCollectionWrapper();
 
         /// <summary>
         /// Gets or sets the orientation.

--- a/Microsoft.Toolkit.Uwp.UI.Controls/HeaderedTextBlock/HeaderedTextBlock.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/HeaderedTextBlock/HeaderedTextBlock.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             _textContent = GetTemplateChild("TextContent") as TextBlock;
 
             UpdateVisibility();
-            UpdateInlines();
+            Inlines.AddItemsToTextBlock(_textContent);
             UpdateForOrientation(this.Orientation);
         }
 
@@ -77,16 +77,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                     VisualStateManager.GoToState(this, "Horizontal", true);
                     break;
             }
-        }
-
-        private void UpdateInlines()
-        {
-            if (_textContent == null || Inlines.Count == 0)
-            {
-                return;
-            }
-
-            Inlines.ApplyCollectionToTextBlock(_textContent);
         }
     }
 }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/HeaderedTextBlock/HeaderedTextBlock.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/HeaderedTextBlock/HeaderedTextBlock.cs
@@ -10,7 +10,6 @@
 // THE CODE OR THE USE OR OTHER DEALINGS IN THE CODE.
 // ******************************************************************
 
-using System.Linq;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Markup;
@@ -87,12 +86,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 return;
             }
 
-            _textContent.Inlines.Clear();
-
-            foreach (var inline in Inlines)
-            {
-                _textContent.Inlines.Add(inline);
-            }
+            Inlines.ApplyCollectionToTextBlock(_textContent);
 
             // To follow the behavior of UWP use Text instead of Inlines if Text property is set.
             if (!string.IsNullOrEmpty(Text))

--- a/Microsoft.Toolkit.Uwp.UI.Controls/HeaderedTextBlock/HeaderedTextBlock.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/HeaderedTextBlock/HeaderedTextBlock.cs
@@ -10,8 +10,10 @@
 // THE CODE OR THE USE OR OTHER DEALINGS IN THE CODE.
 // ******************************************************************
 
+using System.Linq;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Markup;
 
 namespace Microsoft.Toolkit.Uwp.UI.Controls
 {
@@ -19,6 +21,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
     /// Defines a control for providing a header for read-only text.
     /// </summary>
     [TemplatePart(Name = "HeaderContentPresenter", Type = typeof(ContentPresenter))]
+    [ContentProperty(Name = nameof(Inlines))]
     public partial class HeaderedTextBlock : Control
     {
         private ContentPresenter _headerContentPresenter;
@@ -43,6 +46,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             _textContent = GetTemplateChild("TextContent") as TextBlock;
 
             UpdateVisibility();
+            UpdateInlines();
             UpdateForOrientation(this.Orientation);
         }
 
@@ -57,7 +61,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
             if (_textContent != null)
             {
-                _textContent.Visibility = string.IsNullOrWhiteSpace(_textContent.Text) && HideTextIfEmpty
+                _textContent.Visibility = string.IsNullOrWhiteSpace(_textContent.Text) && Inlines == null && HideTextIfEmpty
                                                     ? Visibility.Collapsed
                                                     : Visibility.Visible;
             }
@@ -73,6 +77,32 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 case Orientation.Horizontal:
                     VisualStateManager.GoToState(this, "Horizontal", true);
                     break;
+            }
+        }
+
+        private void UpdateInlines()
+        {
+            if (_textContent == null || Inlines == null || Inlines.Count == 0)
+            {
+                return;
+            }
+
+            _textContent.Inlines.Clear();
+            var inlines = Inlines.ToList();
+
+            Inlines.Clear();
+
+            foreach (var inline in inlines)
+            {
+                _textContent.Inlines.Add(inline);
+            }
+
+            // in UWP if Text is se then the value of Inlines is not used. Following will ensure this.
+            if (!string.IsNullOrEmpty(Text))
+            {
+                var test = Text;
+                Text = null;
+                Text = test;
             }
         }
     }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/HeaderedTextBlock/HeaderedTextBlock.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/HeaderedTextBlock/HeaderedTextBlock.cs
@@ -88,21 +88,18 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             }
 
             _textContent.Inlines.Clear();
-            var inlines = Inlines.ToList();
 
-            Inlines.Clear();
-
-            foreach (var inline in inlines)
+            foreach (var inline in Inlines)
             {
                 _textContent.Inlines.Add(inline);
             }
 
-            // in UWP if Text is se then the value of Inlines is not used. Following will ensure this.
+            // To follow the behavior of UWP use Text instead of Inlines if Text property is set.
             if (!string.IsNullOrEmpty(Text))
             {
-                var test = Text;
+                var temp = Text;
                 Text = null;
-                Text = test;
+                Text = temp;
             }
         }
     }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/HeaderedTextBlock/HeaderedTextBlock.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/HeaderedTextBlock/HeaderedTextBlock.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
             if (_textContent != null)
             {
-                _textContent.Visibility = string.IsNullOrWhiteSpace(_textContent.Text) && Inlines == null && HideTextIfEmpty
+                _textContent.Visibility = string.IsNullOrWhiteSpace(_textContent.Text) && HideTextIfEmpty
                                                     ? Visibility.Collapsed
                                                     : Visibility.Visible;
             }
@@ -82,7 +82,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
         private void UpdateInlines()
         {
-            if (_textContent == null || Inlines == null || Inlines.Count == 0)
+            if (_textContent == null || Inlines.Count == 0)
             {
                 return;
             }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/HeaderedTextBlock/HeaderedTextBlock.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/HeaderedTextBlock/HeaderedTextBlock.cs
@@ -87,14 +87,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             }
 
             Inlines.ApplyCollectionToTextBlock(_textContent);
-
-            // To follow the behavior of UWP use Text instead of Inlines if Text property is set.
-            if (!string.IsNullOrEmpty(Text))
-            {
-                var temp = Text;
-                Text = null;
-                Text = temp;
-            }
         }
     }
 }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/InlineCollectionWrapper.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/InlineCollectionWrapper.cs
@@ -1,0 +1,127 @@
+﻿// ******************************************************************
+// Copyright (c) Microsoft. All rights reserved.
+// This code is licensed under the MIT License (MIT).
+// THE CODE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH
+// THE CODE OR THE USE OR OTHER DEALINGS IN THE CODE.
+// ******************************************************************
+
+namespace Microsoft.Toolkit.Uwp.UI.Controls
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using Windows.UI.Xaml.Controls;
+    using Windows.UI.Xaml.Documents;
+
+    /// <inheritdoc />
+    /// <summary>A wrapper class for <see cref="TextBlock.Inlines">TextBlock.Inlines</see> to hack the problem that <see cref="Windows.UI.Xaml.Documents.InlineCollection" /> has no accessible constructor</summary>
+    public class InlineCollectionWrapper : IList<Inline>
+    {
+        private IList<Inline> _collection;
+
+        internal InlineCollectionWrapper()
+        {
+            _collection = new List<Inline>();
+        }
+
+        /// <inheritdoc />
+        public int Count => _collection.Count;
+
+        /// <inheritdoc />
+        public bool IsReadOnly => _collection.IsReadOnly;
+
+        /// <inheritdoc />
+        public Inline this[int index]
+        {
+            get => _collection[index];
+            set => _collection[index] = value;
+        }
+
+        /// <inheritdoc />
+        public void Add(Inline item)
+        {
+            _collection.Add(item);
+        }
+
+        /// <inheritdoc />
+        public void Clear()
+        {
+            _collection.Clear();
+        }
+
+        /// <inheritdoc />
+        public bool Contains(Inline item)
+        {
+            return _collection.Contains(item);
+        }
+
+        /// <inheritdoc />
+        public void CopyTo(Inline[] array, int arrayIndex)
+        {
+            _collection.CopyTo(array, arrayIndex);
+        }
+
+        /// <inheritdoc />
+        public IEnumerator<Inline> GetEnumerator()
+        {
+            foreach (var inline in _collection)
+            {
+                yield return inline;
+            }
+        }
+
+        /// <inheritdoc />
+        public int IndexOf(Inline item)
+        {
+            return _collection.IndexOf(item);
+        }
+
+        /// <inheritdoc />
+        public void Insert(int index, Inline item)
+        {
+            _collection.Insert(index, item);
+        }
+
+        /// <inheritdoc />
+        public bool Remove(Inline item)
+        {
+            return _collection.Remove(item);
+        }
+
+        /// <inheritdoc />
+        public void RemoveAt(int index)
+        {
+            _collection.RemoveAt(index);
+        }
+
+        /// <summary>
+        /// Sets the items of this collection as <see cref="TextBlock.Inlines"/> to <paramref name="textBlock"/>.
+        /// </summary>
+        /// <param name="textBlock">The textBlock where the items are added.</param>
+        internal void ApplyCollectionToTextBlock(TextBlock textBlock)
+        {
+            if (textBlock == null)
+            {
+                throw new ArgumentNullException(nameof(textBlock));
+            }
+
+            foreach (var inline in _collection)
+            {
+                textBlock.Inlines.Add(inline);
+            }
+
+            _collection = textBlock.Inlines;
+        }
+
+        /// <inheritdoc />
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}

--- a/Microsoft.Toolkit.Uwp.UI.Controls/InlineCollectionWrapper.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/InlineCollectionWrapper.cs
@@ -19,7 +19,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
     using Windows.UI.Xaml.Documents;
 
     /// <inheritdoc />
-    /// <summary>A wrapper class for <see cref="TextBlock.Inlines">TextBlock.Inlines</see> to hack the problem that <see cref="Windows.UI.Xaml.Documents.InlineCollection" /> has no accessible constructor</summary>
+    /// <summary>A wrapper class for <see cref="TextBlock.Inlines">TextBlock.Inlines</see> to
+    /// hack the problem that <see cref="Windows.UI.Xaml.Documents.InlineCollection" />.
+    /// has no accessible constructor</summary>
     public class InlineCollectionWrapper : IList<Inline>
     {
         private IList<Inline> _collection;

--- a/Microsoft.Toolkit.Uwp.UI.Controls/InlineCollectionWrapper.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/InlineCollectionWrapper.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// Sets the items of this collection as <see cref="TextBlock.Inlines"/> to <paramref name="textBlock"/>.
         /// </summary>
         /// <param name="textBlock">The textBlock where the items are added.</param>
-        internal void ApplyCollectionToTextBlock(TextBlock textBlock)
+        internal void AddItemsToTextBlock(TextBlock textBlock)
         {
             if (textBlock == null)
             {


### PR DESCRIPTION
# Request

As in WPF, UWP `HeadededTextBlock` should have the same behavior as `TextBlock`.

This is because as I saw the `HeaderedTextBlock` control I wanted to use it with `Run` immediately. But I saw that it does not exist. As `HeaderedTextBlock` has the name `TextBlock` inside I expected the same behavior. With this pull request it has.

# Sample:

~~~
<HeaderedTextBlock Header="Header>
  <Run Text="Normal"/>
  <Italic>
    <Run Text="Italic"/>
  </Italic>
  <Bold>
     <Run Text="Bold"/>
  </Bold>
  <Run Text="Red" Foreground="Red"/>
</HeaderedTextBlock />
~~~

![header](https://user-images.githubusercontent.com/4341039/29933566-6504ea3e-8e78-11e7-9ab8-aea180e1ee28.PNG)

# Breaking changes:
**NONE**
