### PR TITLE
Added dependency property to replace the ItemContainerStyle of…

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/HamburgerMenu/HamburgerMenu.Properties.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/HamburgerMenu/HamburgerMenu.Properties.cs
@@ -83,6 +83,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         public static readonly DependencyProperty SelectedIndexProperty = DependencyProperty.Register(nameof(SelectedIndex), typeof(int), typeof(HamburgerMenu), new PropertyMetadata(-1));
 
         /// <summary>
+        /// Identifies the <see cref="ItemContainerStyle"/> dependency property.
+        /// </summary>
+        public static readonly DependencyProperty ItemContainerStyleProperty = DependencyProperty.Register("ItemContainerStyle", typeof(Style), typeof(HamburgerMenu), new PropertyMetadata(null));
+
+        /// <summary>
         /// Gets or sets the width of the pane when it's fully expanded.
         /// </summary>
         public double OpenPaneLength
@@ -208,6 +213,15 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         {
             get { return (int)GetValue(SelectedIndexProperty); }
             set { SetValue(SelectedIndexProperty, value); }
+        }
+
+        /// <summary>
+        /// Gets or sets a value that sets the menu item's container style (useful for overriding the selection indicator)
+        /// </summary>
+        public Style ItemContainerStyle
+        {
+            get { return (Style)GetValue(ItemContainerStyleProperty); }
+            set { SetValue(ItemContainerStyleProperty, value); }
         }
     }
 }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/HamburgerMenu/HamburgerMenu.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/HamburgerMenu/HamburgerMenu.cs
@@ -64,6 +64,12 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             _buttonsListView = (ListViewBase)GetTemplateChild("ButtonsListView");
             _optionsListView = (ListViewBase)GetTemplateChild("OptionsListView");
 
+            if (this.ItemContainerStyle != null)
+            {
+                _buttonsListView.ItemContainerStyle = this.ItemContainerStyle;
+                _optionsListView.ItemContainerStyle = this.ItemContainerStyle;
+            }
+
             if (_hamburgerButton != null)
             {
                 _hamburgerButton.Click += HamburgerButton_Click;


### PR DESCRIPTION
… both ListViews inside the HamburgerMenu.  This allows the replacement of the built-in selection indicator.

I was using the Windows Template Studio plugin that automatically generates the Hamburger-style menu in an app.  They use a ``DataTemplate`` for both ``ItemsTemplate`` and ``OptionItems`` inside the ``HamburgerMenu`` control that has its own selection indicator.  It mirrors the underlying built-in selection indicator.  However, when you use the BackButton navigation to go back, the built-in indicator doesn't change (the custom one does).

I wasn't satisfied with just using an opaque control on top of the built-in indicator to cover it.  I wanted to get rid of it, so I used my own ``ListViewItem`` ``Style``.  This required adding the dependency property to the ``HamburgerMenu`` control and applying it to both ``ListView``s if the Dependency Property was not null.