### PR TITLE
Fix AdaptiveGridView OneRowMode height

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveGridView.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveGridView.cs
@@ -175,7 +175,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                     var b = new Binding()
                     {
                         Source = this,
-                        Path = new PropertyPath("ItemHeight")
+                        Path = new PropertyPath("ItemHeight"),
+                        Converter = new AdaptiveHeightValueConverter(),
+                        ConverterParameter = this
                     };
 
                     if (itemsWrapGridPanel != null)
@@ -184,7 +186,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                         itemsWrapGridPanel.Orientation = Orientation.Vertical;
                     }
 
-                    ItemsPanelRoot.SetBinding(Panel.MaxHeightProperty, b);
+                    SetBinding(Panel.MaxHeightProperty, b);
 
                     _savedHorizontalScrollMode = ScrollViewer.GetHorizontalScrollMode(this);
                     _savedVerticalScrollMode = ScrollViewer.GetVerticalScrollMode(this);
@@ -199,7 +201,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 }
                 else
                 {
-                    ItemsPanelRoot.ClearValue(Panel.MaxHeightProperty);
+                    ClearValue(Panel.MaxHeightProperty);
 
                     if (!_needToRestoreScrollStates)
                     {

--- a/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveGridView.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveGridView.cs
@@ -186,7 +186,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                         itemsWrapGridPanel.Orientation = Orientation.Vertical;
                     }
 
-                    SetBinding(Panel.MaxHeightProperty, b);
+                    SetBinding(MaxHeightProperty, b);
 
                     _savedHorizontalScrollMode = ScrollViewer.GetHorizontalScrollMode(this);
                     _savedVerticalScrollMode = ScrollViewer.GetVerticalScrollMode(this);
@@ -201,7 +201,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 }
                 else
                 {
-                    ClearValue(Panel.MaxHeightProperty);
+                    ClearValue(MaxHeightProperty);
 
                     if (!_needToRestoreScrollStates)
                     {

--- a/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveGridView.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveGridView.cs
@@ -184,7 +184,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                         itemsWrapGridPanel.Orientation = Orientation.Vertical;
                     }
 
-                    SetBinding(MaxHeightProperty, b);
+                    ItemsPanelRoot.SetBinding(Panel.MaxHeightProperty, b);
 
                     _savedHorizontalScrollMode = ScrollViewer.GetHorizontalScrollMode(this);
                     _savedVerticalScrollMode = ScrollViewer.GetVerticalScrollMode(this);
@@ -199,7 +199,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 }
                 else
                 {
-                    ClearValue(MaxHeightProperty);
+                    ItemsPanelRoot.ClearValue(Panel.MaxHeightProperty);
 
                     if (!_needToRestoreScrollStates)
                     {

--- a/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveHeightValueConverter.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveHeightValueConverter.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 return height;
             }
 
-            return value;
+            return double.NaN;
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, string language)

--- a/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveHeightValueConverter.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveHeightValueConverter.cs
@@ -1,4 +1,16 @@
-﻿using System;
+﻿// ******************************************************************
+// Copyright (c) Microsoft. All rights reserved.
+// This code is licensed under the MIT License (MIT).
+// THE CODE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH
+// THE CODE OR THE USE OR OTHER DEALINGS IN THE CODE.
+// ******************************************************************
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveHeightValueConverter.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveHeightValueConverter.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         {
             if (value != null)
             {
-                var gridView = parameter as AdaptiveGridView;
+                var gridView = (GridView)parameter;
                 if (gridView == null)
                 {
                     return value;

--- a/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveHeightValueConverter.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveHeightValueConverter.cs
@@ -23,8 +23,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
                 double.TryParse(value.ToString(), out double height);
 
+                var padding = gridView.Padding;
                 var margin = GetItemMargin(gridView);
-                height = height + margin.Top + margin.Bottom;
+                height = height + margin.Top + margin.Bottom + padding.Top + padding.Bottom;
 
                 return height;
             }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveHeightValueConverter.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveHeightValueConverter.cs
@@ -23,12 +23,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
                 double.TryParse(value.ToString(), out double height);
 
-                var setter = gridView.ItemContainerStyle?.Setters.OfType<Setter>().FirstOrDefault(s => s.Property == FrameworkElement.MarginProperty);
-                if (setter != null)
-                {
-                    var margin = (Thickness)setter.Value;
-                    height = height + margin.Top + margin.Bottom;
-                }
+                var margin = GetItemMargin(gridView);
+                height = height + margin.Top + margin.Bottom;
 
                 return height;
             }
@@ -39,6 +35,29 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         public object ConvertBack(object value, Type targetType, object parameter, string language)
         {
             throw new NotImplementedException();
+        }
+
+        private static Thickness GetItemMargin(GridView view)
+        {
+            var setter = view.ItemContainerStyle?.Setters.OfType<Setter>().FirstOrDefault(s => s.Property == FrameworkElement.MarginProperty);
+            if (setter != null)
+            {
+                return (Thickness)setter.Value;
+            }
+            else
+            {
+                if (view.Items.Count > 0)
+                {
+                    var container = (GridViewItem)view.ContainerFromIndex(0);
+                    if (container != null)
+                    {
+                        return container.Margin;
+                    }
+                }
+
+                // Use the default thickness for a GridViewItem
+                return new Thickness(0, 0, 4, 4);
+            }
         }
     }
 }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveHeightValueConverter.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveHeightValueConverter.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Data;
+
+namespace Microsoft.Toolkit.Uwp.UI.Controls
+{
+    internal class AdaptiveHeightValueConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, string language)
+        {
+            if (value != null)
+            {
+                var gridView = parameter as AdaptiveGridView;
+                if (gridView == null)
+                {
+                    return value;
+                }
+
+                double.TryParse(value.ToString(), out double height);
+
+                var setter = gridView.ItemContainerStyle?.Setters.OfType<Setter>().FirstOrDefault(s => s.Property == FrameworkElement.MarginProperty);
+                if (setter != null)
+                {
+                    var margin = (Thickness)setter.Value;
+                    height = height + margin.Top + margin.Bottom;
+                }
+
+                return height;
+            }
+
+            return value;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, string language)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveHeightValueConverter.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveHeightValueConverter.cs
@@ -20,6 +20,14 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 {
     internal class AdaptiveHeightValueConverter : IValueConverter
     {
+        private Thickness thickness = new Thickness(0, 0, 4, 4);
+
+        public Thickness DefaultItemMargin
+        {
+            get { return thickness; }
+            set { thickness = value; }
+        }
+
         public object Convert(object value, Type targetType, object parameter, string language)
         {
             if (value != null)
@@ -47,7 +55,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             throw new NotImplementedException();
         }
 
-        private static Thickness GetItemMargin(GridView view)
+        private Thickness GetItemMargin(GridView view)
         {
             var setter = view.ItemContainerStyle?.Setters.OfType<Setter>().FirstOrDefault(s => s.Property == FrameworkElement.MarginProperty);
             if (setter != null)
@@ -66,7 +74,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 }
 
                 // Use the default thickness for a GridViewItem
-                return new Thickness(0, 0, 4, 4);
+                return DefaultItemMargin;
             }
         }
     }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveHeightValueConverter.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveHeightValueConverter.cs
@@ -11,10 +11,7 @@
 // ******************************************************************
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Data;

--- a/UnitTests/Converters/Test_AdaptiveHeightValueConverter.cs
+++ b/UnitTests/Converters/Test_AdaptiveHeightValueConverter.cs
@@ -1,0 +1,93 @@
+﻿// ******************************************************************
+// Copyright (c) Microsoft. All rights reserved.
+// This code is licensed under the MIT License (MIT).
+// THE CODE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH
+// THE CODE OR THE USE OR OTHER DEALINGS IN THE CODE.
+// ******************************************************************
+
+using Microsoft.Toolkit.Uwp.UI.Controls;
+using Microsoft.Toolkit.Uwp.UI.Converters;
+using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
+using System.Linq;
+using Windows.UI;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Media.Imaging;
+using UITestMethod = Microsoft.VisualStudio.TestPlatform.UnitTestFramework.AppContainer.UITestMethodAttribute;
+
+namespace UnitTests.Converters
+{
+    [TestClass]
+    public class Test_AdaptiveHeightValueConverter
+    {
+        [TestCategory("Converters")]
+        [TestMethod]
+        public void Convert_ValueIsNull_ReturnsNaN()
+        {
+            var converter = new AdaptiveHeightValueConverter();
+            var result = converter.Convert(null, null, null, null);
+            Assert.AreEqual(result, double.NaN);
+        }
+
+        [TestCategory("Converters")]
+        [TestMethod]
+        public void Convert_ParameterIsNull_ReturnsValue()
+        {
+            var converter = new AdaptiveHeightValueConverter();
+            double value = 100;
+            var result = converter.Convert(value, null, null, null);
+            Assert.AreEqual(result, value);
+        }
+
+
+        [TestCategory("Converters")]
+        [TestMethod]
+        public void Convert_GridViewIsNull_ReturnsValue()
+        {
+            var converter = new AdaptiveHeightValueConverter();
+            double value = 100;
+            var result = converter.Convert(value, null, null, null);
+            Assert.AreEqual(result, value);
+        }
+
+        [TestCategory("Converters")]
+        [UITestMethod]
+        public void Convert_DefaultAdaptiveGridView_ReturnsHeightPlusItemMargin()
+        {
+            var converter = new AdaptiveHeightValueConverter();
+            double value = 100;
+            var gridView = new AdaptiveGridView();
+            var margin = (Thickness)gridView.ItemContainerStyle?.Setters.OfType<Setter>().First(s => s.Property == FrameworkElement.MarginProperty).Value;
+
+            var result = converter.Convert(value, null, gridView, null);
+            Assert.AreEqual(result, value + margin.Bottom);
+        }
+
+        [TestCategory("Converters")]
+        [UITestMethod]
+        public void Convert_GridViewWithNoItemContainerStyleAndNoItems_ReturnsHeightPlusDefaultItemMargin()
+        {
+            var converter = new AdaptiveHeightValueConverter();
+            double value = 100;
+            var gridView = new AdaptiveGridView { ItemContainerStyle = null };
+            var result = converter.Convert(value, null, gridView, null);
+            Assert.AreEqual(result, value + converter.DefaultItemMargin.Bottom + converter.DefaultItemMargin.Top);
+        }
+
+        [TestCategory("Converters")]
+        [UITestMethod]
+        public void Convert_GridViewWithPadding_ReturnsHeightPlusPadding()
+        {
+            var converter = new AdaptiveHeightValueConverter { DefaultItemMargin = new Thickness(0) };
+            double value = 100;
+            var gridView = new AdaptiveGridView { ItemContainerStyle = null, Padding = new Thickness(10) };
+            var result = converter.Convert(value, null, gridView, null);
+            Assert.AreEqual(result, value + gridView.Padding.Bottom + gridView.Padding.Top);
+        }
+    }
+}

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -124,6 +124,7 @@
     <SDKReference Include="TestPlatform.Universal, Version=$(UnitTestPlatformVersion)" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Converters\Test_AdaptiveHeightValueConverter.cs" />
     <Compile Include="Converters\Test_BoolToObjectConverter.cs" />
     <Compile Include="Converters\Test_EmptyCollectionToObjectConverter.cs" />
     <Compile Include="Converters\Test_EmptyStringToObjectConverter.cs" />


### PR DESCRIPTION
Issue: #1613
<!-- Link to relevant issue. All PRs should be asociated with an issue -->

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build or CI related changes
[ ] Documentation content changes
[ ] Sample app changes
[ ] Other... Please describe:
```


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Height of the items does not match the requested height

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Sample in sample app has been added / updated (for bug fixes / features)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)


## What is the new behavior?
Height of items should now match the requested height

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
