### PR TITLE
Fix NRE when there's no value for AppUptime in local settings

### DIFF
--- a/Microsoft.Toolkit.Uwp/Helpers/SystemInformation.cs
+++ b/Microsoft.Toolkit.Uwp/Helpers/SystemInformation.cs
@@ -134,9 +134,13 @@ namespace Microsoft.Toolkit.Uwp.Helpers
                 {
                     var subsessionLength = DateTime.UtcNow.Subtract(_sessionStart).Ticks;
 
-                    ApplicationData.Current.LocalSettings.Values.TryGetValue(nameof(AppUptime), out object uptimeSoFar);
+                    var hasPreviousAppUptime =
+                        ApplicationData.Current.LocalSettings.Values.TryGetValue(nameof(AppUptime),
+                            out object uptimeSoFar);
 
-                    return new TimeSpan((long)uptimeSoFar + subsessionLength);
+                    return hasPreviousAppUptime ?
+                        new TimeSpan((long)uptimeSoFar + subsessionLength)
+                        : new TimeSpan(subsessionLength);
                 }
                 else
                 {
@@ -187,9 +191,19 @@ namespace Microsoft.Toolkit.Uwp.Helpers
                 {
                     var subsessionLength = DateTime.UtcNow.Subtract(_sessionStart).Ticks;
 
-                    ApplicationData.Current.LocalSettings.Values.TryGetValue(nameof(AppUptime), out object uptimeSoFar);
+                    var hasPreviousAppUptime =
+                        ApplicationData.Current.LocalSettings.Values.TryGetValue(nameof(AppUptime),
+                            out object uptimeSoFar);
 
-                    ApplicationData.Current.LocalSettings.Values[nameof(AppUptime)] = (long)uptimeSoFar + subsessionLength;
+                    if (hasPreviousAppUptime)
+                    {
+                        ApplicationData.Current.LocalSettings.Values[nameof(AppUptime)] =
+                            (long)uptimeSoFar + subsessionLength;
+                    }
+                    else
+                    {
+                        ApplicationData.Current.LocalSettings.Values[nameof(AppUptime)] = subsessionLength;
+                    }
                 }
             }
 
@@ -213,9 +227,11 @@ namespace Microsoft.Toolkit.Uwp.Helpers
         /// <param name="duration">The amount to time to add</param>
         public static void AddToAppUptime(TimeSpan duration)
         {
-            ApplicationData.Current.LocalSettings.Values.TryGetValue(nameof(AppUptime), out object uptimeSoFar);
-
-            ApplicationData.Current.LocalSettings.Values[nameof(AppUptime)] = (long)uptimeSoFar + duration.Ticks;
+            if (ApplicationData.Current.LocalSettings.Values.TryGetValue(nameof(AppUptime),
+                out object uptimeSoFar))
+            {
+                ApplicationData.Current.LocalSettings.Values[nameof(AppUptime)] = (long)uptimeSoFar + duration.Ticks;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Issue: #
<!-- Link to relevant issue. All PRs should be asociated with an issue -->

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build or CI related changes
[ ] Documentation content changes
[ ] Sample app changes
[ ] Other... Please describe:
```


## What is the current behavior?
Possible NRE when AppUptime does not have value stored in local app settings


## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)


## What is the new behavior?
No NRE

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
Possible fix for https://github.com/Microsoft/UWPCommunityToolkit/issues/1598