### PR TITLE
ScrollHeader fix for hidden focused elements

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Animations/Behaviors/QuickReturnHeaderBehavior.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Animations/Behaviors/QuickReturnHeaderBehavior.cs
@@ -11,11 +11,13 @@
 // ******************************************************************
 
 using Microsoft.Toolkit.Uwp.UI.Extensions;
+using Windows.Foundation;
 using Windows.Foundation.Metadata;
 using Windows.UI.Composition;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Hosting;
+using Windows.UI.Xaml.Input;
 
 namespace Microsoft.Toolkit.Uwp.UI.Animations.Behaviors
 {
@@ -103,7 +105,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations.Behaviors
         /// for the Header as it is scrolling off-screen. The opacity reaches 0 when the Header
         /// is entirely scrolled off.
         /// </summary>
-        /// <returns><c>true</c> if the assignment was successfull; otherwise, <c>false</c>.</returns>
+        /// <returns><c>true</c> if the assignment was successful; otherwise, <c>false</c>.</returns>
         private bool AssignAnimation()
         {
             StopAnimation();
@@ -169,6 +171,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations.Behaviors
             _scrollViewer.ViewChanged -= ScrollViewer_ViewChanged;
             _scrollViewer.ViewChanged += ScrollViewer_ViewChanged;
 
+            _scrollViewer.GotFocus -= ScrollViewer_GotFocus;
+            _scrollViewer.GotFocus += ScrollViewer_GotFocus;
+
             headerElement.SizeChanged -= ScrollHeader_SizeChanged;
             headerElement.SizeChanged += ScrollHeader_SizeChanged;
 
@@ -199,8 +204,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations.Behaviors
                 _scrollViewer.ViewChanged -= ScrollViewer_ViewChanged;
             }
 
-            var element = HeaderElement as FrameworkElement;
-            if (element != null)
+            if (HeaderElement is FrameworkElement element)
             {
                 element.SizeChanged -= ScrollHeader_SizeChanged;
             }
@@ -245,9 +249,28 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations.Behaviors
                 else if (_headerPosition > _scrollViewer.VerticalOffset)
                 {
                     // scrolling up: move header up, align with top border.
-                    // the expression animation makes sure it never relly is shown below border, so no lag effect!
+                    // the expression animation makes sure it never really is shown below border, so no lag effect!
                     _headerPosition = _scrollViewer.VerticalOffset;
                     _animationProperties.InsertScalar("OffsetY", (float)_headerPosition);
+                }
+            }
+        }
+
+        private void ScrollViewer_GotFocus(object sender, RoutedEventArgs e)
+        {
+            var scroller = sender as ScrollViewer;
+
+            var focusedElement = FocusManager.GetFocusedElement();
+
+            if (focusedElement is UIElement element)
+            {
+                FrameworkElement header = (FrameworkElement)HeaderElement;
+
+                var point = element.TransformToVisual(scroller).TransformPoint(new Point(0, 0));
+
+                if (point.Y < header.ActualHeight)
+                {
+                    scroller.ChangeView(0, scroller.VerticalOffset - (header.ActualHeight - point.Y), 1, false);
                 }
             }
         }

--- a/Microsoft.Toolkit.Uwp.UI.Animations/Behaviors/QuickReturnHeaderBehavior.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Animations/Behaviors/QuickReturnHeaderBehavior.cs
@@ -202,6 +202,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations.Behaviors
             if (_scrollViewer != null)
             {
                 _scrollViewer.ViewChanged -= ScrollViewer_ViewChanged;
+                _scrollViewer.GotFocus -= ScrollViewer_GotFocus;
             }
 
             if (HeaderElement is FrameworkElement element)

--- a/Microsoft.Toolkit.Uwp.UI.Animations/Behaviors/QuickReturnHeaderBehavior.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Animations/Behaviors/QuickReturnHeaderBehavior.cs
@@ -259,7 +259,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations.Behaviors
 
         private void ScrollViewer_GotFocus(object sender, RoutedEventArgs e)
         {
-            var scroller = sender as ScrollViewer;
+            var scroller = (ScrollViewer)sender;
 
             var focusedElement = FocusManager.GetFocusedElement();
 

--- a/Microsoft.Toolkit.Uwp.UI.Animations/Behaviors/StickyHeaderBehavior.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Animations/Behaviors/StickyHeaderBehavior.cs
@@ -238,7 +238,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations.Behaviors
 
         private void ScrollViewer_GotFocus(object sender, RoutedEventArgs e)
         {
-            var scroller = sender as ScrollViewer;
+            var scroller = (ScrollViewer)sender;
 
             var focusedElement = FocusManager.GetFocusedElement();
 

--- a/Microsoft.Toolkit.Uwp.UI.Animations/Behaviors/StickyHeaderBehavior.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Animations/Behaviors/StickyHeaderBehavior.cs
@@ -11,11 +11,13 @@
 // ******************************************************************
 
 using Microsoft.Toolkit.Uwp.UI.Extensions;
+using Windows.Foundation;
 using Windows.Foundation.Metadata;
 using Windows.UI.Composition;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Hosting;
+using Windows.UI.Xaml.Input;
 
 namespace Microsoft.Toolkit.Uwp.UI.Animations.Behaviors
 {
@@ -105,7 +107,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations.Behaviors
         /// for the Header as it is scrolling off-screen. The opacity reaches 0 when the Header
         /// is entirely scrolled off.
         /// </summary>
-        /// <returns><c>true</c> if the assignment was successfull; otherwise, <c>false</c>.</returns>
+        /// <returns><c>true</c> if the assignment was successful; otherwise, <c>false</c>.</returns>
         private bool AssignAnimation()
         {
             StopAnimation();
@@ -172,6 +174,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations.Behaviors
             headerElement.SizeChanged -= ScrollHeader_SizeChanged;
             headerElement.SizeChanged += ScrollHeader_SizeChanged;
 
+            _scrollViewer.GotFocus -= ScrollViewer_GotFocus;
+            _scrollViewer.GotFocus += ScrollViewer_GotFocus;
+
             var compositor = _scrollProperties.Compositor;
 
             if (_animationProperties == null)
@@ -196,8 +201,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations.Behaviors
         /// </summary>
         private void RemoveAnimation()
         {
-            var element = HeaderElement as FrameworkElement;
-            if (element != null)
+            if (HeaderElement is FrameworkElement element)
             {
                 element.SizeChanged -= ScrollHeader_SizeChanged;
             }
@@ -225,6 +229,25 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations.Behaviors
         private void ScrollHeader_SizeChanged(object sender, SizeChangedEventArgs e)
         {
             AssignAnimation();
+        }
+
+        private void ScrollViewer_GotFocus(object sender, RoutedEventArgs e)
+        {
+            var scroller = sender as ScrollViewer;
+
+            var focusedElement = FocusManager.GetFocusedElement();
+
+            if (focusedElement is UIElement element)
+            {
+                FrameworkElement header = (FrameworkElement)HeaderElement;
+
+                var point = element.TransformToVisual(scroller).TransformPoint(new Point(0, 0));
+
+                if (point.Y < header.ActualHeight)
+                {
+                    scroller.ChangeView(0, scroller.VerticalOffset - (header.ActualHeight - point.Y), 1, false);
+                }
+            }
         }
     }
 }

--- a/Microsoft.Toolkit.Uwp.UI.Animations/Behaviors/StickyHeaderBehavior.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Animations/Behaviors/StickyHeaderBehavior.cs
@@ -206,6 +206,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations.Behaviors
                 element.SizeChanged -= ScrollHeader_SizeChanged;
             }
 
+            if (_scrollViewer != null)
+            {
+                _scrollViewer.GotFocus -= ScrollViewer_GotFocus;
+            }
+
             StopAnimation();
         }
 


### PR DESCRIPTION
Issue: #1553 
<!-- Link to relevant issue. All PRs should be asociated with an issue -->

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build or CI related changes
[ ] Documentation content changes
[ ] Sample app changes
[ ] Other... Please describe:
```


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
See #1553 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)


## What is the new behavior?
When an item is focused near the header, the ScrollViewer will  scroll to make sure item is not hidden by the header.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
