### PR TITLE
Fix for Sign Client in Cake Build

### DIFF
--- a/build/build.cake
+++ b/build/build.cake
@@ -188,7 +188,16 @@ Task("SignNuGet")
         foreach(var package in packages)
         {
             Information("\nSubmitting " + package + " for signing...");
-            DotNetCoreTool(signClientAppPath, "sign", "-c " + signClientSettings + " -s " + signClientSecret + " -n '" + name + "' -d '" + name +"' -u '" + address + "'");
+            var arguments = new ProcessArgumentBuilder()
+                .Append("sign")
+                .AppendSwitchQuoted("-s", signClientSecret)
+                .AppendSwitchQuoted("-c", signClientSettings)
+                .AppendSwitchQuoted("-n", name)
+                .AppendSwitchQuoted("-d", name)
+                .AppendSwitchQuoted("-u", address);
+
+            //Excute Signing
+            DotNetCoreExecute(signClientAppPath, arguments);
             Information("\nFinished signing " + package);
         }
     }


### PR DESCRIPTION
Switched to Correct DotNet Alias, built Arguments with Argument Builder.

If this doesn't work,
switch out lines 191-200 for:
```C#
var arguments = new ProcessArgumentBuilder()
    .AppendQuoted(signClientAppPath)
    .Append("sign")
    .AppendSwitchQuoted("-s", signClientSecret)
    .AppendSwitchQuoted("-c", signClientSettings)
    .AppendSwitchQuoted("-n", name)
    .AppendSwitchQuoted("-d", name)
    .AppendSwitchQuoted("-u", address);

var result = StartProcess("dotnet", new ProcessSettings {  Arguments = arguments });
if(result != 0)
{
    throw new InvalidOperationException("Signing failed!");
}
```