### PR TITLE
Move conditionals into Choose When for better legacy project system support

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,33 +20,53 @@
     <IsUwpProject>$(MSBuildProjectName.Contains('Uwp'))</IsUwpProject>
     <IsSampleProject>$(MSBuildProjectName.Contains('Sample'))</IsSampleProject>
 
-    <GenerateDocumentationFile Condition="'$(IsTestProject)' != 'true' and '$(IsSampleProject)' != 'true'">true</GenerateDocumentationFile>
+    
     
     <UwpMetaPackageVersion>5.3.4</UwpMetaPackageVersion>
     <DefaultTargetPlatformVersion>15063</DefaultTargetPlatformVersion>
     <DefaultTargetPlatformMinVersion>14393</DefaultTargetPlatformMinVersion>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(IsUwpProject)' == 'true'">
-    <GenerateLibraryLayout>true</GenerateLibraryLayout>
-  </PropertyGroup>
+  <Choose>
+    <When Condition="'$(IsTestProject)' != 'true' and '$(IsSampleProject)' != 'true'">
+      <PropertyGroup>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>    
+      </PropertyGroup>
+    </When>
+  </Choose>
 
-  <ItemGroup Condition="'$(IsTestProject)' != 'true' and '$(SourceLinkEnabled)' != 'false'">
-    <PackageReference Include="SourceLink.Create.CommandLine" Version="2.2.0" PrivateAssets="All" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(IsTestProject)' != 'true' and '$(IsSampleProject)' != 'true'">
-    <!--<PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="15.3.83" PrivateAssets="all" />-->
-    <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" PrivateAssets="all" />
+  <Choose>
+    <When Condition="'$(IsUwpProject)' == 'true' and '$(IsSampleProject)' != 'true'">
+      <PropertyGroup>
+        <GenerateLibraryLayout>true</GenerateLibraryLayout>
+      </PropertyGroup>
+      
+      <ItemGroup>
+        <PackageReference Include="MSBuild.Sdk.Extras" Version="1.0.9" PrivateAssets="all" />
+      </ItemGroup>
+    </When>
+  </Choose>
 
-    <EmbeddedResource Include="**\*.rd.xml" />
-    <Page Include="**\*.xaml" Exclude="**\bin\**\*.xaml;**\obj\**\*.xaml" SubType="Designer" Generator="MSBuild:Compile" />
-    <Compile Update="**\*.xaml.cs" DependentUpon="%(Filename)" />
-  </ItemGroup>
+  <Choose>
+    <When Condition="'$(IsTestProject)' != 'true' and '$(SourceLinkEnabled)' != 'false' and '$(IsSampleProject)' != 'true'">
+      <ItemGroup>
+        <PackageReference Include="SourceLink.Create.CommandLine" Version="2.2.0" PrivateAssets="All" />
+      </ItemGroup>
+    </When>
+  </Choose>
 
-  <ItemGroup Condition="'$(IsUwpProject)' == 'true'">
-    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.0.9" PrivateAssets="all" />
-  </ItemGroup>
+  <Choose>
+    <When Condition="'$(IsTestProject)' != 'true' and '$(IsSampleProject)' != 'true'">
+      <ItemGroup>
+        <!--<PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="15.3.83" PrivateAssets="all" />-->
+        <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" PrivateAssets="all" />
 
+        <EmbeddedResource Include="**\*.rd.xml" />
+        <Page Include="**\*.xaml" Exclude="**\bin\**\*.xaml;**\obj\**\*.xaml" SubType="Designer" Generator="MSBuild:Compile" />
+        <Compile Update="**\*.xaml.cs" DependentUpon="%(Filename)" />
+      </ItemGroup>
+    </When>
+  </Choose>
   
   <PropertyGroup>
     <NerdbankGitVersioningVersion>2.0.37-beta</NerdbankGitVersioningVersion>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,23 +1,26 @@
 <Project>
 
-  <!-- UAP versions for uap10.0 where TPMV isn't implied -->
-  <PropertyGroup Condition="'$(TargetFramework)' == 'uap10.0' or '$(TargetFramework)' == 'native'">
-    <TargetPlatformVersion>10.0.$(DefaultTargetPlatformVersion).0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.$(DefaultTargetPlatformMinVersion).0</TargetPlatformMinVersion>
-    <DebugType>Full</DebugType>
-  </PropertyGroup>
+  <Choose>
+    <When Condition="'$(TargetFramework)' == 'uap10.0' or '$(TargetFramework)' == 'native'">
+      <!-- UAP versions for uap10.0 where TPMV isn't implied -->
+      <PropertyGroup>
+        <TargetPlatformVersion>10.0.$(DefaultTargetPlatformVersion).0</TargetPlatformVersion>
+        <TargetPlatformMinVersion>10.0.$(DefaultTargetPlatformMinVersion).0</TargetPlatformMinVersion>
+        <DebugType>Full</DebugType>
+      </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'uap10.0' or '$(TargetFramework)' == 'native'">
+      <ItemGroup>
+        <PackageReference Condition="'$(UseUwpMetaPackage)' == 'true'" Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="$(UwpMetaPackageVersion)" />
 
-    <PackageReference Condition="'$(UseUwpMetaPackage)' == 'true'" Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="$(UwpMetaPackageVersion)" />
-    
-    <SDKReference Condition="'$(UseWindowsDesktopSdk)' == 'true' " Include="WindowsDesktop, Version=$(TargetPlatformVersion)">
-      <Name>Windows Desktop Extensions for the UWP</Name>
-    </SDKReference>
-    <SDKReference Condition="'$(UseWindowsMobileSdk)' == 'true' " Include="WindowsMobile, Version=$(TargetPlatformVersion)">
-      <Name>Windows Mobile Extensions for the UWP</Name>
-    </SDKReference>
+        <SDKReference Condition="'$(UseWindowsDesktopSdk)' == 'true' " Include="WindowsDesktop, Version=$(TargetPlatformVersion)">
+          <Name>Windows Desktop Extensions for the UWP</Name>
+        </SDKReference>
+        <SDKReference Condition="'$(UseWindowsMobileSdk)' == 'true' " Include="WindowsMobile, Version=$(TargetPlatformVersion)">
+          <Name>Windows Mobile Extensions for the UWP</Name>
+        </SDKReference>
+      </ItemGroup>
 
-  </ItemGroup>
+    </When>
+  </Choose>
 
 </Project>


### PR DESCRIPTION
The legacy project system (IDE and Design Time builds), always includes items that have a false condition. The workaround is to use a Choose/When construct.

This updates the directory.build.props/targets to use the Choose/When construct so the legacy projects don't get confused.