### PR TITLE
Update style of RangeSelector to match the style of Slider

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/RangeSelector/RangeSelector.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/RangeSelector/RangeSelector.xaml
@@ -3,30 +3,29 @@
                     xmlns:controls="using:Microsoft.Toolkit.Uwp.UI.Controls">
 
     <Style TargetType="controls:RangeSelector">
-        <Setter Property="Background" Value="{ThemeResource SystemControlForegroundBaseMediumLowBrush}" />
-        <Setter Property="Foreground" Value="{ThemeResource SystemControlHighlightAccentBrush}" />
+        <Setter Property="Background" Value="{ThemeResource SliderTrackFill}"/>
+        <Setter Property="BorderThickness" Value="{ThemeResource SliderBorderThemeThickness}"/>
+        <Setter Property="Foreground" Value="{ThemeResource SliderTrackValueFill}"/>
+        <Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}"/>
+        <Setter Property="FontSize" Value="{ThemeResource ControlContentThemeFontSize}"/>
+        <Setter Property="UseSystemFocusVisuals" Value="True"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="controls:RangeSelector">
                     <Grid x:Name="ControlGrid" Height="24" >
                         <Grid.Resources>
-                            <Style x:Key="SliderThumbStyle"
-                                   TargetType="Thumb">
-                                <Setter Property="UseSystemFocusVisuals" Value="True" />
-                                <Setter Property="BorderThickness" Value="0" />
-                                <Setter Property="Background" Value="{ThemeResource SystemControlForegroundAccentBrush}" />                              
+                            <Style x:Key="SliderThumbStyle" TargetType="Thumb">
+                                <Setter Property="BorderThickness" Value="0"/>
+                                <Setter Property="Background" Value="{ThemeResource SliderThumbBackground}"/>
+                                <Setter Property="Height" Value="24"/>
+                                <Setter Property="Width" Value="8"/>
                                 <Setter Property="Template">
                                     <Setter.Value>
                                         <ControlTemplate TargetType="Thumb">
-                                            <Grid Background="Transparent">
-                                                <Border Width="8"
-                                                    Height="24"                                                    
-                                                    HorizontalAlignment="Center"
-                                                    Background="{TemplateBinding Background}"
-                                                    BorderBrush="{TemplateBinding BorderBrush}"
-                                                    BorderThickness="{TemplateBinding BorderThickness}"
-                                                    CornerRadius="4" />
-                                            </Grid>
+                                            <Border Background="{TemplateBinding Background}" 
+                                                    BorderThickness="{TemplateBinding BorderThickness}" 
+                                                    BorderBrush="{TemplateBinding BorderBrush}" 
+                                                    CornerRadius="4"/>
                                         </ControlTemplate>
                                     </Setter.Value>
                                 </Setter>
@@ -34,14 +33,13 @@
                         </Grid.Resources>
 
                         <Border x:Name="OutOfRangeContentContainer"                                 
-                                Margin="12,0"
                                 Background="Transparent">
                             <Rectangle x:Name="BackgroundElement"
                                        Height="2"
                                        Fill="{TemplateBinding Background}" />
                         </Border>
                         <Canvas x:Name="ContainerCanvas"
-                                Margin="12,0"
+                                Margin="0,0,8,0"
                                 Background="Transparent">
                             <Rectangle x:Name="ActiveRectangle"                                                                     
                                        Height="2"
@@ -49,13 +47,11 @@
                                        Fill="{TemplateBinding Foreground}" />
                             <Thumb x:Name="MinThumb"
                                    AutomationProperties.Name="Min thumb"
-                                   Background="{TemplateBinding Foreground}"
                                    IsTabStop="True" 
                                    Style="{StaticResource SliderThumbStyle}"
                                    TabIndex="0" />
                             <Thumb x:Name="MaxThumb"
                                    AutomationProperties.Name="Max thumb"
-                                   Background="{TemplateBinding Foreground}"
                                    IsTabStop="True"
                                    Style="{StaticResource SliderThumbStyle}"
                                    TabIndex="1" />

--- a/Microsoft.Toolkit.Uwp.UI.Controls/RangeSelector/RangeSelector.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/RangeSelector/RangeSelector.xaml
@@ -8,13 +8,13 @@
         <Setter Property="Foreground" Value="{ThemeResource SliderTrackValueFill}"/>
         <Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}"/>
         <Setter Property="FontSize" Value="{ThemeResource ControlContentThemeFontSize}"/>
-        <Setter Property="UseSystemFocusVisuals" Value="True"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="controls:RangeSelector">
                     <Grid x:Name="ControlGrid" Height="24" >
                         <Grid.Resources>
                             <Style x:Key="SliderThumbStyle" TargetType="Thumb">
+                                <Setter Property="UseSystemFocusVisuals" Value="True"/>
                                 <Setter Property="BorderThickness" Value="0"/>
                                 <Setter Property="Background" Value="{ThemeResource SliderThumbBackground}"/>
                                 <Setter Property="Height" Value="24"/>


### PR DESCRIPTION
Issue: #1769
<!-- Link to relevant issue. All PRs should be asociated with an issue -->

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[x] Feature
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Style of the RangeSelector is not consistent with the style of the Slider control

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://raw.githubusercontent.com/Microsoft/UWPCommunityToolkit/tree/master/docs/.template.md). (for bug fixes / features)

## What is the new behavior?
Style now is consistent with that of the Slider. Thumbs match theme color and will rest in the same position
![image](https://user-images.githubusercontent.com/1594689/35347748-4d9083b6-00f3-11e8-8fee-5c3342837f9f.png)

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
