### PR TITLE
ImageEx ProgressRing Visibility toggled through VisualState

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/ImageEx/ImageEx.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/ImageEx/ImageEx.xaml
@@ -27,7 +27,8 @@
                                       VerticalAlignment="Center"
                                       Background="Transparent"
                                       Foreground="{TemplateBinding Foreground}"
-                                      IsActive="False" />
+                                      IsActive="False"
+                                      Visibility="Collapsed" />
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup x:Name="CommonStates">
                                 <VisualState x:Name="Failed">
@@ -47,6 +48,11 @@
                                 <VisualState x:Name="Loading">
                                     <Storyboard>
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Progress"
+                                                                       Storyboard.TargetProperty="Visibility">
+                                            <DiscreteObjectKeyFrame KeyTime="0"
+                                                                    Value="Visible" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Progress"
                                                                        Storyboard.TargetProperty="IsActive">
                                             <DiscreteObjectKeyFrame KeyTime="0"
                                                                     Value="True" />
@@ -65,11 +71,6 @@
                                 </VisualState>
                                 <VisualState x:Name="Loaded">
                                     <Storyboard>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Progress"
-                                                                       Storyboard.TargetProperty="IsActive">
-                                            <DiscreteObjectKeyFrame KeyTime="0"
-                                                                    Value="False" />
-                                        </ObjectAnimationUsingKeyFrames>
                                         <DoubleAnimation AutoReverse="False"
                                                          BeginTime="0"
                                                          Storyboard.TargetName="Image"


### PR DESCRIPTION
Issue: #1328

## PR Type
Setting Visibility of ProgressRing to Collapsed by default.
Modify VisualState to make ProgressRing Visible when Loading.
Removed un-necessary modification in Loaded state.

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build or CI related changes
[ ] Documentation content changes
[ ] Sample app changes
[ ] Other... Please describe:
```


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The ProgressRing is always visible with only IsActive being toggled.
If large number of ImageEx controls are used, LayoutCycleException is encountered

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x ] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)


## What is the new behavior?
Setting Visibility of ProgressRing to Collapsed by default.
Modify VisualState to make ProgressRing Visible when Loading.
Removed un-necessary modification in Loaded state.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
