### PR TITLE
Fix for #1605, only remove items that were selected for removal from the cache

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI/Cache/CacheBase.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Cache/CacheBase.cs
@@ -220,7 +220,7 @@ namespace Microsoft.Toolkit.Uwp.UI
                 }
             }
 
-            await InternalClearAsync(files).ConfigureAwait(false);
+            await InternalClearAsync(filesToDelete).ConfigureAwait(false);
 
             _inMemoryFileStorage.Remove(keys);
         }


### PR DESCRIPTION
Issue: #1605 
<!-- Link to relevant issue. All PRs should be asociated with an issue -->

## PR Type
Only remove items that were selected for removal from the cache

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build or CI related changes
[ ] Documentation content changes
[ ] Sample app changes
[ ] Other... Please describe:
```


## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)


## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
I found this issue while using the Cache in our app. Unfortunately, I was not yet able to run, adjust or fix any of the UWP-toolkit tests, because I ran out of time at the moment. Sorry 4 that!