### PR TITLE
ItemWidth fix for AdaptiveGridView

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveGridView.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveGridView.cs
@@ -56,6 +56,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             var style = new Style(typeof(GridViewItem));
             style.Setters.Add(new Setter(HorizontalContentAlignmentProperty, HorizontalAlignment.Stretch));
             style.Setters.Add(new Setter(VerticalContentAlignmentProperty, VerticalAlignment.Stretch));
+            style.Setters.Add(new Setter(MarginProperty, new Thickness(0, 0, 0, 4)));
+            style.Setters.Add(new Setter(PaddingProperty, new Thickness(2, 0, 2, 0)));
             ItemContainerStyle = style;
         }
 
@@ -67,8 +69,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         protected override void PrepareContainerForItemOverride(DependencyObject obj, object item)
         {
             base.PrepareContainerForItemOverride(obj, item);
-            var element = obj as FrameworkElement;
-            if (element != null)
+            if (obj is FrameworkElement element)
             {
                 var heightBinding = new Binding()
                 {
@@ -106,7 +107,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 columns = Items.Count;
             }
 
-            return (containerWidth / columns) - 5;
+            return containerWidth / columns;
         }
 
         /// <summary>
@@ -232,11 +233,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             if (containerWidth > 0)
             {
                 var newWidth = CalculateItemWidth(containerWidth);
-
-                if (double.IsNaN(ItemWidth) || Math.Abs(newWidth - ItemWidth) > 1)
-                {
-                    ItemWidth = newWidth;
-                }
+                ItemWidth = Math.Floor(newWidth - 1);
             }
         }
     }


### PR DESCRIPTION
Issue: #1551 
<!-- Link to relevant issue. All PRs should be asociated with an issue -->

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build or CI related changes
[ ] Documentation content changes
[ ] Sample app changes
[ ] Other... Please describe:
```


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
ItemWidth on AdaptiveGridView can be a fraction too big and cause the panel to overflow elements to next row on certain panel widths

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)


## What is the new behavior?
Made sure ItemWidth does not cause the item DesiredSize to overflow the panel

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
