### PR TITLE
GridSplitter: Fix broken cursor handling after unload+reload of control

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/GridSplitter/GridSplitter.Events.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/GridSplitter/GridSplitter.Events.cs
@@ -41,17 +41,20 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 Element = _gripperDisplay;
             }
 
-            var hoverWrapper = new GripperHoverWrapper(
-                CursorBehavior == SplitterCursorBehavior.ChangeOnSplitterHover
-                ? this
-                : Element,
-                _resizeDirection,
-                GripperCursor,
-                GripperCustomCursorResource);
-            ManipulationStarted += hoverWrapper.SplitterManipulationStarted;
-            ManipulationCompleted += hoverWrapper.SplitterManipulationCompleted;
+            if (_hoverWrapper == null)
+            {
+                var hoverWrapper = new GripperHoverWrapper(
+                    CursorBehavior == SplitterCursorBehavior.ChangeOnSplitterHover
+                    ? this
+                    : Element,
+                    _resizeDirection,
+                    GripperCursor,
+                    GripperCustomCursorResource);
+                ManipulationStarted += hoverWrapper.SplitterManipulationStarted;
+                ManipulationCompleted += hoverWrapper.SplitterManipulationCompleted;
 
-            _hoverWrapper = hoverWrapper;
+                _hoverWrapper = hoverWrapper;
+            }
         }
 
         private void CreateGripperDisplay()

--- a/Microsoft.Toolkit.Uwp.UI.Controls/GridSplitter/GridSplitter.Options.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/GridSplitter/GridSplitter.Options.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 nameof(Element),
                 typeof(UIElement),
                 typeof(GridSplitter),
-                new PropertyMetadata(default(UIElement)));
+                new PropertyMetadata(default(UIElement), OnElementPropertyChanged));
 
         /// <summary>
         /// Identifies the <see cref="ResizeDirection"/> dependency property.
@@ -215,6 +215,16 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         }
 
         private static void CursorBehaviorPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            var gridSplitter = (GridSplitter)d;
+
+            gridSplitter._hoverWrapper?.UpdateHoverElement(gridSplitter.CursorBehavior ==
+                                                           SplitterCursorBehavior.ChangeOnSplitterHover
+                ? gridSplitter
+                : gridSplitter.Element);
+        }
+
+        private static void OnElementPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             var gridSplitter = (GridSplitter)d;
 


### PR DESCRIPTION
This fixes #1501. 

If the control is unloaded and then loaded again (e.g. when using page caching), a second cursor handler was created although one already existed. This is fixed now.