### PR TITLE
Fixing `MarkdownTextBlock` Parsing Table Issue

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/Parse/Blocks/TableBlock.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/Parse/Blocks/TableBlock.cs
@@ -225,7 +225,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls.Markdown.Parse
 
                         if (c == '\r')
                         {
-                            if (pos < maxEndingPos && (markdown[pos] == '\n' || markdown[pos + 1] == '\n'))
+                            if (pos < maxEndingPos && markdown[pos + 1] == '\n')
                             {
                                 pos++; // Swallow the complete linefeed.
                             }

--- a/docs/animations/Scale.md
+++ b/docs/animations/Scale.md
@@ -86,7 +86,7 @@ You can change the way how the animation interpolates between keyframes by defin
     ```
     **Sample Output**
 
-    ![Use Case 1 Output](../resources/images/Animations/Saturation/Scale.gif)
+    ![Use Case 1 Output](../resources/images/Animations/Scale/Sample-Output.gif)
 - Use this to create chaining animations with other animations. Visit the [AnimationSet](\AnimationSet.md) documentation for more information.
 
     **Sample Code**


### PR DESCRIPTION
Considering Carriage Return and Line Feed instead of only Linefeed when parsing MarkdownTable Data.

Issue: #1516

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Sample app changes
- [ ] Build or CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:
```


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently it ignores Carriage Return if they are coupled as `\r\n`

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)

## What is the new behavior?

Now it will not ignore when Carriage Return and Line Feed are coupled like `\r\n`

## Does this PR introduce a breaking change?
```
- [ ] Yes
- [x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
