### PR TITLE
Update Microsoft.NETCore.UniversalWindowsPlatform to 5.4.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -22,7 +22,7 @@
 
     <GenerateDocumentationFile Condition="'$(IsTestProject)' != 'true' and '$(IsSampleProject)' != 'true'">true</GenerateDocumentationFile>
     
-    <UwpMetaPackageVersion>5.3.4</UwpMetaPackageVersion>
+    <UwpMetaPackageVersion>5.4.0</UwpMetaPackageVersion>
     <DefaultTargetPlatformVersion>15063</DefaultTargetPlatformVersion>
     <DefaultTargetPlatformMinVersion>14393</DefaultTargetPlatformMinVersion>
   </PropertyGroup>


### PR DESCRIPTION
Update Microsoft.NETCore.UniversalWindowsPlatform to 5.4.0 to fix issues packaging and side loading apps when using toolkit 2.0
Related issues #1484, #1479 and #1477 