### PR TITLE
Add LiveShaping to AdvancedCollectionView

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI/AdvancedCollectionView/IAdvancedCollectionView.cs
+++ b/Microsoft.Toolkit.Uwp.UI/AdvancedCollectionView/IAdvancedCollectionView.cs
@@ -69,5 +69,25 @@ namespace Microsoft.Toolkit.Uwp.UI
         /// Manually refreshes the view
         /// </summary>
         void Refresh();
+
+        /// <summary>
+        /// Manually refreshes the filter on the view
+        /// </summary>
+        void RefreshFilter();
+
+        /// <summary>
+        /// Manually refreshes the sorting on the view
+        /// </summary>
+        void RefreshSorting();
+
+        /// <summary>
+        /// Add a property to re-filter an item on when it is changed
+        /// </summary>
+        void ObserveFilterProperty(string propertyName);
+
+        /// <summary>
+        /// Clears all properties items are re-filtered on
+        /// </summary>
+        void ClearObservedFilterProperties();
     }
 }

--- a/UnitTests/UI/Person.cs
+++ b/UnitTests/UI/Person.cs
@@ -11,17 +11,53 @@
 // ******************************************************************
 
 using System;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
 
 namespace UnitTests.UI
 {
     /// <summary>
     /// Sample class to test AdvancedCollectionViewSource functionality
     /// </summary>
-    internal class Person : IComparable
+    internal class Person : IComparable, INotifyPropertyChanged
     {
-        public string Name { get; set; }
+        private string _name;
 
-        public int Age { get; set; }
+        public string Name
+        {
+            get
+            {
+                return _name;
+            }
+
+            set
+            {
+                if (_name != value)
+                {
+                    _name = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        private int _age;
+
+        public int Age
+        {
+            get
+            {
+                return _age;
+            }
+
+            set
+            {
+                if (_age != value)
+                {
+                    _age = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
 
         public int CompareTo(object obj)
         {
@@ -33,6 +69,13 @@ namespace UnitTests.UI
             }
 
             return Age.CompareTo(other.Age);
+        }
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
     }
 }

--- a/UnitTests/UI/Test_AdvancedCollectionView.cs
+++ b/UnitTests/UI/Test_AdvancedCollectionView.cs
@@ -352,6 +352,501 @@ namespace UnitTests.UI
             Assert.AreEqual(42, ((Person)a.First()).Age);
         }
 
+        [TestCategory("AdvancedCollectionView")]
+        [UITestMethod]
+        public void Test_AdvancedCollectionView_Filter_With_Shaping()
+        {
+            var l = new List<string>
+            {
+                "lorem",
+                "ipsum",
+                "dolor",
+                "sit",
+                "amet"
+            };
+
+            var a = new AdvancedCollectionView(l, true)
+            {
+                Filter = (x) => x.ToString().Length < 5
+            };
+
+            Assert.AreEqual(2, a.Count);
+        }
+
+        [TestCategory("AdvancedCollectionView")]
+        [UITestMethod]
+        public void Test_AdvancedCollectionView_Filter_With_Shaping_And_Refresh_Call()
+        {
+            var l = new List<string>
+            {
+                "lorem",
+                "ipsum",
+                "dolor",
+                "sit",
+                "amet"
+            };
+
+            var a = new AdvancedCollectionView(l, true);
+
+            a.Filter = (x) => x.ToString().Length < 5;
+
+            Assert.AreEqual(2, a.Count);
+        }
+
+        [TestCategory("AdvancedCollectionView")]
+        [UITestMethod]
+        public void Test_AdvancedCollectionView_Updating_With_Shaping()
+        {
+            var l = new ObservableCollection<string>
+            {
+                "lorem",
+                "ipsum",
+                "dolor",
+                "sit",
+                "amet"
+            };
+
+            var a = new AdvancedCollectionView(l, true);
+
+            Assert.AreEqual(5, a.Count);
+
+            l.Add("new item");
+
+            Assert.AreEqual(6, a.Count);
+        }
+
+        [TestCategory("AdvancedCollectionView")]
+        [UITestMethod]
+        public void Test_AdvancedCollectionView_Sorting_With_Shaping()
+        {
+            var l = new ObservableCollection<Person>
+            {
+                new Person()
+                {
+                    Name = "lorem",
+                    Age = 4
+                },
+                new Person()
+                {
+                    Name = "imsum",
+                    Age = 8
+                },
+                new Person()
+                {
+                    Name = "dolor",
+                    Age = 15
+                },
+                new Person()
+                {
+                    Name = "sit",
+                    Age = 16
+                },
+                new Person()
+                {
+                    Name = "amet",
+                    Age = 23
+                },
+                new Person()
+                {
+                    Name = "consectetur",
+                    Age = 42
+                },
+            };
+
+            var a = new AdvancedCollectionView(l, true)
+            {
+                SortDescriptions =
+                {
+                    new SortDescription(nameof(Person.Age), SortDirection.Descending)
+                }
+            };
+
+            Assert.AreEqual(42, ((Person)a.First()).Age);
+        }
+
+        [TestCategory("AdvancedCollectionView")]
+        [UITestMethod]
+        public void Test_AdvancedCollectionView_Sorting_Using_Shaping()
+        {
+            var l = new ObservableCollection<Person>
+            {
+                new Person()
+                {
+                    Name = "lorem",
+                    Age = 4
+                },
+                new Person()
+                {
+                    Name = "imsum",
+                    Age = 8
+                },
+                new Person()
+                {
+                    Name = "dolor",
+                    Age = 15
+                },
+                new Person()
+                {
+                    Name = "sit",
+                    Age = 16
+                },
+                new Person()
+                {
+                    Name = "amet",
+                    Age = 23
+                },
+                new Person()
+                {
+                    Name = "consectetur",
+                    Age = 42
+                },
+            };
+
+            var a = new AdvancedCollectionView(l, true);
+
+            a.SortDescriptions.Add(new SortDescription(nameof(Person.Age), SortDirection.Descending));
+
+            Assert.AreEqual(42, ((Person)a.First()).Age);
+        }
+
+        [TestCategory("AdvancedCollectionView")]
+        [UITestMethod]
+        public void Test_AdvancedCollectionView_Combined_With_Shaping()
+        {
+            var l = new ObservableCollection<Person>
+            {
+                new Person()
+                {
+                    Name = "lorem",
+                    Age = 4
+                },
+                new Person()
+                {
+                    Name = "imsum",
+                    Age = 8
+                },
+                new Person()
+                {
+                    Name = "dolor",
+                    Age = 15
+                },
+                new Person()
+                {
+                    Name = "sit",
+                    Age = 16
+                },
+                new Person()
+                {
+                    Name = "amet",
+                    Age = 23
+                },
+                new Person()
+                {
+                    Name = "consectetur",
+                    Age = 42
+                },
+            };
+
+            var a = new AdvancedCollectionView(l, true)
+            {
+                SortDescriptions =
+                {
+                    new SortDescription(nameof(Person.Age), SortDirection.Descending)
+                },
+                Filter = (x) => ((Person)x).Name.Length > 5
+            };
+
+            Assert.AreEqual(42, ((Person)a.First()).Age);
+            Assert.AreEqual(1, a.Count);
+
+            l.Add(new Person
+            {
+                Name = "foo",
+                Age = 50
+            });
+
+            l.Add(new Person
+            {
+                Name = "Person McPersonface",
+                Age = 10
+            });
+
+            Assert.AreEqual(42, ((Person)a.First()).Age);
+            Assert.AreEqual(2, a.Count);
+        }
+
+        [TestCategory("AdvancedCollectionView")]
+        [UITestMethod]
+        public void Test_AdvancedCollectionView_Combined_Using_Shaping_Changing_Properties()
+        {
+            var personLorem = new Person()
+            {
+                Name = "lorem",
+                Age = 4
+            };
+
+            var l = new ObservableCollection<Person>
+            {
+                personLorem,
+                new Person()
+                {
+                    Name = "imsum",
+                    Age = 8
+                },
+                new Person()
+                {
+                    Name = "dolor",
+                    Age = 15
+                },
+                new Person()
+                {
+                    Name = "sit",
+                    Age = 16
+                },
+                new Person()
+                {
+                    Name = "amet",
+                    Age = 23
+                },
+                new Person()
+                {
+                    Name = "consectetur",
+                    Age = 42
+                },
+            };
+
+            var a = new AdvancedCollectionView(l, true)
+            {
+                SortDescriptions =
+                {
+                    new SortDescription(nameof(Person.Age), SortDirection.Descending)
+                },
+                Filter = (x) => ((Person)x).Name.Length > 5
+            };
+
+            a.ObserveFilterProperty(nameof(Person.Name));
+
+            Assert.AreEqual(42, ((Person)a.First()).Age);
+            Assert.AreEqual(1, a.Count);
+
+            personLorem.Name = "lorems";
+            personLorem.Age = 96;
+
+            Assert.AreEqual(96, ((Person)a.First()).Age);
+            Assert.AreEqual(2, a.Count);
+        }
+
+        [TestCategory("AdvancedCollectionView")]
+        [UITestMethod]
+        public void Test_AdvancedCollectionView_Combined_Using_Shaping()
+        {
+            var l = new ObservableCollection<Person>
+            {
+                new Person()
+                {
+                    Name = "lorem",
+                    Age = 4
+                },
+                new Person()
+                {
+                    Name = "imsum",
+                    Age = 8
+                },
+                new Person()
+                {
+                    Name = "dolor",
+                    Age = 15
+                },
+                new Person()
+                {
+                    Name = "sit",
+                    Age = 16
+                },
+                new Person()
+                {
+                    Name = "amet",
+                    Age = 23
+                },
+                new Person()
+                {
+                    Name = "consectetur",
+                    Age = 42
+                },
+            };
+
+            var a = new AdvancedCollectionView(l, true);
+
+            a.Filter = (x) => ((Person)x).Name.Length > 5;
+            a.RefreshFilter();
+
+            a.SortDescriptions.Add(new SortDescription(nameof(Person.Age), SortDirection.Descending));
+
+            Assert.AreEqual(42, ((Person)a.First()).Age);
+            Assert.AreEqual(1, a.Count);
+
+            l.Add(new Person
+            {
+                Name = "foo",
+                Age = 50
+            });
+
+            l.Add(new Person
+            {
+                Name = "Person McPersonface",
+                Age = 10
+            });
+
+            Assert.AreEqual(42, ((Person)a.First()).Age);
+            Assert.AreEqual(2, a.Count);
+        }
+
+        [TestCategory("AdvancedCollectionView")]
+        [UITestMethod]
+        public void Test_AdvancedCollectionView_Sorting_OnSelf_With_Shaping()
+        {
+            var l = new ObservableCollection<Person>
+            {
+                new Person()
+                {
+                    Name = "lorem",
+                    Age = 4
+                },
+                new Person()
+                {
+                    Name = "imsum",
+                    Age = 8
+                },
+                new Person()
+                {
+                    Name = "dolor",
+                    Age = 15
+                },
+                new Person()
+                {
+                    Name = "sit",
+                    Age = 16
+                },
+                new Person()
+                {
+                    Name = "amet",
+                    Age = 23
+                },
+                new Person()
+                {
+                    Name = "consectetur",
+                    Age = 42
+                },
+            };
+
+            var a = new AdvancedCollectionView(l, true)
+            {
+                SortDescriptions =
+                {
+                    new SortDescription(SortDirection.Descending)
+                }
+            };
+
+            Assert.AreEqual(42, ((Person)a.First()).Age);
+        }
+
+        [TestCategory("AdvancedCollectionView")]
+        [UITestMethod]
+        public void Test_AdvancedCollectionView_Sorting_OnSelf_CustomComparable_With_Shaping()
+        {
+            var l = new ObservableCollection<Person>
+            {
+                new Person()
+                {
+                    Name = "lorem",
+                    Age = 4
+                },
+                new Person()
+                {
+                    Name = "imsum",
+                    Age = 8
+                },
+                new Person()
+                {
+                    Name = "dolor",
+                    Age = 15
+                },
+                new Person()
+                {
+                    Name = "sit",
+                    Age = 16
+                },
+                new Person()
+                {
+                    Name = "amet",
+                    Age = 23
+                },
+                new Person()
+                {
+                    Name = "consectetur",
+                    Age = 42
+                },
+            };
+
+            var a = new AdvancedCollectionView(l, true)
+            {
+                SortDescriptions =
+                {
+                    new SortDescription(SortDirection.Ascending, new DelegateComparable((x, y) => -((Person)x).Age.CompareTo(((Person)y).Age)))
+                }
+            };
+
+            Assert.AreEqual(42, ((Person)a.First()).Age);
+        }
+
+        [TestCategory("AdvancedCollectionView")]
+        [UITestMethod]
+        public void Test_AdvancedCollectionView_Sorting_CustomComparable_With_Shaping()
+        {
+            var l = new ObservableCollection<Person>
+            {
+                new Person()
+                {
+                    Name = "lorem",
+                    Age = 4
+                },
+                new Person()
+                {
+                    Name = "imsum",
+                    Age = 8
+                },
+                new Person()
+                {
+                    Name = "dolor",
+                    Age = 15
+                },
+                new Person()
+                {
+                    Name = "sit",
+                    Age = 16
+                },
+                new Person()
+                {
+                    Name = "amet",
+                    Age = 23
+                },
+                new Person()
+                {
+                    Name = "consectetur",
+                    Age = 42
+                },
+            };
+
+            var a = new AdvancedCollectionView(l, true)
+            {
+                SortDescriptions =
+                {
+                    new SortDescription(nameof(Person.Age), SortDirection.Ascending, new DelegateComparable((x, y) => -((int)x).CompareTo((int)y)))
+                }
+            };
+
+            Assert.AreEqual(42, ((Person)a.First()).Age);
+        }
+
         private class DelegateComparable : IComparer
         {
             private Func<object, object, int> _func;

--- a/docs/helpers/AdvancedCollectionView.md
+++ b/docs/helpers/AdvancedCollectionView.md
@@ -18,6 +18,7 @@ In your viewmodel instead of having a public [IEnumerable](https://docs.microsof
 * filtering your list using a [Predicate](https://docs.microsoft.com/en-us/dotnet/core/api/system.predicate-1): this will automatically filter your list only to the items that pass the check by the predicate provided
 * deferring notifications using the `NotificationDeferrer` helper: with a convenient _using_ pattern you can increase performance while doing large-scale modifications in your list by waiting with updates until you've completed your work
 * incremental loading: if your source collection supports the feature then AdvancedCollectionView will do as well (it simply forwards the calls)
+* live shaping: when constructing the `AdvancedCollectionView` you may specify that the collection use live shaping. This means that the collection will re-filter or re-sort if there are changes to the sort properties or filter properties that are specified using `ObserveFilterProperty`
 
 ## Example
 
@@ -54,9 +55,9 @@ In your viewmodel instead of having a public [IEnumerable](https://docs.microsof
         new Person { Name = "8" },
     };
 
-    // Set up the AdvancedCollectionView to filter and sort the original list
+    // Set up the AdvancedCollectionView with live shaping enabled to filter and sort the original list
 
-    var acv = new AdvancedCollectionView(oc);
+    var acv = new AdvancedCollectionView(oc, true);
 
     // Let's filter out the integers
     int nul;
@@ -65,6 +66,13 @@ In your viewmodel instead of having a public [IEnumerable](https://docs.microsof
     // And sort ascending by the property "Name"
     acv.SortDescriptions.Add(new SortDescription("Name", SortDirection.Ascending));
 
+    // Let's add a Person to the observable collection
+    var person = new Person { Name = "Aardvark" };
+    oc.Add(person);
+    
+    // Our added person is now at the top of the list, but if we rename this person, we can trigger a re-sort
+    person.Name = "Zaphod"; // Now a re-sort is triggered and person will be last in the list
+    
     // AdvancedCollectionView can be bound to anything that uses collections. 
     YourListView.ItemsSource = acv;
 


### PR DESCRIPTION
Issue: https://github.com/Microsoft/UWPCommunityToolkit/issues/1128
(this is not meant to tackle the grouping that is also requested in the above issue)

## PR Type
What kind of change does this PR introduce?
I guess this is only a feature, feel free to correct me.
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build or CI related changes
[x] Documentation content changes
[ ] Sample app changes
[ ] Other... Please describe:
```


## What is the current behavior?
With the current behavior you need to call `Refresh` if you change any references that are relied on by the Filter.  Also, if properties that are sorted/filtered on are changed, you need to call `Refresh` manually.  `Refresh` is also very heavy handed and basically acts as if the source has been reset.  This makes it very difficult to implement a dynamic filter or have a list filled with dynamic data.


## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../blob/master/readme.md#supported)
  - [ ] Anniversary update
  - [x] Creators update
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)


## What is the new behavior?
You are now able to specify that you would like your advanced collection view to live shape in the constructor.  This means that any change to a property being sorted on will trigger a resort.  It means that adding a sort description will trigger a resort.  It means that resetting the filter will trigger a re-filter.  It means that anytime a property that you have registered with the new `ObserveFilterProperty` func changes that there will be a re-filter.  This results in a much easier time when dealing with a list of dynamic data or changing sorts/filters.  

There are also two new types of refresh that are more respectful of the type of refresh that is required: `RefreshFilter` and `RefreshSorting`.  This means that if your Filter uses a property that gets changed, you can call `RefreshFilter` and not have the entire list blink out of existence for a moment.  This is because `RefreshFilter` invokes the specific `CollectionChange` enum so that the list animations look nice.



## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
