### PR TITLE
Use explicit invariant culture to ensure correct float notation when creating animation expressions

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Animations/Expressions/ExpressionNodes/ScalarNode.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Animations/Expressions/ExpressionNodes/ScalarNode.cs
@@ -262,7 +262,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations.Expressions
         /// <returns>System.String.</returns>
         protected internal override string GetValue()
         {
-            return _value.ToString();
+            // Important to use invariant culture to make sure that floats are written using a .
+            return _value.ToString(System.Globalization.CultureInfo.InvariantCulture);
         }
 
         private float _value;


### PR DESCRIPTION
More info in #1707 .

Summarized it means there is a major bug in the animation expression compositor on cultures that don't use a `.` as decimal separator.