### PR TITLE
Change MenuItem to inherit from HeaderedItemsControl

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/Menu/MenuItem.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/Menu/MenuItem.cs
@@ -54,6 +54,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             {
                 _isInternalHeaderUpdate = true;
                 Header = value;
+                _isInternalHeaderUpdate = false;
             }
         }
 
@@ -477,7 +478,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
             if (_isInternalHeaderUpdate)
             {
-                _isInternalHeaderUpdate = false;
                 return;
             }
 

--- a/Microsoft.Toolkit.Uwp.UI.Controls/Menu/MenuItem.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/Menu/MenuItem.cs
@@ -59,20 +59,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         }
 
         /// <summary>
-        /// Identifies the <see cref="HeaderTemplate"/> dependency property.
-        /// </summary>
-        public static readonly DependencyProperty HeaderTemplateProperty = DependencyProperty.Register(nameof(HeaderTemplate), typeof(DataTemplate), typeof(MenuItem), new PropertyMetadata(null));
-
-        /// <summary>
-        /// Gets or sets the data template that is used to display the content of the MenuItem
-        /// </summary>
-        public DataTemplate HeaderTemplate
-        {
-            get { return (DataTemplate)GetValue(HeaderTemplateProperty); }
-            set { SetValue(HeaderTemplateProperty, value); }
-        }
-
-        /// <summary>
         /// Gets a value indicating whether the menu is opened or not
         /// </summary>
         public bool IsOpened

--- a/Microsoft.Toolkit.Uwp.UI.Controls/Menu/MenuItem.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/Menu/MenuItem.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
     /// <summary>
     /// Menu Item is the items main container for Class Menu control
     /// </summary>
-    public class MenuItem : ItemsControl
+    public class MenuItem : HeaderedItemsControl
     {
         private const string FlyoutButtonName = "FlyoutButton";
         private const char UnderlineCharacter = '^';
@@ -47,20 +47,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         internal Button FlyoutButton { get; private set; }
 
         private Rect _bounds;
-
-        /// <summary>
-        /// Identifies the <see cref="Header"/> dependency property.
-        /// </summary>
-        public static readonly DependencyProperty HeaderProperty = DependencyProperty.Register(nameof(Header), typeof(object), typeof(MenuItem), new PropertyMetadata(null, HeaderPropertyChanged));
-
-        /// <summary>
-        /// Gets or sets the title to appear in the title bar
-        /// </summary>
-        public object Header
-        {
-            get { return GetValue(HeaderProperty); }
-            set { SetValue(HeaderProperty, value); }
-        }
 
         private object InternalHeader
         {
@@ -484,19 +470,20 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             InternalHeader = text;
         }
 
-        private static void HeaderPropertyChanged(DependencyObject sender, DependencyPropertyChangedEventArgs e)
+        /// <inheritdoc />
+        protected override void OnHeaderChanged(object oldValue, object newValue)
         {
-            var menuItem = (MenuItem)sender;
+            base.OnHeaderChanged(oldValue, newValue);
 
-            if (menuItem._isInternalHeaderUpdate)
+            if (_isInternalHeaderUpdate)
             {
-                menuItem._isInternalHeaderUpdate = false;
+                _isInternalHeaderUpdate = false;
                 return;
             }
 
-            menuItem._originalHeader = null;
+            _originalHeader = null;
 
-            var headerString = menuItem.Header as string;
+            var headerString = newValue as string;
 
             if (string.IsNullOrEmpty(headerString))
             {
@@ -512,12 +499,12 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
             if (underlineCharacterIndex == headerString.Length - 1)
             {
-                menuItem.InternalHeader = headerString.Replace(UnderlineCharacter.ToString(), string.Empty);
+                InternalHeader = headerString.Replace(UnderlineCharacter.ToString(), string.Empty);
                 return;
             }
 
-            menuItem._originalHeader = headerString;
-            menuItem.InternalHeader = headerString.Replace(UnderlineCharacter.ToString(), string.Empty);
+            _originalHeader = headerString;
+            InternalHeader = headerString.Replace(UnderlineCharacter.ToString(), string.Empty);
         }
 
         internal void RemoveUnderline()


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
Change MenuItem to inherit from HeaderedItemsControl instead of ItemsControl. Remove the Header and HeaderTemplate properties from MenuItem

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting)
[x] Refactoring (no functional changes, no api changes)
[ ] Build or CI related changes
[ ] Documentation content changes
[ ] Sample app changes
[ ] Other... Please describe:
```


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
MenuItem inherits from ItemsControl and has a local Header and HeaderTemplate property

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Sample in sample app has been added / updated (for bug fixes / features)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)


## What is the new behavior?
MenuItem now inherits from HeaderedItemsControl and takes advantage of it's Header and HeaderTemplate properties

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
