### PR TITLE
Fix some ACV bugs

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI/AdvancedCollectionView/AdvancedCollectionView.cs
+++ b/Microsoft.Toolkit.Uwp.UI/AdvancedCollectionView/AdvancedCollectionView.cs
@@ -208,15 +208,7 @@ namespace Microsoft.Toolkit.Uwp.UI
                 throw new NotSupportedException("Collection is read-only.");
             }
 
-            if (_sortDescriptions.Count > 0 || _filter != null)
-            {
-                // no sense in inserting w/ filters or sorts, just add it
-                _sourceList.Add(item);
-            }
-            else
-            {
-                _sourceList.Insert(index, item);
-            }
+            _sourceList.Insert(index, item);
         }
 
         /// <summary>
@@ -555,15 +547,20 @@ namespace Microsoft.Toolkit.Uwp.UI
             }
 
             var viewHash = new HashSet<object>(_view);
+            var viewIndex = 0;
             for (var index = 0; index < _sourceList.Count; index++)
             {
                 var item = _sourceList[index];
                 if (viewHash.Contains(item))
                 {
+                    viewIndex++;
                     continue;
                 }
 
-                HandleItemAdded(index, item);
+                if (HandleItemAdded(index, item))
+                {
+                    viewIndex++;
+                }
             }
         }
 
@@ -642,20 +639,22 @@ namespace Microsoft.Toolkit.Uwp.UI
             }
         }
 
-        private void HandleItemAdded(int newStartingIndex, object newItem)
+        private bool HandleItemAdded(int newStartingIndex, object newItem, int? viewIndex = null)
         {
             if (_filter != null && !_filter(newItem))
             {
-                return;
+                return false;
             }
+
+            var newViewIndex = _view.Count;
 
             if (_sortDescriptions.Any())
             {
                 _sortProperties.Clear();
-                newStartingIndex = _view.BinarySearch(newItem, this);
-                if (newStartingIndex < 0)
+                newViewIndex = _view.BinarySearch(newItem, this);
+                if (newViewIndex < 0)
                 {
-                    newStartingIndex = ~newStartingIndex;
+                    newViewIndex = ~newViewIndex;
                 }
             }
             else if (_filter != null)
@@ -663,29 +662,49 @@ namespace Microsoft.Toolkit.Uwp.UI
                 if (_sourceList == null)
                 {
                     HandleSourceChanged();
-                    return;
+                    return false;
                 }
 
-                var visibleBelowIndex = 0;
-                for (var i = newStartingIndex; i < _sourceList.Count; i++)
+                if (newStartingIndex == 0 || _view.Count == 0)
                 {
-                    if (!_filter(_sourceList[i]))
+                    newViewIndex = 0;
+                }
+                else if (newStartingIndex == _sourceList.Count - 1)
+                {
+                    newViewIndex = _view.Count - 1;
+                }
+                else if (viewIndex.HasValue)
+                {
+                    newViewIndex = viewIndex.Value;
+                }
+                else
+                {
+                    var viewSet = new Dictionary<object, int>(_view.Count);
+                    for (int i = 0; i < _view.Count; i++)
                     {
-                        visibleBelowIndex++;
+                        viewSet.Add(_view[i], i);
+                    }
+
+                    for (var i = newStartingIndex; i < _sourceList.Count; i++)
+                    {
+                        if (viewSet.ContainsKey(_sourceList[i]))
+                        {
+                            newViewIndex = viewSet[_sourceList[i]];
+                            break;
+                        }
                     }
                 }
-
-                newStartingIndex = _view.Count - visibleBelowIndex;
             }
 
-            _view.Insert(newStartingIndex, newItem);
-            if (newStartingIndex <= _index)
+            _view.Insert(newViewIndex, newItem);
+            if (newViewIndex <= _index)
             {
                 _index++;
             }
 
-            var e = new VectorChangedEventArgs(CollectionChange.ItemInserted, newStartingIndex, newItem);
+            var e = new VectorChangedEventArgs(CollectionChange.ItemInserted, newViewIndex, newItem);
             OnVectorChanged(e);
+            return true;
         }
 
         private void HandleItemRemoved(int oldStartingIndex, object oldItem)

--- a/Microsoft.Toolkit.Uwp.UI/AdvancedCollectionView/AdvancedCollectionView.cs
+++ b/Microsoft.Toolkit.Uwp.UI/AdvancedCollectionView/AdvancedCollectionView.cs
@@ -557,7 +557,7 @@ namespace Microsoft.Toolkit.Uwp.UI
                     continue;
                 }
 
-                if (HandleItemAdded(index, item))
+                if (HandleItemAdded(index, item, viewIndex))
                 {
                     viewIndex++;
                 }

--- a/Microsoft.Toolkit.Uwp.UI/AdvancedCollectionView/AdvancedCollectionView.cs
+++ b/Microsoft.Toolkit.Uwp.UI/AdvancedCollectionView/AdvancedCollectionView.cs
@@ -679,18 +679,17 @@ namespace Microsoft.Toolkit.Uwp.UI
                 }
                 else
                 {
-                    var viewSet = new Dictionary<object, int>(_view.Count);
-                    for (int i = 0; i < _view.Count; i++)
+                    for (int i = 0, j = 0; i < _sourceList.Count; i++)
                     {
-                        viewSet.Add(_view[i], i);
-                    }
-
-                    for (var i = newStartingIndex; i < _sourceList.Count; i++)
-                    {
-                        if (viewSet.ContainsKey(_sourceList[i]))
+                        if (i == newStartingIndex)
                         {
-                            newViewIndex = viewSet[_sourceList[i]];
+                            newViewIndex = j;
                             break;
+                        }
+
+                        if (_view[j] == _sourceList[i])
+                        {
+                            j++;
                         }
                     }
                 }

--- a/UnitTests/UI/Test_AdvancedCollectionView.cs
+++ b/UnitTests/UI/Test_AdvancedCollectionView.cs
@@ -70,6 +70,59 @@ namespace UnitTests.UI
 
         [TestCategory("AdvancedCollectionView")]
         [UITestMethod]
+        public void Test_AdvancedCollectionView_FilterOrder()
+        {
+            var l = new ObservableCollection<string>
+            {
+                "lorem",
+                "ipsum",
+                "dolor",
+                "sit",
+                "amet"
+            };
+
+            var a = new AdvancedCollectionView(l)
+            {
+                Filter = (x) => x.ToString().Length < 5
+            };
+
+            a.Insert(4, "how");
+
+            Assert.AreEqual(3, a.Count);
+            Assert.AreEqual(a[0], "sit");
+            Assert.AreEqual(a[1], "how");
+            Assert.AreEqual(a[2], "amet");
+
+        }
+
+        [TestCategory("AdvancedCollectionView")]
+        [UITestMethod]
+        public void Test_AdvancedCollectionView_FilterOrderShowBefore()
+        {
+            var l = new ObservableCollection<string>
+            {
+                "lorem",
+                "ipsum",
+                "dolor",
+                "sitter",
+                "amet"
+            };
+
+            var a = new AdvancedCollectionView(l)
+            {
+                Filter = (x) => x.ToString().Length < 5
+            };
+
+            a.Insert(0, "how");
+
+            Assert.AreEqual(2, a.Count);
+            Assert.AreEqual(a[0], "how");
+            Assert.AreEqual(a[1], "amet");
+
+        }
+
+        [TestCategory("AdvancedCollectionView")]
+        [UITestMethod]
         public void Test_AdvancedCollectionView_Updating()
         {
             var l = new ObservableCollection<string>
@@ -698,6 +751,73 @@ namespace UnitTests.UI
 
             Assert.AreEqual(42, ((Person)a.First()).Age);
             Assert.AreEqual(2, a.Count);
+        }
+
+        [TestCategory("AdvancedCollectionView")]
+        [UITestMethod]
+        public void Test_AdvancedCollectionView_Combined_Using_Shaping_Filter_Back_In()
+        {
+            var l = new ObservableCollection<Person>
+            {
+                new Person()
+                {
+                    Name = "lorem",
+                    Age = 4
+                },
+                new Person()
+                {
+                    Name = "imsum",
+                    Age = 8
+                },
+                new Person()
+                {
+                    Name = "dolor",
+                    Age = 15
+                },
+                new Person()
+                {
+                    Name = "sit",
+                    Age = 16
+                },
+                new Person()
+                {
+                    Name = "amet",
+                    Age = 23
+                },
+                new Person()
+                {
+                    Name = "consectetur",
+                    Age = 42
+                },
+            };
+
+            var a = new AdvancedCollectionView(l, true);
+
+            a.Filter = (x) => ((Person)x).Name.Length > 5;
+            a.RefreshFilter();
+
+            a.Filter = (x) => ((Person)x).Name.Length > 4;
+            a.RefreshFilter();
+
+            a.SortDescriptions.Add(new SortDescription(nameof(Person.Age), SortDirection.Descending));
+
+            Assert.AreEqual(42, ((Person)a.First()).Age);
+            Assert.AreEqual(4, a.Count);
+
+            l.Add(new Person
+            {
+                Name = "foo",
+                Age = 50
+            });
+
+            l.Add(new Person
+            {
+                Name = "Person McPersonface",
+                Age = 10
+            });
+
+            Assert.AreEqual(42, ((Person)a.First()).Age);
+            Assert.AreEqual(5, a.Count);
         }
 
         [TestCategory("AdvancedCollectionView")]

--- a/UnitTests/UI/Test_AdvancedCollectionView.cs
+++ b/UnitTests/UI/Test_AdvancedCollectionView.cs
@@ -89,9 +89,67 @@ namespace UnitTests.UI
             a.Insert(4, "how");
 
             Assert.AreEqual(3, a.Count);
-            Assert.AreEqual(a[0], "sit");
-            Assert.AreEqual(a[1], "how");
-            Assert.AreEqual(a[2], "amet");
+            Assert.AreEqual("sit", a[0]);
+            Assert.AreEqual("how", a[1]);
+            Assert.AreEqual("amet", a[2]);
+
+        }
+
+        [TestCategory("AdvancedCollectionView")]
+        [UITestMethod]
+        public void Test_AdvancedCollectionView_FilterInsertDuplicate()
+        {
+            var l = new ObservableCollection<string>
+            {
+                "lorem",
+                "ipsum",
+                "dolor",
+                "sit",
+                "amet"
+            };
+
+            var a = new AdvancedCollectionView(l)
+            {
+                Filter = (x) => x.ToString().Length >= 5
+            };
+
+            a.Insert(3, "ipsum");
+
+            Assert.AreEqual(4, a.Count);
+            Assert.AreEqual(4, a.Count);
+            Assert.AreEqual("lorem", a[0]);
+            Assert.AreEqual("ipsum", a[1]);
+            Assert.AreEqual("dolor", a[2]);
+            Assert.AreEqual("ipsum", a[3]);
+
+        }
+
+        [TestCategory("AdvancedCollectionView")]
+        [UITestMethod]
+        public void Test_AdvancedCollectionView_RefreshFilterWithDuplicate()
+        {
+            var l = new ObservableCollection<string>
+            {
+                "lorem",
+                "ipsum",
+                "dolor",
+                "sit",
+                "ipsum",
+                "amet"
+            };
+
+            var a = new AdvancedCollectionView(l)
+            {
+                Filter = (x) => x.ToString().Length < 5
+            };
+
+            a.Filter = (x) => x.ToString().Length >= 5;
+
+            Assert.AreEqual(4, a.Count);
+            Assert.AreEqual("lorem", a[0]);
+            Assert.AreEqual("ipsum", a[1]);
+            Assert.AreEqual("dolor", a[2]);
+            Assert.AreEqual("ipsum", a[3]);
 
         }
 

--- a/UnitTests/UI/Test_AdvancedCollectionView.cs
+++ b/UnitTests/UI/Test_AdvancedCollectionView.cs
@@ -70,7 +70,7 @@ namespace UnitTests.UI
 
         [TestCategory("AdvancedCollectionView")]
         [UITestMethod]
-        public void Test_AdvancedCollectionView_FilterOrder()
+        public void Test_AdvancedCollectionView_Filter_Preserves_Order()
         {
             var l = new ObservableCollection<string>
             {
@@ -86,6 +86,10 @@ namespace UnitTests.UI
                 Filter = (x) => x.ToString().Length < 5
             };
 
+            Assert.AreEqual(2, a.Count);
+            Assert.AreEqual("sit", a[0]);
+            Assert.AreEqual("amet", a[1]);
+
             a.Insert(4, "how");
 
             Assert.AreEqual(3, a.Count);
@@ -97,7 +101,7 @@ namespace UnitTests.UI
 
         [TestCategory("AdvancedCollectionView")]
         [UITestMethod]
-        public void Test_AdvancedCollectionView_FilterInsertDuplicate()
+        public void Test_AdvancedCollectionView_Filter_Preserves_Order_When_Inserting_Duplicate()
         {
             var l = new ObservableCollection<string>
             {
@@ -113,9 +117,13 @@ namespace UnitTests.UI
                 Filter = (x) => x.ToString().Length >= 5
             };
 
+            Assert.AreEqual(3, a.Count);
+            Assert.AreEqual("lorem", a[0]);
+            Assert.AreEqual("ipsum", a[1]);
+            Assert.AreEqual("dolor", a[2]);
+
             a.Insert(3, "ipsum");
 
-            Assert.AreEqual(4, a.Count);
             Assert.AreEqual(4, a.Count);
             Assert.AreEqual("lorem", a[0]);
             Assert.AreEqual("ipsum", a[1]);
@@ -126,7 +134,7 @@ namespace UnitTests.UI
 
         [TestCategory("AdvancedCollectionView")]
         [UITestMethod]
-        public void Test_AdvancedCollectionView_RefreshFilterWithDuplicate()
+        public void Test_AdvancedCollectionView_Updating_Filter_Preserves_Order_With_Duplicate()
         {
             var l = new ObservableCollection<string>
             {
@@ -143,6 +151,10 @@ namespace UnitTests.UI
                 Filter = (x) => x.ToString().Length < 5
             };
 
+            Assert.AreEqual(2, a.Count);
+            Assert.AreEqual("sit", a[0]);
+            Assert.AreEqual("amet", a[1]);
+
             a.Filter = (x) => x.ToString().Length >= 5;
 
             Assert.AreEqual(4, a.Count);
@@ -155,7 +167,7 @@ namespace UnitTests.UI
 
         [TestCategory("AdvancedCollectionView")]
         [UITestMethod]
-        public void Test_AdvancedCollectionView_FilterOrderShowBefore()
+        public void Test_AdvancedCollectionView_Filter_Preserves_Order_When_Inserting_After_Items_In_View()
         {
             var l = new ObservableCollection<string>
             {
@@ -170,6 +182,9 @@ namespace UnitTests.UI
             {
                 Filter = (x) => x.ToString().Length < 5
             };
+
+            Assert.AreEqual(1, a.Count);
+            Assert.AreEqual(a[0], "amet");
 
             a.Insert(0, "how");
 


### PR DESCRIPTION
Fix exception caused by filtering back in removed items using RefreshFilter and Live shaping. Also fix incorrect ordering bug when inserting new items to ACV.

Issue: #
https://github.com/Microsoft/UWPCommunityToolkit/issues/1626

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build or CI related changes
[ ] Documentation content changes
[ ] Sample app changes
[ ] Other... Please describe:
```


## What is the current behavior?
https://github.com/Microsoft/UWPCommunityToolkit/issues/1626


## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)


## What is the new behavior?
No exception get's thrown and view respects the ordering of the source when there is no sort applied.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->