### PR TITLE
Add CarouselItem control

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/Carousel/Carousel.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/Carousel/Carousel.cs
@@ -216,6 +216,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                     }
                 }
 
+                bool isNewSelectedItem = carouselControl.SelectedItem != newValue
+
                 if (newValue != null)
                 {
                     var item = (CarouselItem)carouselControl.ContainerFromIndex((int)e.NewValue);
@@ -228,7 +230,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 }
 
                 // double check
-                if (carouselControl.SelectedItem != newValue)
+                if (isNewSelectedItem)
                 {
                     carouselControl.SetValue(SelectedItemProperty, newValue);
                     var newValues = new List<object>() { newValue };
@@ -480,11 +482,20 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         }
 
         /// <inheritdoc/>
+        protected override void ClearContainerForItemOverride(DependencyObject element, object item)
+        {
+            base.ClearContainerForItemOverride(element, item);
+            var carouselItem = (CarouselItem)element;
+            carouselItem.Selected -= OnCarouselItemSelected;
+        }
+
+        /// <inheritdoc/>
         protected override void PrepareContainerForItemOverride(DependencyObject element, object item)
         {
             base.PrepareContainerForItemOverride(element, item);
 
             var carouselItem = (CarouselItem)element;
+            carouselItem.Selected += OnCarouselItemSelected;
 
             carouselItem.RenderTransformOrigin = new Point(0.5, 0.5);
 
@@ -508,6 +519,13 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             {
                 carouselItem.IsSelected = true;
             }
+        }
+
+        private void OnCarouselItemSelected(object sender, EventArgs e)
+        {
+            var item = (CarouselItem)sender;
+
+            SelectedItem = ItemFromContainer(item);
         }
     }
 }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/Carousel/Carousel.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/Carousel/Carousel.cs
@@ -469,13 +469,13 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         {
             base.PrepareContainerForItemOverride(element, item);
 
-            var contentControl = (ContentControl)element;
+            var carouselItem = (CarouselItem)element;
 
-            contentControl.RenderTransformOrigin = new Point(0.5, 0.5);
-            contentControl.Tag = "CarouselItem";
+            carouselItem.RenderTransformOrigin = new Point(0.5, 0.5);
+            carouselItem.Tag = "CarouselItem";
 
-            contentControl.IsTabStop = Items.IndexOf(item) == SelectedIndex;
-            contentControl.UseSystemFocusVisuals = true;
+            carouselItem.IsTabStop = Items.IndexOf(item) == SelectedIndex;
+            carouselItem.UseSystemFocusVisuals = true;
 
             PlaneProjection planeProjection = new PlaneProjection();
             planeProjection.CenterOfRotationX = 0.5;
@@ -487,8 +487,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             compositeTransform.CenterY = 0.5;
             compositeTransform.CenterY = 0.5;
 
-            contentControl.Projection = planeProjection;
-            contentControl.RenderTransform = compositeTransform;
+            carouselItem.Projection = planeProjection;
+            carouselItem.RenderTransform = compositeTransform;
         }
     }
 }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/Carousel/Carousel.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/Carousel/Carousel.cs
@@ -469,21 +469,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         {
             base.PrepareContainerForItemOverride(element, item);
 
-            FrameworkElement contentControl = element as ContentControl;
-
-            if (contentControl == null)
-            {
-                contentControl = element as FrameworkElement;
-            }
-            else if (ItemTemplate != null && (contentControl as ContentControl) != null)
-            {
-                ((ContentControl)contentControl).Content = ItemTemplate.LoadContent();
-            }
-
-            if (contentControl == null)
-            {
-                throw new InvalidCastException("Any element added to the Carousel should be at least a Control component");
-            }
+            var contentControl = (ContentControl)element;
 
             contentControl.DataContext = item;
             contentControl.Opacity = 1;

--- a/Microsoft.Toolkit.Uwp.UI.Controls/Carousel/Carousel.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/Carousel/Carousel.cs
@@ -471,7 +471,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
             var contentControl = (ContentControl)element;
 
-            contentControl.Opacity = 1;
             contentControl.RenderTransformOrigin = new Point(0.5, 0.5);
             contentControl.Tag = "CarouselItem";
 

--- a/Microsoft.Toolkit.Uwp.UI.Controls/Carousel/Carousel.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/Carousel/Carousel.cs
@@ -207,8 +207,23 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             {
                 var newValue = (int)e.NewValue == -1 ? null : carouselControl.Items[(int)e.NewValue];
                 var oldValue = e.OldValue == null ? null : carouselControl.Items.ElementAtOrDefault((int)e.OldValue);
+                if (oldValue != null)
+                {
+                    var item = (CarouselItem)carouselControl.ContainerFromIndex((int)e.OldValue);
+                    if (item != null)
+                    {
+                        item.IsSelected = false;
+                    }
+                }
+
                 if (newValue != null)
                 {
+                    var item = (CarouselItem)carouselControl.ContainerFromIndex((int)e.NewValue);
+                    if (item != null)
+                    {
+                        item.IsSelected = true;
+                    }
+
                     carouselControl.FocusContainerFromIndex((int)e.NewValue);
                 }
 
@@ -488,6 +503,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
             carouselItem.Projection = planeProjection;
             carouselItem.RenderTransform = compositeTransform;
+
+            if (item == SelectedItem)
+            {
+                carouselItem.IsSelected = true;
+            }
         }
     }
 }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/Carousel/Carousel.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/Carousel/Carousel.cs
@@ -216,7 +216,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                     }
                 }
 
-                bool isNewSelectedItem = carouselControl.SelectedItem != newValue
+                bool isNewSelectedItem = carouselControl.SelectedItem != newValue;
 
                 if (newValue != null)
                 {

--- a/Microsoft.Toolkit.Uwp.UI.Controls/Carousel/Carousel.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/Carousel/Carousel.cs
@@ -283,10 +283,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// <summary>
         /// Returns the container used for each item
         /// </summary>
-        /// <returns>Returns always a ContentControl</returns>
+        /// <returns>Returns always a CarouselItem</returns>
         protected override DependencyObject GetContainerForItemOverride()
         {
-            return new ContentControl();
+            return new CarouselItem();
         }
 
         /// <summary>
@@ -461,7 +461,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// <inheritdoc/>
         protected override bool IsItemItsOwnContainerOverride(object item)
         {
-            return false;
+            return item is CarouselItem;
         }
 
         /// <inheritdoc/>

--- a/Microsoft.Toolkit.Uwp.UI.Controls/Carousel/Carousel.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/Carousel/Carousel.cs
@@ -260,7 +260,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 newElem.Focus(oldElem != null && oldElem.FocusState != FocusState.Unfocused ? oldElem.FocusState : FocusState.Programmatic);
             }
 
-            if (oldElem != null && (string)oldElem.Tag == "CarouselItem")
+            if (oldElem != null && oldElem is CarouselItem)
             {
                 oldElem.IsTabStop = false;
             }
@@ -472,7 +472,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             var carouselItem = (CarouselItem)element;
 
             carouselItem.RenderTransformOrigin = new Point(0.5, 0.5);
-            carouselItem.Tag = "CarouselItem";
 
             carouselItem.IsTabStop = Items.IndexOf(item) == SelectedIndex;
             carouselItem.UseSystemFocusVisuals = true;

--- a/Microsoft.Toolkit.Uwp.UI.Controls/Carousel/Carousel.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/Carousel/Carousel.cs
@@ -476,11 +476,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             contentControl.RenderTransformOrigin = new Point(0.5, 0.5);
             contentControl.Tag = "CarouselItem";
 
-            if (contentControl as Control != null)
-            {
-                ((Control)contentControl).IsTabStop = Items.IndexOf(item) == SelectedIndex;
-                ((Control)contentControl).UseSystemFocusVisuals = true;
-            }
+            contentControl.IsTabStop = Items.IndexOf(item) == SelectedIndex;
+            contentControl.UseSystemFocusVisuals = true;
 
             PlaneProjection planeProjection = new PlaneProjection();
             planeProjection.CenterOfRotationX = 0.5;

--- a/Microsoft.Toolkit.Uwp.UI.Controls/Carousel/Carousel.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/Carousel/Carousel.cs
@@ -471,7 +471,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
             var contentControl = (ContentControl)element;
 
-            contentControl.DataContext = item;
             contentControl.Opacity = 1;
             contentControl.RenderTransformOrigin = new Point(0.5, 0.5);
             contentControl.Tag = "CarouselItem";

--- a/Microsoft.Toolkit.Uwp.UI.Controls/Carousel/Carousel.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/Carousel/Carousel.xaml
@@ -12,7 +12,9 @@
                                 <VisualState x:Name="Normal"/>
                                 <VisualState x:Name="Selected"/>
                                 <VisualState x:Name="PointerOver"/>
+                                <VisualState x:Name="PointerOverSelected"/>
                                 <VisualState x:Name="Pressed"/>
+                                <VisualState x:Name="PressedSelected"/>
                             </VisualStateGroup>
                             <VisualStateGroup x:Name="DisabledStates">
                                 <VisualState x:Name="Enabled"/>

--- a/Microsoft.Toolkit.Uwp.UI.Controls/Carousel/Carousel.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/Carousel/Carousel.xaml
@@ -7,7 +7,7 @@
             <Setter.Value>
                 <ControlTemplate TargetType="local:CarouselItem">
                     <Border BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}">
-                        <ContentPresenter ContentTemplate="{TemplateBinding ContentTemplate}" Content="{TemplateBinding Content}" Margin="{TemplateBinding Padding}"/>
+                        <ContentPresenter ContentTemplate="{TemplateBinding ContentTemplate}" Content="{TemplateBinding Content}" Margin="{TemplateBinding Padding}" ContentTransitions="{TemplateBinding ContentTransitions}"/>
                     </Border>
                 </ControlTemplate>
             </Setter.Value>

--- a/Microsoft.Toolkit.Uwp.UI.Controls/Carousel/Carousel.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/Carousel/Carousel.xaml
@@ -10,7 +10,9 @@
                         <ContentPresenter Content="{TemplateBinding Content}" 
                                           ContentTemplate="{TemplateBinding ContentTemplate}"
                                           ContentTransitions="{TemplateBinding ContentTransitions}"
-                                          Margin="{TemplateBinding Padding}" />
+                                          HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" 
+                                          Margin="{TemplateBinding Padding}" 
+                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
                     </Border>
                 </ControlTemplate>
             </Setter.Value>

--- a/Microsoft.Toolkit.Uwp.UI.Controls/Carousel/Carousel.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/Carousel/Carousel.xaml
@@ -7,7 +7,7 @@
             <Setter.Value>
                 <ControlTemplate TargetType="local:CarouselItem">
                     <Border BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}">
-                        <ContentPresenter Margin="{TemplateBinding Padding}"/>
+                        <ContentPresenter ContentTemplate="{TemplateBinding ContentTemplate}" Content="{TemplateBinding Content}" Margin="{TemplateBinding Padding}"/>
                     </Border>
                 </ControlTemplate>
             </Setter.Value>

--- a/Microsoft.Toolkit.Uwp.UI.Controls/Carousel/Carousel.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/Carousel/Carousel.xaml
@@ -6,14 +6,26 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="local:CarouselItem">
-                    <Border BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}">
+                    <Grid BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}">
+                        <VisualStateManager.VisualStateGroups>
+                            <VisualStateGroup x:Name="CommonStates">
+                                <VisualState x:Name="Normal"/>
+                                <VisualState x:Name="Selected"/>
+                                <VisualState x:Name="PointerOver"/>
+                                <VisualState x:Name="Pressed"/>
+                            </VisualStateGroup>
+                            <VisualStateGroup x:Name="DisabledStates">
+                                <VisualState x:Name="Enabled"/>
+                                <VisualState x:Name="Disabled"/>
+                            </VisualStateGroup>
+                        </VisualStateManager.VisualStateGroups>
                         <ContentPresenter Content="{TemplateBinding Content}" 
                                           ContentTemplate="{TemplateBinding ContentTemplate}"
                                           ContentTransitions="{TemplateBinding ContentTransitions}"
                                           HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" 
                                           Margin="{TemplateBinding Padding}" 
                                           VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
-                    </Border>
+                    </Grid>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>

--- a/Microsoft.Toolkit.Uwp.UI.Controls/Carousel/Carousel.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/Carousel/Carousel.xaml
@@ -7,7 +7,10 @@
             <Setter.Value>
                 <ControlTemplate TargetType="local:CarouselItem">
                     <Border BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}">
-                        <ContentPresenter ContentTemplate="{TemplateBinding ContentTemplate}" Content="{TemplateBinding Content}" Margin="{TemplateBinding Padding}" ContentTransitions="{TemplateBinding ContentTransitions}"/>
+                        <ContentPresenter Content="{TemplateBinding Content}" 
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          ContentTransitions="{TemplateBinding ContentTransitions}"
+                                          Margin="{TemplateBinding Padding}" />
                     </Border>
                 </ControlTemplate>
             </Setter.Value>

--- a/Microsoft.Toolkit.Uwp.UI.Controls/Carousel/Carousel.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/Carousel/Carousel.xaml
@@ -2,6 +2,18 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:local="using:Microsoft.Toolkit.Uwp.UI.Controls">
 
+    <Style TargetType="local:CarouselItem">
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="local:CarouselItem">
+                    <Border BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}">
+                        <ContentPresenter Margin="{TemplateBinding Padding}"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
     <Style TargetType="local:Carousel">
         <Setter Property="ItemsPanel">
             <Setter.Value>

--- a/Microsoft.Toolkit.Uwp.UI.Controls/Carousel/CarouselItem.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/Carousel/CarouselItem.cs
@@ -1,0 +1,31 @@
+﻿// ******************************************************************
+// Copyright (c) Microsoft. All rights reserved.
+// This code is licensed under the MIT License (MIT).
+// THE CODE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH
+// THE CODE OR THE USE OR OTHER DEALINGS IN THE CODE.
+// ******************************************************************
+
+using Windows.UI.Xaml.Controls;
+
+namespace Microsoft.Toolkit.Uwp.UI.Controls
+{
+    /// <summary>
+    /// Represents the container for an item in a Carousel control.
+    /// </summary>
+    public class CarouselItem : ContentControl
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CarouselItem"/> class.
+        /// </summary>
+        public CarouselItem()
+        {
+            // Set style
+            DefaultStyleKey = typeof(CarouselItem);
+        }
+    }
+}

--- a/Microsoft.Toolkit.Uwp.UI.Controls/Carousel/CarouselItem.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/Carousel/CarouselItem.cs
@@ -65,11 +65,21 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             VisualStateManager.GoToState(this, IsSelected ? PressedSelectedState : PressedState, true);
         }
 
+        internal event EventHandler Selected;
+
         private void OnIsSelectedChanged(DependencyObject sender, DependencyProperty dp)
         {
             var item = (CarouselItem)sender;
 
-            VisualStateManager.GoToState(item, item.IsSelected ? SelectedState : NormalState, true);
+            if (item.IsSelected)
+            {
+                Selected?.Invoke(this, EventArgs.Empty);
+                VisualStateManager.GoToState(item, SelectedState, true);
+            }
+            else
+            {
+                VisualStateManager.GoToState(item, NormalState, true);
+            }
         }
     }
 }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/Carousel/CarouselItem.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/Carousel/CarouselItem.cs
@@ -24,7 +24,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
     public class CarouselItem : SelectorItem
     {
         private const string PointerOverState = "PointerOver";
+        private const string PointerOverSelectedState = "PointerOverSelected";
         private const string PressedState = "Pressed";
+        private const string PressedSelectedState = "PressedSelected";
         private const string SelectedState = "Selected";
         private const string NormalState = "Normal";
 
@@ -44,7 +46,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         {
             base.OnPointerEntered(e);
 
-            VisualStateManager.GoToState(this, PointerOverState, true);
+            VisualStateManager.GoToState(this, IsSelected ? PointerOverSelectedState : PointerOverState, true);
         }
 
         /// <inheritdoc/>
@@ -60,7 +62,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         {
             base.OnPointerPressed(e);
 
-            VisualStateManager.GoToState(this, PressedState, true);
+            VisualStateManager.GoToState(this, IsSelected ? PressedSelectedState : PressedState, true);
         }
 
         private void OnIsSelectedChanged(DependencyObject sender, DependencyProperty dp)

--- a/Microsoft.Toolkit.Uwp.UI.Controls/Carousel/CarouselItem.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/Carousel/CarouselItem.cs
@@ -10,15 +10,24 @@
 // THE CODE OR THE USE OR OTHER DEALINGS IN THE CODE.
 // ******************************************************************
 
+using System;
+using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Input;
 
 namespace Microsoft.Toolkit.Uwp.UI.Controls
 {
     /// <summary>
     /// Represents the container for an item in a Carousel control.
     /// </summary>
-    public class CarouselItem : ContentControl
+    public class CarouselItem : SelectorItem
     {
+        private const string PointerOverState = "PointerOver";
+        private const string PressedState = "Pressed";
+        private const string SelectedState = "Selected";
+        private const string NormalState = "Normal";
+
         /// <summary>
         /// Initializes a new instance of the <see cref="CarouselItem"/> class.
         /// </summary>
@@ -26,6 +35,39 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         {
             // Set style
             DefaultStyleKey = typeof(CarouselItem);
+
+            RegisterPropertyChangedCallback(SelectorItem.IsSelectedProperty, OnIsSelectedChanged);
+        }
+
+        /// <inheritdoc/>
+        protected override void OnPointerEntered(PointerRoutedEventArgs e)
+        {
+            base.OnPointerEntered(e);
+
+            VisualStateManager.GoToState(this, PointerOverState, true);
+        }
+
+        /// <inheritdoc/>
+        protected override void OnPointerExited(PointerRoutedEventArgs e)
+        {
+            base.OnPointerExited(e);
+
+            VisualStateManager.GoToState(this, IsSelected ? SelectedState : NormalState, true);
+        }
+
+        /// <inheritdoc/>
+        protected override void OnPointerPressed(PointerRoutedEventArgs e)
+        {
+            base.OnPointerPressed(e);
+
+            VisualStateManager.GoToState(this, PressedState, true);
+        }
+
+        private void OnIsSelectedChanged(DependencyObject sender, DependencyProperty dp)
+        {
+            var item = (CarouselItem)sender;
+
+            VisualStateManager.GoToState(item, item.IsSelected ? SelectedState : NormalState, true);
         }
     }
 }


### PR DESCRIPTION
Issue: #1233
<!-- Link to relevant issue. All PRs should be asociated with an issue -->

## PR Type


<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[x] Feature
[ ] Code style update (formatting)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build or CI related changes
[ ] Documentation content changes
[ ] Sample app changes
[ ] Other... Please describe:
```


## What is the current behavior?
The Carousel currently creates ContentControl elements to host content which makes it hard to change the style of the items. In particular are selection and pointer visual state


## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://raw.githubusercontent.com/Microsoft/UWPCommunityToolkit/tree/master/docs/.template.md). (for bug fixes / features)
- [x] Sample in sample app has been added / updated (for bug fixes / features)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)


## What is the new behavior?
Carousel now creates a CarouselItem control for each item. The CarouselItem has visual states for pointer and selection. These states are empty to provide the same functionality that is currently in place.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->