### PR TITLE
Moved zindex ordering for ScrollHeader to the behaviors

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Animations/Behaviors/FadeHeaderBehavior.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Animations/Behaviors/FadeHeaderBehavior.cs
@@ -116,6 +116,15 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations.Behaviors
                 return false;
             }
 
+            if (AssociatedObject is Windows.UI.Xaml.Controls.ListViewBase listViewBase)
+            {
+                var panel = listViewBase.ItemsPanelRoot;
+                if (panel != null)
+                {
+                    Canvas.SetZIndex(panel, -1);
+                }
+            }
+
             // Implicit operation: Find the Header object of the control if it uses ListViewBase
             if (HeaderElement == null)
             {

--- a/Microsoft.Toolkit.Uwp.UI.Animations/Behaviors/QuickReturnHeaderBehavior.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Animations/Behaviors/QuickReturnHeaderBehavior.cs
@@ -133,6 +133,15 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations.Behaviors
                 return false;
             }
 
+            if (AssociatedObject is Windows.UI.Xaml.Controls.ListViewBase listViewBase)
+            {
+                var panel = listViewBase.ItemsPanelRoot;
+                if (panel != null)
+                {
+                    Canvas.SetZIndex(panel, -1);
+                }
+            }
+
             if (_scrollProperties == null)
             {
                 _scrollProperties = ElementCompositionPreview.GetScrollViewerManipulationPropertySet(_scrollViewer);

--- a/Microsoft.Toolkit.Uwp.UI.Animations/Behaviors/StickyHeaderBehavior.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Animations/Behaviors/StickyHeaderBehavior.cs
@@ -135,6 +135,15 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations.Behaviors
                 return false;
             }
 
+            if (AssociatedObject is Windows.UI.Xaml.Controls.ListViewBase listViewBase)
+            {
+                var panel = listViewBase.ItemsPanelRoot;
+                if (panel != null)
+                {
+                    Canvas.SetZIndex(panel, -1);
+                }
+            }
+
             if (_scrollProperties == null)
             {
                 _scrollProperties = ElementCompositionPreview.GetScrollViewerManipulationPropertySet(_scrollViewer);

--- a/Microsoft.Toolkit.Uwp.UI.Controls/Expander/Expander.Constants.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/Expander/Expander.Constants.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// Key of the VisualState when expander is collapsed and expander direction is set to Up
         /// </summary>
         private const string StateContentCollapsedUp = "CollapsedUp";
-        
+
         /// <summary>
         /// Key of the UI Element that toggle IsExpanded property
         /// </summary>

--- a/Microsoft.Toolkit.Uwp.UI.Controls/ScrollHeader/ScrollHeader.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/ScrollHeader/ScrollHeader.cs
@@ -67,18 +67,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// </summary>
         protected override void OnApplyTemplate()
         {
-            if (TargetListViewBase == null)
-            {
-                return;
-            }
-
-            // Place items below header
-            var panel = TargetListViewBase.ItemsPanelRoot;
-            if (panel != null)
-            {
-                Canvas.SetZIndex(panel, -1);
-            }
-
             UpdateScrollHeaderBehavior();
         }
 


### PR DESCRIPTION
Issue: #1659
<!-- Link to relevant issue. All PRs should be asociated with an issue -->

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build or CI related changes
[ ] Documentation content changes
[ ] Sample app changes
[ ] Other... Please describe:
```

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)

## What is the new behavior?
Panels using the behaviors without the ScrollHeader will have the correct z-ordering

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
