### PR TITLE
ScrollHeader and Behaviors tweak

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/ScrollHeader/ScrollHeaderCode.bind
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/ScrollHeader/ScrollHeaderCode.bind
@@ -9,7 +9,7 @@
   <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
     <ListView Name="listView">
       <ListView.Header>
-        <controls:ScrollHeader TargetListViewBase="{Binding ElementName=listView}" Mode="@[Mode:Enum:ScrollHeaderMode.QuickReturn]">
+        <controls:ScrollHeader Mode="@[Mode:Enum:ScrollHeaderMode.QuickReturn]">
           <Grid x:Name="MyHeaderGrid"
             MinHeight="250"
             Background="{StaticResource Brush-Blue-01}">

--- a/Microsoft.Toolkit.Uwp.UI.Animations/Behaviors/FadeHeaderBehavior.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Animations/Behaviors/FadeHeaderBehavior.cs
@@ -116,23 +116,17 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations.Behaviors
                 return false;
             }
 
-            if (AssociatedObject is Windows.UI.Xaml.Controls.ListViewBase listViewBase)
+            var listView = AssociatedObject as Windows.UI.Xaml.Controls.ListViewBase ?? AssociatedObject.FindDescendant<Windows.UI.Xaml.Controls.ListViewBase>();
+
+            if (listView != null && listView.ItemsPanelRoot != null)
             {
-                var panel = listViewBase.ItemsPanelRoot;
-                if (panel != null)
-                {
-                    Canvas.SetZIndex(panel, -1);
-                }
+                Canvas.SetZIndex(listView.ItemsPanelRoot, -1);
             }
 
             // Implicit operation: Find the Header object of the control if it uses ListViewBase
-            if (HeaderElement == null)
+            if (HeaderElement == null && listView != null)
             {
-                var listElement = AssociatedObject as Windows.UI.Xaml.Controls.ListViewBase ?? AssociatedObject.FindDescendant<Windows.UI.Xaml.Controls.ListViewBase>();
-                if (listElement != null)
-                {
-                    HeaderElement = listElement.Header as UIElement;
-                }
+                HeaderElement = listView.Header as UIElement;
             }
 
             // If no header is set or detected, return.

--- a/Microsoft.Toolkit.Uwp.UI.Animations/Behaviors/QuickReturnHeaderBehavior.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Animations/Behaviors/QuickReturnHeaderBehavior.cs
@@ -133,13 +133,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations.Behaviors
                 return false;
             }
 
-            if (AssociatedObject is Windows.UI.Xaml.Controls.ListViewBase listViewBase)
+            var listView = AssociatedObject as Windows.UI.Xaml.Controls.ListViewBase ?? AssociatedObject.FindDescendant<Windows.UI.Xaml.Controls.ListViewBase>();
+
+            if (listView != null && listView.ItemsPanelRoot != null)
             {
-                var panel = listViewBase.ItemsPanelRoot;
-                if (panel != null)
-                {
-                    Canvas.SetZIndex(panel, -1);
-                }
+                Canvas.SetZIndex(listView.ItemsPanelRoot, -1);
             }
 
             if (_scrollProperties == null)
@@ -153,13 +151,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations.Behaviors
             }
 
             // Implicit operation: Find the Header object of the control if it uses ListViewBase
-            if (HeaderElement == null)
+            if (HeaderElement == null && listView != null)
             {
-                var listElement = AssociatedObject as Windows.UI.Xaml.Controls.ListViewBase ?? AssociatedObject.FindDescendant<Windows.UI.Xaml.Controls.ListViewBase>();
-                if (listElement != null)
-                {
-                    HeaderElement = listElement.Header as UIElement;
-                }
+                HeaderElement = listView.Header as UIElement;
             }
 
             var headerElement = HeaderElement as FrameworkElement;

--- a/Microsoft.Toolkit.Uwp.UI.Animations/Behaviors/StickyHeaderBehavior.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Animations/Behaviors/StickyHeaderBehavior.cs
@@ -135,13 +135,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations.Behaviors
                 return false;
             }
 
-            if (AssociatedObject is Windows.UI.Xaml.Controls.ListViewBase listViewBase)
+            var listView = AssociatedObject as Windows.UI.Xaml.Controls.ListViewBase ?? AssociatedObject.FindDescendant<Windows.UI.Xaml.Controls.ListViewBase>();
+
+            if (listView != null && listView.ItemsPanelRoot != null)
             {
-                var panel = listViewBase.ItemsPanelRoot;
-                if (panel != null)
-                {
-                    Canvas.SetZIndex(panel, -1);
-                }
+                Canvas.SetZIndex(listView.ItemsPanelRoot, -1);
             }
 
             if (_scrollProperties == null)
@@ -155,14 +153,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations.Behaviors
             }
 
             // Implicit operation: Find the Header object of the control if it uses ListViewBase
-            if (HeaderElement == null)
+            if (HeaderElement == null && listView != null)
             {
-                var listElement = AssociatedObject as Windows.UI.Xaml.Controls.ListViewBase ?? AssociatedObject.FindDescendant<Windows.UI.Xaml.Controls.ListViewBase>();
-
-                if (listElement != null)
-                {
-                    HeaderElement = listElement.Header as UIElement;
-                }
+                HeaderElement = listView.Header as UIElement;
             }
 
             var headerElement = HeaderElement as FrameworkElement;

--- a/Microsoft.Toolkit.Uwp.UI.Controls/ScrollHeader/ScrollHeader.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/ScrollHeader/ScrollHeader.cs
@@ -11,7 +11,9 @@
 // ******************************************************************
 
 using Microsoft.Toolkit.Uwp.UI.Animations.Behaviors;
+using Microsoft.Toolkit.Uwp.UI.Extensions;
 using Microsoft.Xaml.Interactivity;
+using System;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 
@@ -40,8 +42,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// <summary>
         /// Identifies the <see cref="TargetListViewBase"/> property.
         /// </summary>
+#pragma warning disable CS0618 // Type or member is obsolete
         public static readonly DependencyProperty TargetListViewBaseProperty =
-            DependencyProperty.Register(nameof(TargetListViewBase), typeof(ListViewBase), typeof(ScrollHeader), new PropertyMetadata(null, OnTargetChanged));
+            DependencyProperty.Register(nameof(TargetListViewBase), typeof(Windows.UI.Xaml.Controls.ListViewBase), typeof(ScrollHeader), new PropertyMetadata(null, OnTargetChanged));
+#pragma warning restore CS0618 // Type or member is obsolete
 
         /// <summary>
         /// Gets or sets a value indicating whether the current mode.
@@ -56,9 +60,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// <summary>
         /// Gets or sets the container this header belongs to
         /// </summary>
-        public ListViewBase TargetListViewBase
+        [Obsolete("This property has been deprecated and isn't required.")]
+        public Windows.UI.Xaml.Controls.ListViewBase TargetListViewBase
         {
-            get { return (ListViewBase)GetValue(TargetListViewBaseProperty); }
+            get { return (Windows.UI.Xaml.Controls.ListViewBase)GetValue(TargetListViewBaseProperty); }
             set { SetValue(TargetListViewBaseProperty, value); }
         }
 
@@ -82,17 +87,19 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
         private void UpdateScrollHeaderBehavior()
         {
-            if (TargetListViewBase == null)
+            var targetListViewBase = TargetListViewBase ?? this.FindAscendant<Windows.UI.Xaml.Controls.ListViewBase>();
+
+            if (targetListViewBase == null)
             {
                 return;
             }
 
             // Remove previous behaviors
-            foreach (var behavior in Interaction.GetBehaviors(TargetListViewBase))
+            foreach (var behavior in Interaction.GetBehaviors(targetListViewBase))
             {
                 if (behavior is FadeHeaderBehavior || behavior is QuickReturnHeaderBehavior || behavior is StickyHeaderBehavior)
                 {
-                    Interaction.GetBehaviors(TargetListViewBase).Remove(behavior);
+                    Interaction.GetBehaviors(targetListViewBase).Remove(behavior);
                 }
             }
 
@@ -101,13 +108,13 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 case ScrollHeaderMode.None:
                     break;
                 case ScrollHeaderMode.QuickReturn:
-                    Interaction.GetBehaviors(TargetListViewBase).Add(new QuickReturnHeaderBehavior());
+                    Interaction.GetBehaviors(targetListViewBase).Add(new QuickReturnHeaderBehavior());
                     break;
                 case ScrollHeaderMode.Sticky:
-                    Interaction.GetBehaviors(TargetListViewBase).Add(new StickyHeaderBehavior());
+                    Interaction.GetBehaviors(targetListViewBase).Add(new StickyHeaderBehavior());
                     break;
                 case ScrollHeaderMode.Fade:
-                    Interaction.GetBehaviors(TargetListViewBase).Add(new FadeHeaderBehavior());
+                    Interaction.GetBehaviors(targetListViewBase).Add(new FadeHeaderBehavior());
                     break;
             }
         }


### PR DESCRIPTION
Issue: #1659 
<!-- Link to relevant issue. All PRs should be asociated with an issue -->

## PR Type
What kind of change does this PR introduce?
ScrollHeader and Behaviors tweak

<!-- Please check the one that applies to this PR using "x". -->
```
[] Bugfix
[ ] Feature
[ ] Code style update (formatting)
[x] Refactoring (no functional changes, no api changes)
[ ] Build or CI related changes
[ ] Documentation content changes
[x] Sample app changes
[ ] Other... Please describe:
```


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
ScrollHeader requires TargetListView to be set. It should not be mandatory as ScrollHeader is set to ListView / GridView header.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] Sample in sample app has been added / updated (for bug fixes / features)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)


## What is the new behavior?
Make TargetListViewBase in ScrollHeader optional
Mark TargetListViewBase as obsolete
Tweak FadeHeaderBehavior, QuickReturnHeaderBehavior and StickyHeaderBehavior


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
