### PR TITLE
Carousel Sample - Allow negative values for margin and rotation

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Carousel/CarouselCode.bind
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Carousel/CarouselCode.bind
@@ -10,10 +10,10 @@
       <controls:Carousel x:Name="CarouselControl"
                   InvertPositive="@[InvertPositive:Bool:True]"
                   ItemDepth="@[ItemDepth:Slider:300:0-400]"
-                  ItemMargin="@[ItemMargin:Slider:0:0-500]"
-                  ItemRotationX="@[ItemRotationX:Slider:0:0-180]"
-                  ItemRotationY="@[ItemRotationY:Slider:45:0-180]"
-                  ItemRotationZ ="@[ItemRotationZ:Slider:0:0-180]"
+                  ItemMargin="@[ItemMargin:Slider:0:-500-500]"
+                  ItemRotationX="@[ItemRotationX:Slider:0:-180-180]"
+                  ItemRotationY="@[ItemRotationY:Slider:45:-180-180]"
+                  ItemRotationZ ="@[ItemRotationZ:Slider:0:-180-180]"
                   Orientation="@[Orientation:Enum:Orientation.Horizontal]"
                   SelectedIndex="@[SelectedIndex:String:4]">
         <controls:Carousel.EasingFunction>


### PR DESCRIPTION
Issue: #1541

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build or CI related changes
[ ] Documentation content changes
[x] Sample app changes
[ ] Other... Please describe:
```


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently the sliders for Margin and Rotation X,Y and Z only support positive values. See #1541 for more info.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)


## What is the new behavior?
I added support for negative values in Margin and Rotation sliders.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
