### PR TITLE
Fix live shaping null ref bug when no filter is set

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI/AdvancedCollectionView/AdvancedCollectionView.cs
+++ b/Microsoft.Toolkit.Uwp.UI/AdvancedCollectionView/AdvancedCollectionView.cs
@@ -464,23 +464,23 @@ namespace Microsoft.Toolkit.Uwp.UI
                 return;
             }
 
-            var filterResult = _filter(item);
+            var filterResult = _filter?.Invoke(item);
 
-            if (_observedFilterProperties.Contains(e.PropertyName))
+            if (filterResult.HasValue && _observedFilterProperties.Contains(e.PropertyName))
             {
                 var viewIndex = _view.IndexOf(item);
-                if (viewIndex != -1 && !filterResult)
+                if (viewIndex != -1 && !filterResult.Value)
                 {
                     RemoveFromView(viewIndex, item);
                 }
-                else if (viewIndex == -1 && filterResult)
+                else if (viewIndex == -1 && filterResult.Value)
                 {
                     var index = _sourceList.IndexOf(item);
                     HandleItemAdded(index, item);
                 }
             }
 
-            if (filterResult && SortDescriptions.Any(sd => sd.PropertyName == e.PropertyName))
+            if ((filterResult ?? true) && SortDescriptions.Any(sd => sd.PropertyName == e.PropertyName))
             {
                 var oldIndex = _view.IndexOf(item);
                 _view.RemoveAt(oldIndex);

--- a/UnitTests/UI/Test_AdvancedCollectionView.cs
+++ b/UnitTests/UI/Test_AdvancedCollectionView.cs
@@ -592,6 +592,33 @@ namespace UnitTests.UI
 
         [TestCategory("AdvancedCollectionView")]
         [UITestMethod]
+        public void Test_AdvancedCollectionView_Using_Shaping()
+        {
+            var myPerson = new Person()
+            {
+                Name = "lorem",
+                Age = 4
+            };
+            var l = new ObservableCollection<Person>
+            {
+                myPerson,
+                new Person()
+                {
+                    Name = "imsum",
+                    Age = 8
+                },
+            };
+
+            var a = new AdvancedCollectionView(l, true);
+
+            myPerson.Name = "myName";
+
+            Assert.AreEqual("myName", ((Person)a.First()).Name);
+            Assert.AreEqual(2, a.Count);
+        }
+
+        [TestCategory("AdvancedCollectionView")]
+        [UITestMethod]
         public void Test_AdvancedCollectionView_Sorting_Using_Shaping()
         {
             var l = new ObservableCollection<Person>


### PR DESCRIPTION
Fix null reference exception caused by assuming a filter is always set. Now when we evaluate an item's property changed event, we do not assume that a filter has been set.

Issue: #
https://github.com/Microsoft/UWPCommunityToolkit/issues/1686

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build or CI related changes
[ ] Documentation content changes
[ ] Sample app changes
[ ] Other... Please describe:
```


## What is the current behavior?
https://github.com/Microsoft/UWPCommunityToolkit/issues/1686



## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)


## What is the new behavior?
No exception is thrown.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->