### PR TITLE
Fix for MenuItem items not being inserted in the proper order when using Items.Insert instead of Items.Add

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Menu/MenuPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Menu/MenuPage.xaml.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
         {
             base.OnNavigatedTo(e);
 
-            Shell.Current.RegisterNewCommand("Add Item to file menu", (sender, args) =>
+            Shell.Current.RegisterNewCommand("Append Item to file menu", (sender, args) =>
             {
                 if (fileMenu != null)
                 {
@@ -51,6 +51,24 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
                     };
 
                     fileMenu.Items.Add(flyoutItem);
+                }
+            });
+
+            Shell.Current.RegisterNewCommand("Prepend Item to file menu", (sender, args) =>
+            {
+                if (fileMenu != null)
+                {
+                    var flyoutItem = new MenuFlyoutItem
+                    {
+                        Text = "Click to remove"
+                    };
+
+                    flyoutItem.Click += (a, b) =>
+                    {
+                        fileMenu.Items.Remove(flyoutItem);
+                    };
+
+                    fileMenu.Items.Insert(0, flyoutItem);
                 }
             });
         }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/Menu/MenuItem.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/Menu/MenuItem.cs
@@ -268,7 +268,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                     ReAddItemsToFlyout();
                     break;
                 case CollectionChange.ItemInserted:
-                    AddItemToFlyout(sender.ElementAt(index));
+                    InsertItemToFlyout(sender.ElementAt(index), index);
                     break;
                 case CollectionChange.ItemRemoved:
                     MenuFlyout.Items.RemoveAt(index);


### PR DESCRIPTION
Issue: #1680

## PR Type
What kind of change does this PR introduce?

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build or CI related changes
[ ] Documentation content changes
[X] Sample app changes
[ ] Other... Please describe:
```

## What is the current behavior?
If a MenuItem has been already initialized, inserting a new element in its Items collection by using Insert instead of Add doesn't respect the specified index; the new item gets added at the end instead.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Docs have been added / updated (for bug fixes / features)
- [X] Sample in sample app has been added / updated (for bug fixes / features)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)

## What is the new behavior?
The new menu item gets added at the specified index, and not at the last position.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

## Other information
Sample app has been updated so MenuItem page now has two buttons - one for adding new items at the end of the menu and another one to add them at the beginning, so the fix can be properly tested.
