### PR TITLE
Change Expander.Header from string to object

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/Expander/Expander.Properties.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/Expander/Expander.Properties.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// Identifies the <see cref="Header"/> dependency property.
         /// </summary>
         public static readonly DependencyProperty HeaderProperty =
-            DependencyProperty.Register(nameof(Header), typeof(string), typeof(Expander), new PropertyMetadata(null));
+            DependencyProperty.Register(nameof(Header), typeof(object), typeof(Expander), new PropertyMetadata(null));
 
         /// <summary>
         /// Identifies the <see cref="HeaderTemplate"/> dependency property.
@@ -46,9 +46,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// <summary>
         /// Gets or sets a value indicating whether the Header of the control.
         /// </summary>
-        public string Header
+        public object Header
         {
-            get { return (string)GetValue(HeaderProperty); }
+            get { return (object)GetValue(HeaderProperty); }
             set { SetValue(HeaderProperty, value); }
         }
 

--- a/Microsoft.Toolkit.Uwp.UI.Controls/Expander/Expander.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/Expander/Expander.xaml
@@ -413,7 +413,7 @@
                                 </controls:LayoutTransformControl.Transform>
 
                                 <ToggleButton x:Name="PART_ExpanderToggleButton" 
-                                              Height="40"
+                                              MinHeight="40"
                                               TabIndex="0"
                                               AutomationProperties.Name="Expand"
                                               Style="{StaticResource HeaderToggleButtonStyle}" 


### PR DESCRIPTION
# Changes

This feature does allow any header like in [HeaderedContentControl.Header](https://msdn.microsoft.com/en-us/library/system.windows.controls.headeredcontentcontrol.header(v=vs.110).aspx) by changing `Expander.Header` from `string` to `object`

# Preview

## Header

~~~
 <controls:Expander x:Name="Expander1" VerticalAlignment="Top" Margin="0,0,0,10" 
                         Foreground="White"
                         Background="Gray"
                         IsExpanded="False"
                         ExpandDirection="Down">
        <controls:Expander.Header>
          <StackPanel Orientation="Horizontal" >
            <Image Source="ms-appx:///Assets/People/shen.png" Height="24" Width="24"></Image>
            <TextBlock Text="Shen" VerticalAlignment="Center"></TextBlock>
          </StackPanel>
        </controls:Expander.Header>
        <Grid Height="250">
          <TextBlock HorizontalAlignment="Center"
                     TextWrapping="Wrap"
                     Text="This is the content"
                     VerticalAlignment="Center"
                     Style="{StaticResource HeaderTextBlockStyle}" />
        </Grid>
      </controls:Expander>
~~~

## HeaderTemplate
~~~
<controls:Expander x:Name="Expander1" VerticalAlignment="Top" Margin="0,0,0,10" 
                         Header="Shen"
                         Foreground="White"
                         Background="Gray"
                         IsExpanded="True"
                         ExpandDirection="Down">
        <controls:Expander.HeaderTemplate>
          <DataTemplate>
            <StackPanel Orientation="Horizontal" >
              <Image Source="ms-appx:///Assets/People/shen.png" Height="24" Width="24"></Image>
              <TextBlock Text="{Binding}" VerticalAlignment="Center"></TextBlock>
            </StackPanel>
          </DataTemplate>
        </controls:Expander.HeaderTemplate>
        <Grid Height="250">
          <TextBlock HorizontalAlignment="Center"
                     TextWrapping="Wrap"
                     Text="This is the content"
                     VerticalAlignment="Center"
                     Style="{StaticResource HeaderTextBlockStyle}" />
        </Grid>
      </controls:Expander>
~~~

![headertemplate](https://user-images.githubusercontent.com/4341039/30053145-11fbc188-9228-11e7-9931-c74af5b2574b.PNG)

## With bigger image:

![biggerimage](https://user-images.githubusercontent.com/4341039/30053317-a85406ea-9228-11e7-9cf0-b090b7be3ea5.PNG)


# Breaking changes:

Possibliy breaking changes if `Header` is used directly in Code like:

    string content = myHeaderControl.Header;
