### PR TITLE
Fix typo in HamburgetMenuItemInvokedEventArgs

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp/App.xaml
+++ b/Microsoft.Toolkit.Uwp.SampleApp/App.xaml
@@ -186,7 +186,7 @@
             </Grid>
         </DataTemplate>
 
-        <Style x:Key="HambugerMenuItemStyle"
+        <Style x:Key="HamburgerMenuItemStyle"
                TargetType="ListViewItem">
             <Setter Property="Foreground" Value="{ThemeResource SystemControlForegroundBaseHighBrush}" />
             <Setter Property="Background" Value="Transparent" />
@@ -275,7 +275,7 @@
             </Setter>
         </Style>
 
-        <Style x:Key="SecondaryHambugerMenuItemStyle"
+        <Style x:Key="SecondaryHamburgerMenuItemStyle"
                TargetType="GridViewItem">
             <Setter Property="Foreground" Value="{ThemeResource SystemControlForegroundBaseHighBrush}" />
             <Setter Property="Background" Value="Transparent" />
@@ -705,7 +705,7 @@
                                     <GridView x:Name="SamplePickerGridView"
                                               IsItemClickEnabled="True"
                                               animations:ReorderGridAnimation.Duration="200"
-                                              ItemContainerStyle="{StaticResource SecondaryHambugerMenuItemStyle}"
+                                              ItemContainerStyle="{StaticResource SecondaryHamburgerMenuItemStyle}"
                                               ItemTemplate="{StaticResource SampleTemplate}"
                                               SelectionMode="Single"
                                               ItemContainerTransitions="{x:Null}"
@@ -738,7 +738,7 @@
                                 <ListView x:Name="ButtonsListView"
                                           AutomationProperties.Name="Menu items"
                                           IsItemClickEnabled="True"
-                                          ItemContainerStyle="{StaticResource HambugerMenuItemStyle}"
+                                          ItemContainerStyle="{StaticResource HamburgerMenuItemStyle}"
                                           ItemTemplate="{TemplateBinding ItemTemplate}"
                                           ItemTemplateSelector="{TemplateBinding ItemTemplateSelector}"
                                           ItemsSource="{TemplateBinding ItemsSource}"
@@ -819,7 +819,7 @@
                                           Grid.Column="3"
                                           AutomationProperties.Name="Option items"
                                           IsItemClickEnabled="True"
-                                          ItemContainerStyle="{StaticResource HambugerMenuItemStyle}"
+                                          ItemContainerStyle="{StaticResource HamburgerMenuItemStyle}"
                                           ItemTemplate="{TemplateBinding OptionsItemTemplate}"
                                           ItemTemplateSelector="{TemplateBinding OptionsItemTemplateSelector}"
                                           ItemsSource="{TemplateBinding OptionsItemsSource}"

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/HamburgerMenu/HamburgerMenuPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/HamburgerMenu/HamburgerMenuPage.xaml.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
             }
         }
 
-        private async void HamburgerMenuControl_ItemInvoked(object sender, HamburgetMenuItemInvokedEventArgs e)
+        private async void HamburgerMenuControl_ItemInvoked(object sender, HamburgerMenuItemInvokedEventArgs e)
         {
             if (e.IsItemOptions)
             {

--- a/Microsoft.Toolkit.Uwp.UI.Controls/HamburgerMenu/HamburgerMenu.Events.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/HamburgerMenu/HamburgerMenu.Events.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// <summary>
         /// Event raised when an item is invoked
         /// </summary>
-        public event EventHandler<HamburgetMenuItemInvokedEventArgs> ItemInvoked;
+        public event EventHandler<HamburgerMenuItemInvokedEventArgs> ItemInvoked;
 
         private void HamburgerButton_Click(object sender, RoutedEventArgs e)
         {
@@ -51,7 +51,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             }
 
             ItemClick?.Invoke(this, e);
-            ItemInvoked?.Invoke(this, new HamburgetMenuItemInvokedEventArgs() { InvokedItem = e.ClickedItem, IsItemOptions = false });
+            ItemInvoked?.Invoke(this, new HamburgerMenuItemInvokedEventArgs() { InvokedItem = e.ClickedItem, IsItemOptions = false });
         }
 
         private void OptionsListView_ItemClick(object sender, ItemClickEventArgs e)
@@ -62,7 +62,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             }
 
             OptionsItemClick?.Invoke(this, e);
-            ItemInvoked?.Invoke(this, new HamburgetMenuItemInvokedEventArgs() { InvokedItem = e.ClickedItem, IsItemOptions = true });
+            ItemInvoked?.Invoke(this, new HamburgerMenuItemInvokedEventArgs() { InvokedItem = e.ClickedItem, IsItemOptions = true });
         }
 
         private void NavigationViewItemInvoked(NavigationView sender, NavigationViewItemInvokedEventArgs args)
@@ -70,7 +70,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             var options = OptionsItemsSource as IEnumerable<object>;
             var isOption = options != null && options.Contains(args.InvokedItem);
 
-            ItemInvoked?.Invoke(this, new HamburgetMenuItemInvokedEventArgs() { InvokedItem = args.InvokedItem, IsItemOptions = isOption });
+            ItemInvoked?.Invoke(this, new HamburgerMenuItemInvokedEventArgs() { InvokedItem = args.InvokedItem, IsItemOptions = isOption });
         }
     }
 }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/HamburgerMenu/HamburgerMenuItemInvokedEventArgs.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/HamburgerMenu/HamburgerMenuItemInvokedEventArgs.cs
@@ -17,8 +17,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
     /// <summary>
     /// EventArgs used for the <see cref="HamburgerMenu"/> ItemInvoked event
     /// </summary>
-    [Obsolete("The HamburgetMenuItemInvokedEventArgs will be removed alongside the HamburgerMenu in a future major release. Please use the NavigationView control available in the Fall Creators Update")]
-    public class HamburgetMenuItemInvokedEventArgs : EventArgs
+    [Obsolete("The HamburgerMenuItemInvokedEventArgs will be removed alongside the HamburgerMenu in a future major release. Please use the NavigationView control available in the Fall Creators Update")]
+    public class HamburgerMenuItemInvokedEventArgs : EventArgs
     {
         /// <summary>
         /// Gets the invoked item

--- a/Microsoft.Toolkit.Uwp.UI.Controls/HamburgerMenu/HamburgerMenuItemInvokedEventArgs.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/HamburgerMenu/HamburgerMenuItemInvokedEventArgs.cs
@@ -30,4 +30,12 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// </summary>
         public bool IsItemOptions { get; internal set; }
     }
+
+    /// <summary>
+    /// EventArgs used for the <see cref="HamburgerMenu"/> ItemInvoked event
+    /// </summary>
+    [Obsolete("The HamburgetMenuItemInvokedEventArgs will be removed caused by a typo. Please use the HamburgerMenuItemInvokedEventArgs instead.")]
+    public class HamburgetMenuItemInvokedEventArgs : HamburgerMenuItemInvokedEventArgs
+    {
+    }
 }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/HamburgerMenu/HamburgerMenuTemplate.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/HamburgerMenu/HamburgerMenuTemplate.xaml
@@ -2,7 +2,7 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:local="using:Microsoft.Toolkit.Uwp.UI.Controls">
 
-    <Style x:Key="HambugerMenuItemStyle" TargetType="ListViewItem">
+    <Style x:Key="HamburgerMenuItemStyle" TargetType="ListViewItem">
         <Setter Property="Foreground" Value="{ThemeResource SystemControlForegroundBaseHighBrush}" />
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="MinHeight" Value="0"/>
@@ -109,7 +109,7 @@
                                               Width="{TemplateBinding OpenPaneLength}"
                                               AutomationProperties.Name="Menu items"
                                               IsItemClickEnabled="True"
-                                              ItemContainerStyle="{StaticResource HambugerMenuItemStyle}"
+                                              ItemContainerStyle="{StaticResource HamburgerMenuItemStyle}"
                                               ItemTemplate="{TemplateBinding ItemTemplate}"
                                               ItemTemplateSelector="{TemplateBinding ItemTemplateSelector}"
                                               ItemsSource="{TemplateBinding ItemsSource}"
@@ -125,7 +125,7 @@
                                               VerticalAlignment="Bottom"
                                               AutomationProperties.Name="Option items"
                                               IsItemClickEnabled="True"
-                                              ItemContainerStyle="{StaticResource HambugerMenuItemStyle}"
+                                              ItemContainerStyle="{StaticResource HamburgerMenuItemStyle}"
                                               ItemTemplate="{TemplateBinding OptionsItemTemplate}"
                                               ItemTemplateSelector="{TemplateBinding OptionsItemTemplateSelector}"
                                               ItemsSource="{TemplateBinding OptionsItemsSource}"

--- a/Microsoft.Toolkit.Uwp.UI.Controls/HamburgerMenu/HamburgerMenuTemplate.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/HamburgerMenu/HamburgerMenuTemplate.xaml
@@ -83,6 +83,9 @@
         </Setter>
     </Style>
 
+    <!-- Obsolete: The HamburgetMenuItemStyle will be removed caused by a typo. Please use the HamburgerMenuItemStyle instead. -->
+    <Style x:Key="HamburgetMenuItemStyle" TargetType="ListViewItem" BasedOn="{StaticResource HamburgerMenuItemStyle}" />
+
     <ControlTemplate x:Key="HamburgerMenuTemplate" TargetType="local:HamburgerMenu">
         <Grid>
             <SplitView x:Name="MainSplitView"


### PR DESCRIPTION
Issue: #
<!-- Link to relevant issue. All PRs should be asociated with an issue -->

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build or CI related changes
[ ] Documentation content changes
[ ] Sample app changes
[ ] Other... Please describe:
```


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Even though the `HamburgetMenuItemInvokedEventArgs` is marked as obsolete, it should not have this typo.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)


## What is the new behavior?

The fixed typos
- `HamburgetMenuItemInvokedEventArgs -> HamburgerMenuItemInvokedEventArgs`
- `HambugerMenuItemStyle` -> `HamburgerMenuItemStyle`

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->

This is a breaking change if someone uses the `ItemInvoked` event.

## Other information
