### PR TITLE
Sample App value fixes for #1656

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp/Models/PropertyDescriptor/ValueHolder.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/Models/PropertyDescriptor/ValueHolder.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.Models
 
             set
             {
-                if (_value != value)
+                if (!_value.Equals(value))
                 {
                     _value = value;
                     PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("Value"));

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Carousel/CarouselPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Carousel/CarouselPage.xaml.cs
@@ -40,21 +40,5 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
             carouselControl = control.FindDescendantByName("CarouselControl") as Carousel;
             carouselControl.ItemsSource = await new Data.PhotosDataSource().GetItemsAsync();
         }
-
-        /// <summary>
-        /// Invoked when the Page is loaded and becomes the current source of a parent Frame.
-        /// </summary>
-        /// <param name="e">Event data that can be examined by overriding code. The event data is representative of the pending navigation that will load the current Page. Usually the most relevant property to examine is Parameter.</param>
-        protected override void OnNavigatedTo(NavigationEventArgs e)
-        {
-            base.OnNavigatedTo(e);
-
-            var propertyDesc = e.Parameter as PropertyDescriptor;
-
-            if (propertyDesc != null)
-            {
-                DataContext = propertyDesc.Expando;
-            }
-        }
     }
 }

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/ParallaxService/ParallaxPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/ParallaxService/ParallaxPage.xaml.cs
@@ -25,17 +25,5 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
         {
             InitializeComponent();
         }
-
-        protected override void OnNavigatedTo(NavigationEventArgs e)
-        {
-            base.OnNavigatedTo(e);
-
-            var propertyDesc = e.Parameter as PropertyDescriptor;
-
-            if (propertyDesc != null)
-            {
-                DataContext = propertyDesc.Expando;
-            }
-        }
     }
 }

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Toast/ToastPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Toast/ToastPage.xaml.cs
@@ -93,18 +93,6 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
             };
         }
 
-        protected override void OnNavigatedTo(NavigationEventArgs e)
-        {
-            base.OnNavigatedTo(e);
-
-            var propertyDesc = e.Parameter as PropertyDescriptor;
-
-            if (propertyDesc != null)
-            {
-                DataContext = propertyDesc.Expando;
-            }
-        }
-
         private void ButtonPopToast_Click(object sender, RoutedEventArgs e)
         {
             PopToast();

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/WeatherLiveTileAndToast/WeatherLiveTileAndToastCode.bind
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/WeatherLiveTileAndToast/WeatherLiveTileAndToastCode.bind
@@ -107,18 +107,6 @@ public static TileContent GenerateTileContent()
     };
 }
 
-protected override void OnNavigatedTo(NavigationEventArgs e)
-{
-    base.OnNavigatedTo(e);
-
-    var propertyDesc = e.Parameter as PropertyDescriptor;
-
-    if (propertyDesc != null)
-    {
-        DataContext = propertyDesc.Expando;
-    }
-}
-
 private static bool IsAdaptiveToastSupported()
 {
     switch (AnalyticsInfo.VersionInfo.DeviceFamily)

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/WeatherLiveTileAndToast/WeatherLiveTileAndToastPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/WeatherLiveTileAndToast/WeatherLiveTileAndToastPage.xaml.cs
@@ -113,18 +113,6 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
             };
         }
 
-        protected override void OnNavigatedTo(NavigationEventArgs e)
-        {
-            base.OnNavigatedTo(e);
-
-            var propertyDesc = e.Parameter as PropertyDescriptor;
-
-            if (propertyDesc != null)
-            {
-                DataContext = propertyDesc.Expando;
-            }
-        }
-
         private static bool IsAdaptiveToastSupported()
         {
             switch (AnalyticsInfo.VersionInfo.DeviceFamily)


### PR DESCRIPTION
Issue: #1656

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build or CI related changes
[ ] Documentation content changes
[ ] Sample app changes
[ ] Other... Please describe:
```


## What is the current behavior?
PropertyChange notifications were firing for values that were the same.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] Sample in sample app has been added / updated (for bug fixes / features)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)


## What is the new behavior?
Only fire changes on value changes (not ref change).
Clean-up dead code.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
The DataContext is set automatically by the sample engine now, so removed code from samples which did it manually from before.