### PR TITLE
add StepFrequency to RangeSelector

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/RangeSelector/RangeSelectorCode.bind
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/RangeSelector/RangeSelectorCode.bind
@@ -27,7 +27,7 @@
                               Grid.Column="1"                              
                               Minimum="@[Minimum:Slider:0:0-100]@"
                               Maximum="@[Maximum:Slider:100:0-100]@"
-                              StepFrequency="@[StepFrequency:String:1]@"/>
+                              StepFrequency="@[StepFrequency:DoubleSlider:1.0:0.25-10.0]@"/>
       <TextBlock Grid.Column="2"
                  HorizontalAlignment="Right"
                  VerticalAlignment="Center"

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/RangeSelector/RangeSelectorCode.bind
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/RangeSelector/RangeSelectorCode.bind
@@ -27,7 +27,7 @@
                               Grid.Column="1"                              
                               Minimum="@[Minimum:Slider:0:0-100]@"
                               Maximum="@[Maximum:Slider:100:0-100]@"
-                              StepValue="@[StepValue:String:1]@"/>
+                              StepFrequency="@[StepFrequency:String:1]@"/>
       <TextBlock Grid.Column="2"
                  HorizontalAlignment="Right"
                  VerticalAlignment="Center"

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/RangeSelector/RangeSelectorCode.bind
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/RangeSelector/RangeSelectorCode.bind
@@ -6,32 +6,33 @@
     xmlns:controls="using:Microsoft.Toolkit.Uwp.UI.Controls"
     xmlns:converters="using:Microsoft.Toolkit.Uwp.UI.Converters"
     mc:Ignorable="d">
-    <Page.Resources>
-        <converters:StringFormatConverter x:Key="StringFormatConverter"/>
-    </Page.Resources>
+  <Page.Resources>
+    <converters:StringFormatConverter x:Key="StringFormatConverter"/>
+  </Page.Resources>
 
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
-        <Grid VerticalAlignment="Center" 
-		      HorizontalAlignment="Center">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="50"/>
-                <ColumnDefinition Width="200"/>
-                <ColumnDefinition Width="50"/>
-            </Grid.ColumnDefinitions>
-            <TextBlock Grid.Column="0" 
-                       HorizontalAlignment="Left"
-                       VerticalAlignment="Center"
-                       Foreground="Black"
-                       Text="{Binding RangeMin, ElementName=RangeSelectorControl, Converter={StaticResource StringFormatConverter}, ConverterParameter='{}{0:0.##}'}" />
-            <controls:RangeSelector x:Name="RangeSelectorControl"
-                                    Grid.Column="1"
-                                    Minimum="@[Minimum:Slider:0:0-100]@" 
-                                    Maximum="@[Maximum:Slider:100:0-100]@" />
-            <TextBlock Grid.Column="2" 
-                       HorizontalAlignment="Right"
-                       VerticalAlignment="Center"
-                       Foreground="Black"
-                       Text="{Binding RangeMax, ElementName=RangeSelectorControl, Converter={StaticResource StringFormatConverter}, ConverterParameter='{}{0:0.##}'}" />
-        </Grid>
+  <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <Grid VerticalAlignment="Center"
+      HorizontalAlignment="Center">
+      <Grid.ColumnDefinitions>
+        <ColumnDefinition Width="50"/>
+        <ColumnDefinition Width="200"/>
+        <ColumnDefinition Width="50"/>
+      </Grid.ColumnDefinitions>
+      <TextBlock Grid.Column="0"
+                 HorizontalAlignment="Left"
+                 VerticalAlignment="Center"
+                 Foreground="Black"
+                 Text="{Binding RangeMin, ElementName=RangeSelectorControl, Converter={StaticResource StringFormatConverter}, ConverterParameter='{}{0:0.##}'}" />
+      <controls:RangeSelector x:Name="RangeSelectorControl"
+                              Grid.Column="1"                              
+                              Minimum="@[Minimum:Slider:0:0-100]@"
+                              Maximum="@[Maximum:Slider:100:0-100]@"
+                              StepValue="@[StepValue:String:1]@"/>
+      <TextBlock Grid.Column="2"
+                 HorizontalAlignment="Right"
+                 VerticalAlignment="Center"
+                 Foreground="Black"
+                 Text="{Binding RangeMax, ElementName=RangeSelectorControl, Converter={StaticResource StringFormatConverter}, ConverterParameter='{}{0:0.##}'}" />
     </Grid>
+  </Grid>
 </Page>

--- a/Microsoft.Toolkit.Uwp.UI.Controls/RangeSelector/RangeSelector.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/RangeSelector/RangeSelector.cs
@@ -645,16 +645,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 return;
             }
 
-            rangeSelector.ValidateStepFrequency();
             rangeSelector.ResetStepFrequency();
-        }
-
-        private void ValidateStepFrequency()
-        {
-            if (StepFrequency > Maximum)
-            {
-                StepFrequency = DefaultStepFrequency;
-            }
         }
 
         private void ResetStepFrequency()

--- a/Microsoft.Toolkit.Uwp.UI.Controls/RangeSelector/RangeSelector.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/RangeSelector/RangeSelector.cs
@@ -619,10 +619,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         }
 
         /// <summary>
-        /// Gets or sets the step frequency, which is the interval between the values on the RangeSelector
+        /// Gets or sets the value part of a value range that steps should be created for.
         /// </summary>
         /// <value>
-        /// The value for step.
+        /// The value part of a value range that steps should be created for.
         /// </value>
         public double StepFrequency
         {

--- a/Microsoft.Toolkit.Uwp.UI.Controls/RangeSelector/RangeSelector.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/RangeSelector/RangeSelector.cs
@@ -37,6 +37,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
     [TemplatePart(Name = "ControlGrid", Type = typeof(Grid))]
     public class RangeSelector : Control
     {
+        private const double Epsilon = 0.01;
+        private const double DefaultStepFrequency = 0.0;
+
         /// <summary>
         /// Identifies the Minimum dependency property.
         /// </summary>
@@ -66,10 +69,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// Identifies the StepFrequency dependency property.
         /// </summary>
         public static readonly DependencyProperty StepFrequencyProperty = DependencyProperty.Register(nameof(StepFrequency), typeof(double), typeof(RangeSelector), new PropertyMetadata(DefaultStepFrequency, StepFrequencyChangedCallback));
-
-        private const double Epsilon = 0.01;
-
-        private const double DefaultStepFrequency = 0.0;
 
         private Border _outOfRangeContentContainer;
         private Rectangle _activeRectangle;

--- a/Microsoft.Toolkit.Uwp.UI.Controls/RangeSelector/RangeSelector.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/RangeSelector/RangeSelector.cs
@@ -264,6 +264,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 _containerCanvas.IsHitTestVisible = true;
                 ValueChanged?.Invoke(this, new RangeChangedEventArgs(RangeMax, normalizedPosition, RangeSelectorProperty.MaximumValue));
             }
+
+            SyncThumbs();
         }
 
         private void ContainerCanvas_PointerMoved(object sender, PointerRoutedEventArgs e)
@@ -298,6 +300,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 RangeMin = normalizedPosition;
                 _pointerManipulatingMin = true;
             }
+
+            SyncThumbs();
         }
 
         private void ContainerCanvas_SizeChanged(object sender, SizeChangedEventArgs e)
@@ -510,7 +514,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                     return;
                 }
 
-                rangeSelector.SyncThumbs();
+                rangeSelector.SyncActiveRectangle();
 
                 if (newValue > rangeSelector.RangeMax)
                 {
@@ -519,7 +523,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             }
             else
             {
-                rangeSelector.SyncThumbs();
+                rangeSelector.SyncActiveRectangle();
             }
         }
 
@@ -575,7 +579,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                     return;
                 }
 
-                rangeSelector.SyncThumbs();
+                rangeSelector.SyncActiveRectangle();
 
                 if (newValue < rangeSelector.RangeMin)
                 {
@@ -584,7 +588,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             }
             else
             {
-                rangeSelector.SyncThumbs();
+                rangeSelector.SyncActiveRectangle();
             }
         }
 
@@ -752,11 +756,31 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             var relativeRight = ((RangeMax - Minimum) / (Maximum - Minimum)) * _containerCanvas.ActualWidth;
 
             Canvas.SetLeft(_minThumb, relativeLeft);
-            Canvas.SetLeft(_activeRectangle, relativeLeft);
-            Canvas.SetTop(_activeRectangle, (_containerCanvas.ActualHeight - _activeRectangle.ActualHeight) / 2);
-
             Canvas.SetLeft(_maxThumb, relativeRight);
 
+            SyncActiveRectangle();
+        }
+
+        private void SyncActiveRectangle()
+        {
+            if (_containerCanvas == null)
+            {
+                return;
+            }
+
+            if (_minThumb == null)
+            {
+                return;
+            }
+
+            if (_maxThumb == null)
+            {
+                return;
+            }
+
+            var relativeLeft = Canvas.GetLeft(_minThumb);
+            Canvas.SetLeft(_activeRectangle, relativeLeft);
+            Canvas.SetTop(_activeRectangle, (_containerCanvas.ActualHeight - _activeRectangle.ActualHeight) / 2);
             _activeRectangle.Width = Math.Max(0, Canvas.GetLeft(_maxThumb) - Canvas.GetLeft(_minThumb));
         }
 
@@ -809,7 +833,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         {
             ThumbDragCompleted?.Invoke(this, e);
             ValueChanged?.Invoke(this, sender.Equals(_minThumb) ? new RangeChangedEventArgs(_oldValue, RangeMin, RangeSelectorProperty.MinimumValue) : new RangeChangedEventArgs(_oldValue, RangeMax, RangeSelectorProperty.MaximumValue));
-
+            SyncThumbs();
             VisualStateManager.GoToState(this, "Normal", true);
         }
 

--- a/Microsoft.Toolkit.Uwp.UI.Controls/RangeSelector/RangeSelector.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/RangeSelector/RangeSelector.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
     public class RangeSelector : Control
     {
         private const double Epsilon = 0.01;
-        private const double DefaultStepFrequency = 0.0;
+        private const double DefaultStepFrequency = 1.0;
 
         /// <summary>
         /// Identifies the Minimum dependency property.
@@ -656,29 +656,29 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
         private void RangeMinToStepFrequency()
         {
-            if (StepFrequency != DefaultStepFrequency)
-            {
-                RangeMin = MoveToStepFrequency(RangeMin);
-            }
+            RangeMin = MoveToStepFrequency(RangeMin);
         }
 
         private void RangeMaxToStepFrequency()
         {
-            if (StepFrequency != DefaultStepFrequency)
-            {
-                RangeMax = MoveToStepFrequency(RangeMax);
-            }
+            RangeMax = MoveToStepFrequency(RangeMax);
         }
 
         private double MoveToStepFrequency(double rangeValue)
         {
-            if (rangeValue != Maximum && rangeValue != Minimum)
+            double newValue = Minimum + (((int)((rangeValue - Minimum) / StepFrequency)) * StepFrequency);
+
+            if (newValue < Minimum)
             {
-                return Minimum + (((int)((rangeValue - Minimum) / StepFrequency)) * StepFrequency);
+                return Minimum;
+            }
+            else if (newValue > Maximum || Maximum - newValue < StepFrequency)
+            {
+                return Maximum;
             }
             else
             {
-                return rangeValue;
+                return newValue;
             }
         }
 

--- a/Microsoft.Toolkit.Uwp.UI.Controls/RangeSelector/RangeSelector.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/RangeSelector/RangeSelector.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// <summary>
         /// Identifies the StepFrequency dependency property.
         /// </summary>
-        public static readonly DependencyProperty StepFrequencyProperty = DependencyProperty.Register(nameof(StepFrequency), typeof(double), typeof(RangeSelector), new PropertyMetadata(DefaultStepFrequency, StepFrequencyChangedCallback));
+        public static readonly DependencyProperty StepFrequencyProperty = DependencyProperty.Register(nameof(StepFrequency), typeof(double), typeof(RangeSelector), new PropertyMetadata(DefaultStepFrequency));
 
         private Border _outOfRangeContentContainer;
         private Rectangle _activeRectangle;
@@ -185,8 +185,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             {
                 ArrangeForTouch();
             }
-
-            ResetStepFrequency();
 
             base.OnApplyTemplate();
         }
@@ -639,23 +637,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             {
                 SetValue(StepFrequencyProperty, value);
             }
-        }
-
-        private static void StepFrequencyChangedCallback(DependencyObject d, DependencyPropertyChangedEventArgs e)
-        {
-            var rangeSelector = d as RangeSelector;
-            if (rangeSelector == null)
-            {
-                return;
-            }
-
-            rangeSelector.ResetStepFrequency();
-        }
-
-        private void ResetStepFrequency()
-        {
-            RangeMinToStepFrequency();
-            RangeMaxToStepFrequency();
         }
 
         private void RangeMinToStepFrequency()

--- a/Microsoft.Toolkit.Uwp.UI.Controls/RangeSelector/RangeSelector.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/RangeSelector/RangeSelector.cs
@@ -646,7 +646,16 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 return;
             }
 
+            rangeSelector.ValidateStepFrequency();
             rangeSelector.ResetStepFrequency();
+        }
+
+        private void ValidateStepFrequency()
+        {
+            if (StepFrequency > Maximum)
+            {
+                StepFrequency = DefaultStepFrequency;
+            }
         }
 
         private void ResetStepFrequency()

--- a/Microsoft.Toolkit.Uwp.UI.Controls/RangeSelector/RangeSelector.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/RangeSelector/RangeSelector.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
     public class RangeSelector : Control
     {
         private const double Epsilon = 0.01;
-        private const double DefaultStepFrequency = 1.0;
+        private const double DefaultStepFrequency = 0.01;
 
         /// <summary>
         /// Identifies the Minimum dependency property.

--- a/Microsoft.Toolkit.Uwp.UI.Controls/RangeSelector/RangeSelector.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/RangeSelector/RangeSelector.cs
@@ -651,7 +651,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
         private double MoveToStepFrequency(double rangeValue)
         {
-            double newValue = Minimum + (((int)((rangeValue - Minimum) / StepFrequency)) * StepFrequency);
+            double newValue = Minimum + (((int)Math.Round((rangeValue - Minimum) / StepFrequency)) * StepFrequency);
 
             if (newValue < Minimum)
             {

--- a/Microsoft.Toolkit.Uwp.UI.Controls/RangeSelector/RangeSelector.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/RangeSelector/RangeSelector.cs
@@ -618,7 +618,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         }
 
         /// <summary>
-        /// Gets or sets the step value for range selector.
+        /// Gets or sets the step frequency, which is the interval between the values on the RangeSelector
         /// </summary>
         /// <value>
         /// The value for step.

--- a/Microsoft.Toolkit.Uwp.UI.Controls/RangeSelector/RangeSelector.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/RangeSelector/RangeSelector.cs
@@ -69,8 +69,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
         private const double Epsilon = 0.01;
 
-        private List<double> stepValues;
-
         private Border _outOfRangeContentContainer;
         private Rectangle _activeRectangle;
         private Thumb _minThumb;
@@ -656,22 +654,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         {
             if (StepValue != 0)
             {
-                if (stepValues == null)
-                {
-                    stepValues = new List<double>();
-                }
-                else
-                {
-                    stepValues.Clear();
-                }
-
-                double newStep = Minimum + StepValue;
-                while (newStep < Maximum)
-                {
-                    stepValues.Add(newStep);
-                    newStep += StepValue;
-                }
-
                 RangeMinToStepValue();
                 RangeMaxToStepValue();
             }
@@ -695,9 +677,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
         private double MoveToStepValue(double rangeValue)
         {
-            if (stepValues.Any() && rangeValue != Maximum && rangeValue != Minimum)
+            if (rangeValue != Maximum && rangeValue != Minimum)
             {
-                return stepValues.Where(s => s >= rangeValue).FirstOrDefault();
+                return rangeValue - Enumerable.Range((int)Minimum, (int)Maximum)
+                    .Where(x => x % StepValue == 0)
+                    .Min(x => Math.Abs(rangeValue - x));
             }
             else
             {

--- a/Microsoft.Toolkit.Uwp.UI.Controls/RangeSelector/RangeSelector.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/RangeSelector/RangeSelector.cs
@@ -644,10 +644,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 return;
             }
 
-            if (rangeSelector.StepFrequency != 0)
-            {
-                rangeSelector.ResetStepFrequency();
-            }
+            rangeSelector.ResetStepFrequency();
         }
 
         private void ResetStepFrequency()

--- a/Microsoft.Toolkit.Uwp.UI.Controls/RangeSelector/RangeSelector.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/RangeSelector/RangeSelector.cs
@@ -63,9 +63,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         public static readonly DependencyProperty IsTouchOptimizedProperty = DependencyProperty.Register(nameof(IsTouchOptimized), typeof(bool), typeof(RangeSelector), new PropertyMetadata(false, IsTouchOptimizedChangedCallback));
 
         /// <summary>
-        /// Identifies the StepValue dependency property.
+        /// Identifies the StepFrequency dependency property.
         /// </summary>
-        public static readonly DependencyProperty StepValueProperty = DependencyProperty.Register(nameof(StepValue), typeof(double), typeof(RangeSelector), new PropertyMetadata(0.0, StepValueChangedCallback));
+        public static readonly DependencyProperty StepFrequencyProperty = DependencyProperty.Register(nameof(StepFrequency), typeof(double), typeof(RangeSelector), new PropertyMetadata(0.0, StepFrequencyChangedCallback));
 
         private const double Epsilon = 0.01;
 
@@ -185,7 +185,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 ArrangeForTouch();
             }
 
-            ResetStepValues();
+            ResetStepFrequency();
 
             base.OnApplyTemplate();
         }
@@ -493,7 +493,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             }
 
             var newValue = (double)e.NewValue;
-            rangeSelector.RangeMinToStepValue();
+            rangeSelector.RangeMinToStepFrequency();
 
             if (rangeSelector._valuesAssigned)
             {
@@ -558,7 +558,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             }
 
             var newValue = (double)e.NewValue;
-            rangeSelector.RangeMaxToStepValue();
+            rangeSelector.RangeMaxToStepFrequency();
 
             if (rangeSelector._valuesAssigned)
             {
@@ -623,20 +623,20 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// <value>
         /// The value for step.
         /// </value>
-        public double StepValue
+        public double StepFrequency
         {
             get
             {
-                return (double)GetValue(StepValueProperty);
+                return (double)GetValue(StepFrequencyProperty);
             }
 
             set
             {
-                SetValue(StepValueProperty, value);
+                SetValue(StepFrequencyProperty, value);
             }
         }
 
-        private static void StepValueChangedCallback(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        private static void StepFrequencyChangedCallback(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             var rangeSelector = d as RangeSelector;
             if (rangeSelector == null)
@@ -644,43 +644,43 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 return;
             }
 
-            if (rangeSelector.StepValue != 0)
+            if (rangeSelector.StepFrequency != 0)
             {
-                rangeSelector.ResetStepValues();
+                rangeSelector.ResetStepFrequency();
             }
         }
 
-        private void ResetStepValues()
+        private void ResetStepFrequency()
         {
-            if (StepValue != 0)
+            if (StepFrequency != 0)
             {
-                RangeMinToStepValue();
-                RangeMaxToStepValue();
+                RangeMinToStepFrequency();
+                RangeMaxToStepFrequency();
             }
         }
 
-        private void RangeMinToStepValue()
+        private void RangeMinToStepFrequency()
         {
-            if (StepValue != 0)
+            if (StepFrequency != 0)
             {
-                RangeMin = MoveToStepValue(RangeMin);
+                RangeMin = MoveToStepFrequency(RangeMin);
             }
         }
 
-        private void RangeMaxToStepValue()
+        private void RangeMaxToStepFrequency()
         {
-            if (StepValue != 0)
+            if (StepFrequency != 0)
             {
-                RangeMax = MoveToStepValue(RangeMax);
+                RangeMax = MoveToStepFrequency(RangeMax);
             }
         }
 
-        private double MoveToStepValue(double rangeValue)
+        private double MoveToStepFrequency(double rangeValue)
         {
             if (rangeValue != Maximum && rangeValue != Minimum)
             {
                 return rangeValue - Enumerable.Range((int)Minimum, (int)Maximum)
-                    .Where(x => x % StepValue == 0)
+                    .Where(x => x % StepFrequency == 0)
                     .Min(x => Math.Abs(rangeValue - x));
             }
             else

--- a/Microsoft.Toolkit.Uwp.UI.Controls/RangeSelector/RangeSelector.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/RangeSelector/RangeSelector.cs
@@ -65,9 +65,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// <summary>
         /// Identifies the StepFrequency dependency property.
         /// </summary>
-        public static readonly DependencyProperty StepFrequencyProperty = DependencyProperty.Register(nameof(StepFrequency), typeof(double), typeof(RangeSelector), new PropertyMetadata(0.0, StepFrequencyChangedCallback));
+        public static readonly DependencyProperty StepFrequencyProperty = DependencyProperty.Register(nameof(StepFrequency), typeof(double), typeof(RangeSelector), new PropertyMetadata(DefaultStepFrequency, StepFrequencyChangedCallback));
 
         private const double Epsilon = 0.01;
+
+        private const double DefaultStepFrequency = 0.0;
 
         private Border _outOfRangeContentContainer;
         private Rectangle _activeRectangle;
@@ -649,16 +651,13 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
         private void ResetStepFrequency()
         {
-            if (StepFrequency != 0)
-            {
-                RangeMinToStepFrequency();
-                RangeMaxToStepFrequency();
-            }
+            RangeMinToStepFrequency();
+            RangeMaxToStepFrequency();
         }
 
         private void RangeMinToStepFrequency()
         {
-            if (StepFrequency != 0)
+            if (StepFrequency != DefaultStepFrequency)
             {
                 RangeMin = MoveToStepFrequency(RangeMin);
             }
@@ -666,7 +665,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
         private void RangeMaxToStepFrequency()
         {
-            if (StepFrequency != 0)
+            if (StepFrequency != DefaultStepFrequency)
             {
                 RangeMax = MoveToStepFrequency(RangeMax);
             }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/RangeSelector/RangeSelector.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/RangeSelector/RangeSelector.cs
@@ -676,9 +676,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         {
             if (rangeValue != Maximum && rangeValue != Minimum)
             {
-                return rangeValue - Enumerable.Range((int)Minimum, (int)Maximum)
-                    .Where(x => x % StepFrequency == 0)
-                    .Min(x => Math.Abs(rangeValue - x));
+                return Minimum + (((int)((rangeValue - Minimum) / StepFrequency)) * StepFrequency);
             }
             else
             {

--- a/docs/controls/RangeSelector.md
+++ b/docs/controls/RangeSelector.md
@@ -50,7 +50,7 @@ This is because by default, the ScrollViewer will block the thumbs of the RangeS
 
 ## StepFrequency
 
-If you want to use the RangeSelector using a step value, there is a `StepValue` property to set the interval between the values on the RangeSelector. For example; if you set `StepValue` to 2, using Minimum at 0 and Maximum at 10, the range values you can set will be 0,2,4,6,8,10.
+If you want to use the RangeSelector using a step frequency, there is a `StepFrequency` property to set the interval between the values on the RangeSelector. For example; if you set `StepFrequency` to 2, using Minimum at 0 and Maximum at 10, the range values you can set will be 0,2,4,6,8,10.
 
 ## Example Image
 

--- a/docs/controls/RangeSelector.md
+++ b/docs/controls/RangeSelector.md
@@ -48,6 +48,10 @@ This is because by default, the ScrollViewer will block the thumbs of the RangeS
 
 ```
 
+## StepValue
+
+If you want to use the RangeSelector using a step value, there is a `StepValue` property to set the interval between the values on the RangeSelector. For example; if you set `StepValue` to 2, using Minimum at 0 and Maximum at 10, the range values you can set will be 0,2,4,6,8,10.
+
 ## Example Image
 
 ![RangeSelector animation](../resources/images/Controls-RangeSelector.gif "RangeSelector")

--- a/docs/controls/RangeSelector.md
+++ b/docs/controls/RangeSelector.md
@@ -48,7 +48,7 @@ This is because by default, the ScrollViewer will block the thumbs of the RangeS
 
 ```
 
-## StepValue
+## StepFrequency
 
 If you want to use the RangeSelector using a step value, there is a `StepValue` property to set the interval between the values on the RangeSelector. For example; if you set `StepValue` to 2, using Minimum at 0 and Maximum at 10, the range values you can set will be 0,2,4,6,8,10.
 


### PR DESCRIPTION
Issue: #1356 

## PR Type
Improvement on RangeSelector

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x ] Feature
[ ] Code style update (formatting)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build or CI related changes
[x ] Documentation content changes
[x ] Sample app changes
[ ] Other... Please describe:
```


## What is the current behavior?
the rangeselector max and min values change according to the thumb position

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ x] Tested code with current [supported SDKs](../readme.md#supported)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Sample in sample app has been added / updated (for bug fixes / features)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)


## What is the new behavior?
There is a DP called StepValue, and if it is set then the values and the thumbs move to the corresponding position of the next stepvalue.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
