### PR TITLE
Tweaked touch and mouse pull to refresh behavior to match, can now scroll with mouse

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/PullToRefreshListView/PullToRefreshListView.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/PullToRefreshListView/PullToRefreshListView.cs
@@ -493,8 +493,16 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                     }
                 }
 
-                _refreshIndicatorTransform.TranslateY = _pullDistance - offset
+                if (_isManipulatingWithMouse)
+                {
+                    _refreshIndicatorTransform.TranslateY = _pullDistance - offset
                                                         - _refreshIndicatorBorder.ActualHeight;
+                }
+                else
+                {
+                    _refreshIndicatorTransform.TranslateY = _pullDistance
+                                                        - _refreshIndicatorBorder.ActualHeight;
+                }
             }
             else
             {

--- a/Microsoft.Toolkit.Uwp.UI.Controls/PullToRefreshListView/PullToRefreshListView.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/PullToRefreshListView/PullToRefreshListView.cs
@@ -202,12 +202,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             {
                 _scroller.Loaded += Scroller_Loaded;
 
-                if (IsPullToRefreshWithMouseEnabled)
-                {
-                    _root.ManipulationMode = ManipulationModes.TranslateY;
-                    _root.ManipulationStarted += Scroller_ManipulationStarted;
-                    _root.ManipulationCompleted += Scroller_ManipulationCompleted;
-                }
+                SetupMouseMode();
 
                 _scroller.DirectManipulationCompleted += Scroller_DirectManipulationCompleted;
                 _scroller.DirectManipulationStarted += Scroller_DirectManipulationStarted;
@@ -352,6 +347,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         private void Scroller_DirectManipulationCompleted(object sender, object e)
         {
             OnManipulationCompleted();
+            _root.ManipulationMode = ManipulationModes.System;
         }
 
         /// <summary>
@@ -602,9 +598,14 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             _scrollerVerticalScrollBar.PointerExited += ScrollerVerticalScrollBar_PointerExited;
         }
 
-        private void ScrollerVerticalScrollBar_PointerExited(object sender, PointerRoutedEventArgs e)
+        private void Scroller_PointerExited(object sender, PointerRoutedEventArgs e)
         {
-            if (IsPullToRefreshWithMouseEnabled)
+            _root.ManipulationMode = ManipulationModes.System;
+        }
+
+        private void Scroller_PointerMoved(object sender, PointerRoutedEventArgs e)
+        {
+            if (IsPullToRefreshWithMouseEnabled && e.Pointer.PointerDeviceType == Windows.Devices.Input.PointerDeviceType.Mouse)
             {
                 _root.ManipulationMode = ManipulationModes.TranslateY;
             }
@@ -613,6 +614,19 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         private void ScrollerVerticalScrollBar_PointerEntered(object sender, PointerRoutedEventArgs e)
         {
             _root.ManipulationMode = ManipulationModes.System;
+            _root.ManipulationStarted -= Scroller_ManipulationStarted;
+            _root.ManipulationCompleted -= Scroller_ManipulationCompleted;
+        }
+
+        private void ScrollerVerticalScrollBar_PointerExited(object sender, PointerRoutedEventArgs e)
+        {
+            if (IsPullToRefreshWithMouseEnabled)
+            {
+                _root.ManipulationStarted -= Scroller_ManipulationStarted;
+                _root.ManipulationCompleted -= Scroller_ManipulationCompleted;
+                _root.ManipulationStarted += Scroller_ManipulationStarted;
+                _root.ManipulationCompleted += Scroller_ManipulationCompleted;
+            }
         }
 
         /// <summary>
@@ -762,23 +776,35 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
             set
             {
-                if (_root != null)
-                {
-                    if (value)
-                    {
-                        _root.ManipulationMode = ManipulationModes.TranslateY;
-                        _root.ManipulationStarted += Scroller_ManipulationStarted;
-                        _root.ManipulationCompleted += Scroller_ManipulationCompleted;
-                    }
-                    else
-                    {
-                        _root.ManipulationMode = ManipulationModes.System;
-                        _root.ManipulationStarted -= Scroller_ManipulationStarted;
-                        _root.ManipulationCompleted -= Scroller_ManipulationCompleted;
-                    }
-                }
-
                 SetValue(IsPullToRefreshWithMouseEnabledProperty, value);
+                SetupMouseMode();
+            }
+        }
+
+        private void SetupMouseMode()
+        {
+            if (_root != null && _scroller != null)
+            {
+                if (IsPullToRefreshWithMouseEnabled)
+                {
+                    _root.ManipulationStarted -= Scroller_ManipulationStarted;
+                    _root.ManipulationCompleted -= Scroller_ManipulationCompleted;
+                    _scroller.PointerMoved -= Scroller_PointerMoved;
+                    _scroller.PointerExited -= Scroller_PointerExited;
+
+                    _root.ManipulationStarted += Scroller_ManipulationStarted;
+                    _root.ManipulationCompleted += Scroller_ManipulationCompleted;
+                    _scroller.PointerMoved += Scroller_PointerMoved;
+                    _scroller.PointerExited += Scroller_PointerExited;
+                }
+                else
+                {
+                    _root.ManipulationMode = ManipulationModes.System;
+                    _root.ManipulationStarted -= Scroller_ManipulationStarted;
+                    _root.ManipulationCompleted -= Scroller_ManipulationCompleted;
+                    _scroller.PointerMoved -= Scroller_PointerMoved;
+                    _scroller.PointerExited -= Scroller_PointerExited;
+                }
             }
         }
     }


### PR DESCRIPTION
Issue: #1034 #1380 #887
<!-- Link to relevant issue. All PRs should be asociated with an issue -->

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build or CI related changes
[ ] Documentation content changes
[ ] Sample app changes
[ ] Other... Please describe:
```


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
See #1034 #1380 #887 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)


## What is the new behavior?
* Mouse and touch have the same behavior now when pulling down
* When *IsPullToRefreshWithMouseEnabled* set to true, the mouse will scroll the listview
* System manipulations (such as swiping on a pivot) works even when mouse pull to refresh is enabled

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
