### PR TITLE
NetworkHelper updates to fix crashes logged

### DIFF
--- a/Microsoft.Toolkit.Uwp.Connectivity/Network/ConnectionInformation.cs
+++ b/Microsoft.Toolkit.Uwp.Connectivity/Network/ConnectionInformation.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Toolkit.Uwp.Connectivity
         /// <summary>
         /// Resets the current object to default values.
         /// </summary>
-        public void Reset()
+        internal void Reset()
         {
             networkNames.Clear();
 

--- a/Microsoft.Toolkit.Uwp.Connectivity/Network/ConnectionInformation.cs
+++ b/Microsoft.Toolkit.Uwp.Connectivity/Network/ConnectionInformation.cs
@@ -30,22 +30,20 @@ namespace Microsoft.Toolkit.Uwp.Connectivity
         /// Updates  the current object based on profile passed.
         /// </summary>
         /// <param name="profile">instance of <see cref="ConnectionProfile"/></param>
-        public virtual void UpdateConnectionInformation(ConnectionProfile profile)
+        public void UpdateConnectionInformation(ConnectionProfile profile)
         {
-            networkNames.Clear();
-
             if (profile == null)
             {
-                ConnectionType = ConnectionType.Unknown;
-                ConnectivityLevel = NetworkConnectivityLevel.None;
-                IsInternetAvailable = false;
-                ConnectionCost = null;
-                SignalStrength = null;
+                Reset();
 
                 return;
             }
 
-            switch (profile.NetworkAdapter.IanaInterfaceType)
+            networkNames.Clear();
+
+            uint ianaInterfaceType = profile.NetworkAdapter?.IanaInterfaceType ?? 0;
+
+            switch (ianaInterfaceType)
             {
                 case 6:
                     ConnectionType = ConnectionType.Ethernet;
@@ -65,15 +63,13 @@ namespace Microsoft.Toolkit.Uwp.Connectivity
                     break;
             }
 
-            ConnectivityLevel = profile.GetNetworkConnectivityLevel();
-            ConnectionCost = profile.GetConnectionCost();
-            SignalStrength = profile.GetSignalBars();
-
             var names = profile.GetNetworkNames();
             if (names?.Count > 0)
             {
                 networkNames.AddRange(names);
             }
+
+            ConnectivityLevel = profile.GetNetworkConnectivityLevel();
 
             switch (ConnectivityLevel)
             {
@@ -86,6 +82,23 @@ namespace Microsoft.Toolkit.Uwp.Connectivity
                     IsInternetAvailable = true;
                     break;
             }
+
+            ConnectionCost = profile.GetConnectionCost();
+            SignalStrength = profile.GetSignalBars();
+        }
+
+        /// <summary>
+        /// Resets the current object to default values.
+        /// </summary>
+        public void Reset()
+        {
+            networkNames.Clear();
+
+            ConnectionType = ConnectionType.Unknown;
+            ConnectivityLevel = NetworkConnectivityLevel.None;
+            IsInternetAvailable = false;
+            ConnectionCost = null;
+            SignalStrength = null;
         }
 
         /// <summary>

--- a/Microsoft.Toolkit.Uwp.Connectivity/Network/NetworkHelper.cs
+++ b/Microsoft.Toolkit.Uwp.Connectivity/Network/NetworkHelper.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Toolkit.Uwp.Connectivity
         {
             ConnectionInformation = new ConnectionInformation();
 
-            OnNetworkStatusChanged(null);
+            UpdateConnectionInformation();
 
             NetworkInformation.NetworkStatusChanged += OnNetworkStatusChanged;
         }
@@ -60,20 +60,26 @@ namespace Microsoft.Toolkit.Uwp.Connectivity
             NetworkInformation.NetworkStatusChanged -= OnNetworkStatusChanged;
         }
 
+        private void UpdateConnectionInformation()
+        {
+            lock (ConnectionInformation)
+            {
+                try
+                {
+                    ConnectionInformation.UpdateConnectionInformation(NetworkInformation.GetInternetConnectionProfile());
+
+                    NetworkChanged?.Invoke(this, EventArgs.Empty);
+                }
+                catch
+                {
+                    ConnectionInformation.Reset();
+                }
+            }
+        }
+
         private void OnNetworkStatusChanged(object sender)
         {
-            ConnectionProfile profile = null;
-            try
-            {
-                profile = NetworkInformation.GetInternetConnectionProfile();
-            }
-            catch
-            {
-            }
-
-            ConnectionInformation.UpdateConnectionInformation(profile);
-
-            NetworkChanged?.Invoke(this, EventArgs.Empty);
+            UpdateConnectionInformation();
         }
     }
 }


### PR DESCRIPTION
Issue: #1645
<!-- Link to relevant issue. All PRs should be asociated with an issue -->

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting)
[x] Refactoring (no functional changes, no api changes)
[ ] Build or CI related changes
[ ] Documentation content changes
[ ] Sample app changes
[ ] Other... Please describe:
```


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
There are no exception handlers and passing null when initialising the NetworkHelper isn't ideal.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)


## What is the new behavior?
Add UpdateConnectionInformation method to NetworkHelper
Add try catch to UpdateConnectionInformation
Lock NetworkHelper.ConnectionInformation before calling update.
Add Reset method to ConnectionInformation
Tweaks to ConnectionInformation.UpdateConnectionInformation method


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
