### PR TITLE
MenuItem padding

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/Menu/Menu.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/Menu/Menu.xaml
@@ -46,7 +46,8 @@
                             FontStyle="{TemplateBinding FontStyle}"
                             FontWeight="{TemplateBinding FontWeight}"
                             Foreground="{TemplateBinding Foreground}"
-                            IsTabStop="False">
+                            IsTabStop="False"
+                            Padding="{TemplateBinding Padding}">
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup x:Name="CommonStates">
                                 <VisualState x:Name="Normal">

--- a/Microsoft.Toolkit.Uwp.UI.Controls/Menu/Menu.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/Menu/Menu.xaml
@@ -31,6 +31,7 @@
         <Setter Property="BorderBrush" Value="{ThemeResource SystemControlForegroundTransparentBrush}" />
         <Setter Property="BorderThickness" Value="{ThemeResource ButtonBorderThemeThickness}" />
         <Setter Property="UseSystemFocusVisuals" Value="True" />
+        <Setter Property="Padding" Value="8,4,8,4" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="local:MenuItem">


### PR DESCRIPTION
Issue: #1694 

## PR Type
- Bugfix

## What is the current behavior?
Changing the `Padding` property of a `MenuItem` does nothing - the padding of the control reverts to default.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs]
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)

## What is the new behavior?
Changing the `Padding` propery of a `MenuItem` properly reflects the change to the control style.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```
## Other information
