### PR TITLE
ImageEx CornerRadius RS3 Support and RoundImageEx Obsolete Notice

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/ImageEx/ImageExCode.bind
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/ImageEx/ImageExCode.bind
@@ -38,6 +38,15 @@
                                   Source="/Assets/Photos/LunchBreak.jpg"
                                   PlaceholderSource="/Assets/Photos/ImageExPlaceholder.jpg"
                                   Style="{StaticResource RectangleStyle}"/>
+              
+                <controls:ImageEx x:Name="ImageExControl2"
+                                  IsCacheEnabled="@[Enable Cache:Bool:True]"
+                                  Source="/Assets/Photos/LunchBreak.jpg"
+                                  PlaceholderSource="/Assets/Photos/ImageExPlaceholder.jpg"
+                                  CornerRadius="30"
+                                  Style="{StaticResource RectangleStyle}"/>
+              
+                <TextBlock Text="Above ImageEx will have rounded corners on RS3." Margin="4" HorizontalAlignment="Center"/>
 
                 <controls:RoundImageEx x:Name="RoundImageExControl1"
                                        IsCacheEnabled="@[Enable Cache]"

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/ImageEx/ImageExCode.bind
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/ImageEx/ImageExCode.bind
@@ -43,7 +43,7 @@
                                   IsCacheEnabled="@[Enable Cache:Bool:True]"
                                   Source="/Assets/Photos/LunchBreak.jpg"
                                   PlaceholderSource="/Assets/Photos/ImageExPlaceholder.jpg"
-                                  CornerRadius="30"
+                                  CornerRadius="30,60,30,60"
                                   Style="{StaticResource RectangleStyle}"/>
               
                 <TextBlock Text="Above ImageEx will have rounded corners on RS3." Margin="4" HorizontalAlignment="Center"/>

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/ImageEx/ImageExCode.bind
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/ImageEx/ImageExCode.bind
@@ -46,7 +46,7 @@
                                   CornerRadius="30,60,30,60"
                                   Style="{StaticResource RectangleStyle}"/>
               
-                <TextBlock Text="Above ImageEx will have rounded corners on RS3." Margin="4" HorizontalAlignment="Center"/>
+                <TextBlock Text="Above ImageEx will have rounded corners on the Fall Creators Update." Margin="4" HorizontalAlignment="Center"/>
 
                 <controls:RoundImageEx x:Name="RoundImageExControl1"
                                        IsCacheEnabled="@[Enable Cache]"

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/ImageEx/ImageExPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/ImageEx/ImageExPage.xaml.cs
@@ -97,9 +97,11 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
             ImageExBase newImage = null;
             if (round)
             {
+                #pragma warning disable CS0618 // Type or member is obsolete
                 newImage = new RoundImageEx
                 {
                 };
+                #pragma warning restore CS0618 // Type or member is obsolete
 
                 if (resources?.ContainsKey("RoundStyle") == true)
                 {

--- a/Microsoft.Toolkit.Uwp.UI.Controls/ImageEx/ImageEx.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/ImageEx/ImageEx.xaml
@@ -8,7 +8,7 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="controls:ImageEx">
-                    <Grid Background="{TemplateBinding Background}">
+                    <Grid Background="{TemplateBinding Background}" CornerRadius="{TemplateBinding CornerRadius}">
                         <Image Name="PlaceholderImage"
                                HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
                                VerticalAlignment="{TemplateBinding VerticalAlignment}"

--- a/Microsoft.Toolkit.Uwp.UI.Controls/ImageEx/ImageExBase.Members.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/ImageEx/ImageExBase.Members.cs
@@ -29,6 +29,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         public static readonly DependencyProperty StretchProperty = DependencyProperty.Register(nameof(Stretch), typeof(Stretch), typeof(ImageExBase), new PropertyMetadata(Stretch.Uniform));
 
         /// <summary>
+        /// Identifies the <see cref="CornerRadius"/> dependency property.
+        /// </summary>
+        public static readonly DependencyProperty CornerRadiusProperty = DependencyProperty.Register(nameof(CornerRadius), typeof(double), typeof(ImageExBase), new PropertyMetadata(0));
+
+        /// <summary>
         /// Identifies the <see cref="DecodePixelHeight"/> dependency property.
         /// </summary>
         public static readonly DependencyProperty DecodePixelHeightProperty = DependencyProperty.Register(nameof(DecodePixelHeight), typeof(int), typeof(ImageExBase), new PropertyMetadata(0));
@@ -85,6 +90,16 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// Gets a value indicating whether control has been initialized.
         /// </summary>
         public bool IsInitialized { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the CornerRadius for underlying image. <para/>
+        /// Used to created rounded/circular images.
+        /// </summary>
+        public double CornerRadius
+        {
+            get { return (double)GetValue(CornerRadiusProperty); }
+            set { SetValue(CornerRadiusProperty, value); }
+        }
 
         /// <summary>
         /// Gets or sets DecodePixelHeight for underlying bitmap

--- a/Microsoft.Toolkit.Uwp.UI.Controls/ImageEx/ImageExBase.Members.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/ImageEx/ImageExBase.Members.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// <summary>
         /// Identifies the <see cref="CornerRadius"/> dependency property.
         /// </summary>
-        public static readonly DependencyProperty CornerRadiusProperty = DependencyProperty.Register(nameof(CornerRadius), typeof(double), typeof(ImageExBase), new PropertyMetadata(0));
+        public static readonly DependencyProperty CornerRadiusProperty = DependencyProperty.Register(nameof(CornerRadius), typeof(CornerRadius), typeof(ImageExBase), new PropertyMetadata(new CornerRadius(0)));
 
         /// <summary>
         /// Identifies the <see cref="DecodePixelHeight"/> dependency property.
@@ -95,9 +95,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// Gets or sets the CornerRadius for underlying image. <para/>
         /// Used to created rounded/circular images.
         /// </summary>
-        public double CornerRadius
+        public CornerRadius CornerRadius
         {
-            get { return (double)GetValue(CornerRadiusProperty); }
+            get { return (CornerRadius)GetValue(CornerRadiusProperty); }
             set { SetValue(CornerRadiusProperty, value); }
         }
 

--- a/Microsoft.Toolkit.Uwp.UI.Controls/ImageEx/RoundImageEx.Members.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/ImageEx/RoundImageEx.Members.cs
@@ -26,14 +26,14 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// <summary>
         /// Identifies the <see cref="CornerRadius"/> dependency property.
         /// </summary>
-        public static readonly DependencyProperty CornerRadiusProperty =
+        public static new readonly DependencyProperty CornerRadiusProperty =
             DependencyProperty.Register(nameof(CornerRadius), typeof(double), typeof(RoundImageEx), new PropertyMetadata(0));
 
         /// <summary>
         /// Gets or sets the corner radius of the image
         /// </summary>
-		[Obsolete("Use ImageEx directly instead for 16299 and above.", false)]
-        public double CornerRadius
+        [Obsolete("Use ImageEx directly instead for 16299 and above.", false)]
+        public new double CornerRadius
         {
             get { return (double)GetValue(CornerRadiusProperty); }
             set { SetValue(CornerRadiusProperty, value); }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/ImageEx/RoundImageEx.Members.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/ImageEx/RoundImageEx.Members.cs
@@ -10,6 +10,7 @@
 // THE CODE OR THE USE OR OTHER DEALINGS IN THE CODE.
 // ******************************************************************
 
+using System;
 using Windows.UI.Composition;
 using Windows.UI.Xaml;
 
@@ -31,6 +32,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// <summary>
         /// Gets or sets the corner radius of the image
         /// </summary>
+		[Obsolete("Use ImageEx directly instead for 16299 and above.", false)]
         public double CornerRadius
         {
             get { return (double)GetValue(CornerRadiusProperty); }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/ImageEx/RoundImageEx.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/ImageEx/RoundImageEx.cs
@@ -10,6 +10,7 @@
 // THE CODE OR THE USE OR OTHER DEALINGS IN THE CODE.
 // ******************************************************************
 
+using System;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Shapes;
@@ -22,6 +23,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
     /// Once downloaded, the source image is stored in the App local cache to preserve resources and load time next time the image needs to be displayed.
     /// </summary>
     [TemplatePart(Name = PartImageRectangle, Type = typeof(Rectangle))]
+    [Obsolete("Use CornerRadius on ImageEx instead for 16299 and above.", false)]
     public partial class RoundImageEx : ImageExBase
     {
         /// <summary>

--- a/docs/controls/ImageEx.md
+++ b/docs/controls/ImageEx.md
@@ -43,6 +43,10 @@ You can also use a placeholder image that will be displayed will loading the mai
 [ImageEx Control XAML File](https://github.com/Microsoft/UWPCommunityToolkit/blob/master/Microsoft.Toolkit.Uwp.UI.Controls/ImageEx/ImageEx.xaml) is the XAML template used in the toolkit for the default styling.
 [RoundImageEx Control XAML File](https://github.com/Microsoft/UWPCommunityToolkit/blob/master/Microsoft.Toolkit.Uwp.UI.Controls/ImageEx/RoundImageEx.xaml) is the XAML template used in the toolkit for the default styling of the Control that has Corner Rounding.
 
+## Platform Specific Notes
+
+On Windows 10.0.16299.0 or higher, **CornerRadius** is supported on ImageEx.  Use of this property will not cause an exception on downlevel platforms; however, the desired effect will not render.
+
 ## Requirements (Windows 10 Device Family)
 
 | [Device family](http://go.microsoft.com/fwlink/p/?LinkID=526370) | Universal, 10.0.14393.0 or higher |


### PR DESCRIPTION
Issue: #1391 

## PR Type
What kind of change does this PR introduce?
```
[ x ] Bugfix
[ x ] Feature
[ ] Code style update (formatting)
[ x ] Refactoring (no functional changes, no api changes)
[ ] Build or CI related changes
[ x ] Documentation content changes
[ ] Sample app changes
[ x ] Other... Please describe:  Deprecation
```

## What is the current behavior?
Round Image uses its own custom brush and behaves differently than Image/ImageEx in layout (Issue #1391)

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ x ] Tested code with current [supported SDKs](../readme.md#supported)
- [ x ] Docs have been added / updated (for bug fixes / features)
- [ x ] Sample in sample app has been added / updated (for bug fixes / features)
- [ x ] Tests for the changes have been added (for bug fixes / features) (if applicable)

## What is the new behavior?
This adds a `CornerRadius` property to `ImageEx` to replace the need for `RoundImageEx` entirely, now that RS3 properly supports the CornerRadius property.

## Does this PR introduce a breaking change?
```
[ ] Yes
[ x ] No*
```
Does mark RoundImageEx as Obsolete.

## Other information
If trying to use new `CornerRadius` on ImageEx on down-level platforms, rendering is not as expected, as if had tried to do the same on a Grid surrounding an Image.
