### PR TITLE
Issue fix #1736, Empty Hyperlink validation in TextToolbar

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/TextToolbar/TextToolbarStrings.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/TextToolbar/TextToolbarStrings.cs
@@ -110,6 +110,12 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             DependencyProperty.Register(nameof(HeaderLabel), typeof(string), typeof(TextToolbarStrings), new PropertyMetadata("Header"));
 
         /// <summary>
+        /// Identifies the <see cref="EmptyTextLabel"/> dependency property.
+        /// </summary>
+        public static readonly DependencyProperty EmptyTextLabelProperty =
+            DependencyProperty.Register(nameof(EmptyTextLabel), typeof(string), typeof(TextToolbarStrings), new PropertyMetadata("Label cannot be Empty"));
+
+        /// <summary>
         /// Identifies the <see cref="LinkInvalidLabel"/> dependency property.
         /// </summary>
         public static readonly DependencyProperty LinkInvalidLabelProperty =
@@ -260,6 +266,15 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         {
             get { return (string)GetValue(HeaderLabelProperty); }
             set { SetValue(HeaderLabelProperty, value); }
+        }
+
+        /// <summary>
+        /// Gets or sets the label for EmptyTextLabel
+        /// </summary>
+        public string EmptyTextLabel
+        {
+            get { return (string)GetValue(EmptyTextLabelProperty); }
+            set { SetValue(EmptyTextLabelProperty, value); }
         }
 
         /// <summary>

--- a/Microsoft.Toolkit.Uwp.UI.Controls/TextToolbar/ToolbarItems/Common/CommonButtons.Events.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/TextToolbar/ToolbarItems/Common/CommonButtons.Events.cs
@@ -111,23 +111,13 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls.TextToolbarButtons.Common
 
                 if (string.IsNullOrEmpty(labelText.Trim()))
                 {
-                    await new ContentDialog
-                    {
-                        Title = Model.Labels.WarningLabel,
-                        Content = Model.Labels.EmptyTextLabel,
-                        PrimaryButtonText = Model.Labels.OkLabel
-                    }.ShowAsync();
+                    ShowContentDialog(Model.Labels.WarningLabel, Model.Labels.EmptyTextLabel, Model.Labels.OkLabel);
                     return;
                 }
 
                 if (string.IsNullOrWhiteSpace(linkText))
                 {
-                    await new ContentDialog
-                    {
-                        Title = Model.Labels.WarningLabel,
-                        Content = Model.Labels.LinkInvalidLabel,
-                        PrimaryButtonText = Model.Labels.OkLabel
-                    }.ShowAsync();
+                    ShowContentDialog(Model.Labels.WarningLabel, Model.Labels.LinkInvalidLabel, Model.Labels.OkLabel);
                     return;
                 }
 
@@ -136,18 +126,29 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls.TextToolbarButtons.Common
                     var wellFormed = Uri.IsWellFormedUriString(linkText, relativeBox?.IsChecked == true ? UriKind.RelativeOrAbsolute : UriKind.Absolute);
                     if (!wellFormed)
                     {
-                        await new ContentDialog
-                        {
-                            Title = Model.Labels.WarningLabel,
-                            Content = Model.Labels.LinkInvalidLabel,
-                            PrimaryButtonText = Model.Labels.OkLabel
-                        }.ShowAsync();
+                        ShowContentDialog(Model.Labels.WarningLabel, Model.Labels.LinkInvalidLabel, Model.Labels.OkLabel);
                         return;
                     }
                 }
 
                 Model.Formatter.ButtonActions.FormatLink(button, labelText.Trim(), formattedlabelText.Trim(), linkText);
             }
+        }
+
+        /// <summary>
+        /// Opens a <see cref="ContentDialog"/> to notify the user about empty and whitespace inputs.
+        /// </summary>
+        /// <param name="title">The <see cref="string"/> </param>
+        /// <param name="content">The <see cref="string"/> </param>
+        /// <param name="primaryButtonText">The <see cref="string"/> </param>
+        private async void ShowContentDialog(string title, string content, string primaryButtonText)
+        {
+            await new ContentDialog
+            {
+                Title = title,
+                Content = content,
+                PrimaryButtonText = primaryButtonText
+            }.ShowAsync();
         }
     }
 }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/TextToolbar/ToolbarItems/Common/CommonButtons.Events.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/TextToolbar/ToolbarItems/Common/CommonButtons.Events.cs
@@ -109,12 +109,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls.TextToolbarButtons.Common
 
                 string linkText = linkBox.Text.Trim();
 
-                if (string.IsNullOrEmpty(labelText.Trim()))
-                {
-                    ShowContentDialog(Model.Labels.WarningLabel, Model.Labels.EmptyTextLabel, Model.Labels.OkLabel);
-                    return;
-                }
-
                 if (string.IsNullOrWhiteSpace(linkText))
                 {
                     ShowContentDialog(Model.Labels.WarningLabel, Model.Labels.LinkInvalidLabel, Model.Labels.OkLabel);

--- a/Microsoft.Toolkit.Uwp.UI.Controls/TextToolbar/ToolbarItems/Common/CommonButtons.Events.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/TextToolbar/ToolbarItems/Common/CommonButtons.Events.cs
@@ -109,6 +109,28 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls.TextToolbarButtons.Common
 
                 string linkText = linkBox.Text.Trim();
 
+                if (string.IsNullOrEmpty(labelText.Trim()))
+                {
+                    await new ContentDialog
+                    {
+                        Title = Model.Labels.WarningLabel,
+                        Content = Model.Labels.EmptyTextLabel,
+                        PrimaryButtonText = Model.Labels.OkLabel
+                    }.ShowAsync();
+                    return;
+                }
+
+                if (string.IsNullOrWhiteSpace(linkText))
+                {
+                    await new ContentDialog
+                    {
+                        Title = Model.Labels.WarningLabel,
+                        Content = Model.Labels.LinkInvalidLabel,
+                        PrimaryButtonText = Model.Labels.OkLabel
+                    }.ShowAsync();
+                    return;
+                }
+
                 if (Model.UseURIChecker && !string.IsNullOrWhiteSpace(linkText))
                 {
                     var wellFormed = Uri.IsWellFormedUriString(linkText, relativeBox?.IsChecked == true ? UriKind.RelativeOrAbsolute : UriKind.Absolute);


### PR DESCRIPTION
Issue: #1736
<!-- Link to relevant issue. All PRs should be asociated with an issue -->

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build or CI related changes
[ ] Documentation content changes
[ ] Sample app changes
[ ] Other... Please describe:
```


## What is the current behavior?
App crashed if we create a hyperlink with empty label or url in TextToolbar control


## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)


## What is the new behavior?
App crash issue fixed and will show warning validation dialog for the empty label and url.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
