### PR TITLE
Fixes NullReferenceException when GetContentControl method returns null.

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI/Extensions/Tree/LogicalTree.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/Tree/LogicalTree.cs
@@ -160,9 +160,14 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions
                         yield return child as T;
                     }
 
-                    foreach (T childOfChild in (child as FrameworkElement)?.FindChildren<T>())
+                    var childFrameworkElement = child as FrameworkElement;
+
+                    if (childFrameworkElement != null)
                     {
-                        yield return childOfChild;
+                        foreach (T childOfChild in childFrameworkElement.FindChildren<T>())
+                        {
+                            yield return childOfChild;
+                        }
                     }
                 }
             }
@@ -170,9 +175,14 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions
             {
                 foreach (var item in (element as ItemsControl).Items)
                 {
-                    foreach (T childOfChild in (item as FrameworkElement)?.FindChildren<T>())
+                    var childFrameworkElement = item as FrameworkElement;
+
+                    if (childFrameworkElement != null)
                     {
-                        yield return childOfChild;
+                        foreach (T childOfChild in childFrameworkElement.FindChildren<T>())
+                        {
+                            yield return childOfChild;
+                        }
                     }
                 }
             }
@@ -185,9 +195,14 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions
                     yield return content as T;
                 }
 
-                foreach (T childOfChild in (content as FrameworkElement)?.FindChildren<T>())
+                var childFrameworkElement = content as FrameworkElement;
+
+                if (childFrameworkElement != null)
                 {
-                    yield return childOfChild;
+                    foreach (T childOfChild in childFrameworkElement.FindChildren<T>())
+                    {
+                        yield return childOfChild;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Issue: #
<!-- Link to relevant issue. All PRs should be asociated with an issue -->

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build or CI related changes
[ ] Documentation content changes
[ ] Sample app changes
[ ] Other... Please describe:
```


## What is the current behavior?
When GetContentControl extension method returns null, FindChildren<T> throws NRE trying to iterate null in foreach loop.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)


## What is the new behavior?
No NullReferenceException.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
