### PR TITLE
Fixing bug with saturation being overriden

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Animations/Effects/AnimationEffect.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Animations/Effects/AnimationEffect.cs
@@ -148,12 +148,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations.Effects
             }
 
             // Saturation starts from 1 to 0, instead of 0 to 1 so this makes sure the
-            // the brush isn't removed from the UI element incorrectly.
-            if (EffectName == "Saturation" && value >= 1)
-            {
-                animationSet.Completed += AnimationSet_Completed;
-            }
-            else if (EffectName != "Saturation" && value == 0)
+            // the brush isn't removed from the UI element incorrectly. Completing on 
+            // Saturation as it's reusing the same sprite visual. Removing the Sprite removes the effect.
+            if (EffectName != "Saturation" && value == 0)
             {
                 animationSet.Completed += AnimationSet_Completed;
             }


### PR DESCRIPTION
Issue: #1410 

## PR Type
What kind of change does this PR introduce?
Bug Fix

<!-- Please check the one that applies to this PR using "x". -->
```
[x ] Bugfix
[ ] Feature
[ ] Code style update (formatting)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build or CI related changes
[ ] Documentation content changes
[ ] Sample app changes
[ ] Other... Please describe:
```


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
stops saturation overriding itself incorrectly #1410 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x ] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)


## What is the new behavior?
Fixes the issue

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
