### PR TITLE
Ensure that primitive / string types aren't serialised to / deserialised from Json.

### DIFF
--- a/Microsoft.Toolkit.Uwp/Helpers/ObjectStorage/BaseObjectStorageHelper.cs
+++ b/Microsoft.Toolkit.Uwp/Helpers/ObjectStorage/BaseObjectStorageHelper.cs
@@ -15,6 +15,7 @@ using System.Reflection;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Windows.Storage;
+using System;
 
 namespace Microsoft.Toolkit.Uwp.Helpers
 {
@@ -86,7 +87,7 @@ namespace Microsoft.Toolkit.Uwp.Helpers
 
             if (typeInfo.IsPrimitive || type == typeof(string))
             {
-                return (T)value;
+                return (T)Convert.ChangeType(value, type);
             }
 
             return JsonConvert.DeserializeObject<T>((string)value);

--- a/Microsoft.Toolkit.Uwp/Helpers/ObjectStorage/BaseObjectStorageHelper.cs
+++ b/Microsoft.Toolkit.Uwp/Helpers/ObjectStorage/BaseObjectStorageHelper.cs
@@ -11,6 +11,7 @@
 // ******************************************************************
 
 using System.Collections.Generic;
+using System.Reflection;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Windows.Storage;
@@ -73,13 +74,22 @@ namespace Microsoft.Toolkit.Uwp.Helpers
         /// <returns>The T object</returns>
         public T Read<T>(string key, T @default = default(T))
         {
-            string value = (string)Settings.Values[key];
-            if (value != null)
+            object value = null;
+
+            if (!Settings.Values.TryGetValue(key, out value))
             {
-                return JsonConvert.DeserializeObject<T>(value);
+                return @default;
             }
 
-            return @default;
+            var type = typeof(T);
+            var typeInfo = type.GetTypeInfo();
+
+            if (typeInfo.IsPrimitive || type == typeof(string))
+            {
+                return (T)value;
+            }
+
+            return JsonConvert.DeserializeObject<T>((string)value);
         }
 
         /// <summary>
@@ -115,7 +125,17 @@ namespace Microsoft.Toolkit.Uwp.Helpers
         /// <param name="value">Object to save</param>
         public void Save<T>(string key, T value)
         {
-            Settings.Values[key] = JsonConvert.SerializeObject(value);
+            var type = typeof(T);
+            var typeInfo = type.GetTypeInfo();
+
+            if (typeInfo.IsPrimitive || type == typeof(string))
+            {
+                Settings.Values[key] = value;
+            }
+            else
+            {
+                Settings.Values[key] = JsonConvert.SerializeObject(value);
+            }
         }
 
         /// <summary>

--- a/Microsoft.Toolkit.Uwp/Helpers/ObjectStorage/BaseObjectStorageHelper.cs
+++ b/Microsoft.Toolkit.Uwp/Helpers/ObjectStorage/BaseObjectStorageHelper.cs
@@ -82,6 +82,11 @@ namespace Microsoft.Toolkit.Uwp.Helpers
                 return @default;
             }
 
+            if (value == null)
+            {
+                return @default;
+            }
+
             var type = typeof(T);
             var typeInfo = type.GetTypeInfo();
 

--- a/UnitTests/Helpers/Test_StorageHelper.cs
+++ b/UnitTests/Helpers/Test_StorageHelper.cs
@@ -1,0 +1,136 @@
+﻿// ******************************************************************
+// Copyright (c) Microsoft. All rights reserved.
+// This code is licensed under the MIT License (MIT).
+// THE CODE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH
+// THE CODE OR THE USE OR OTHER DEALINGS IN THE CODE.
+// ******************************************************************
+
+using Microsoft.Toolkit.Uwp;
+using Microsoft.Toolkit.Uwp.Helpers;
+using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
+using Newtonsoft.Json;
+using System;
+using UnitTests.UI;
+
+namespace UnitTests.Helpers
+{
+    [TestClass]
+    public class Test_StorageHelper
+    {
+        private LocalObjectStorageHelper storageHelper = new LocalObjectStorageHelper();
+
+        [TestCategory("Helpers")]
+        [TestMethod]
+        public void Test_StorageHelper_LegacyIntTest()
+        {
+            string key = "LifeUniverseAndEverything";
+
+            int input = 42;
+
+            // simulate previous version by generating json and manually inserting it as string
+            string jsonInput = JsonConvert.SerializeObject(input);
+
+            storageHelper.Save<string>(key, jsonInput);
+
+            // now read it as int to valid that the change works
+            int output = storageHelper.Read<int>(key, 0);
+
+            Assert.AreEqual(input, output);
+        }
+
+        [TestCategory("Helpers")]
+        [TestMethod]
+        public void Test_StorageHelper_LegacyDateTest()
+        {
+            string key = "ChristmasDay";
+
+            DateTime input = new DateTime(2017, 12, 25);
+
+            // simulate previous version by generating json and manually inserting it as string
+            string jsonInput = JsonConvert.SerializeObject(input);
+
+            storageHelper.Save<string>(key, jsonInput);
+
+            // now read it as int to valid that the change works
+            DateTime output = storageHelper.Read<DateTime>(key, DateTime.Today);
+
+            Assert.AreEqual(input, output);
+        }
+
+        [TestCategory("Helpers")]
+        [TestMethod]
+        public void Test_StorageHelper_LegacyPersonTest()
+        {
+            string key = "Contact";
+
+            Person input = new Person() { Name = "Joe Bloggs", Age = 42 };
+
+            // simulate previous version by generating json and manually inserting it as string
+            string jsonInput = JsonConvert.SerializeObject(input);
+
+            storageHelper.Save<string>(key, jsonInput);
+
+            // now read it as int to valid that the change works
+            Person output = storageHelper.Read<Person>(key, null);
+
+            Assert.IsNotNull(output);
+            Assert.AreEqual(input.Name, output.Name);
+            Assert.AreEqual(input.Age, output.Age);
+        }
+
+        [TestCategory("Helpers")]
+        [TestMethod]
+        public void Test_StorageHelper_IntTest()
+        {
+            string key = "NewLifeUniverseAndEverything";
+
+            int input = 42;
+
+            storageHelper.Save<int>(key, input);
+
+            // now read it as int to valid that the change works
+            int output = storageHelper.Read<int>(key, 0);
+
+            Assert.AreEqual(input, output);
+        }
+
+        [TestCategory("Helpers")]
+        [TestMethod]
+        public void Test_StorageHelper_NewDateTest()
+        {
+            string key = "NewChristmasDay";
+
+            DateTime input = new DateTime(2017, 12, 25);
+
+            storageHelper.Save<DateTime>(key, input);
+
+            // now read it as int to valid that the change works
+            DateTime output = storageHelper.Read<DateTime>(key, DateTime.Today);
+
+            Assert.AreEqual(input, output);
+        }
+
+        [TestCategory("Helpers")]
+        [TestMethod]
+        public void Test_StorageHelper_NewPersonTest()
+        {
+            string key = "Contact";
+
+            Person input = new Person() { Name = "Joe Bloggs", Age = 42 };
+
+            storageHelper.Save<Person>(key, input);
+
+            // now read it as int to valid that the change works
+            Person output = storageHelper.Read<Person>(key, null);
+
+            Assert.IsNotNull(output);
+            Assert.AreEqual(input.Name, output.Name);
+            Assert.AreEqual(input.Age, output.Age);
+        }
+    }
+}

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -134,6 +134,7 @@
     <Compile Include="Helpers\Test_ScreenUnitHelper.cs" />
     <Compile Include="Helpers\Test_StorageFileHelper.cs" />
     <Compile Include="Helpers\Test_HttpHelper.cs" />
+    <Compile Include="Helpers\Test_StorageHelper.cs" />
     <Compile Include="Helpers\Test_StreamHelper.cs" />
     <Compile Include="Helpers\Test_DeepLinkParser.cs" />
     <Compile Include="Markdown\Parse\BoldTests.cs" />


### PR DESCRIPTION
Issue: #1598

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build or CI related changes
[ ] Documentation content changes
[ ] Sample app changes
[x] Other... Please describe: Tweak to ensure that primitive / string types aren't processed through Json Serialiser.
```


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Every value stored by StorageHelper is serialised to / deserialised from Json. This is not needed for primitive / string types.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
