### PR TITLE
Update RadialGauge to use theme resources

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/RadialGauge/RadialGaugeCode.bind
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/RadialGauge/RadialGaugeCode.bind
@@ -28,8 +28,6 @@
                   Unit="Units"
                   TickBrush="Gainsboro"
                   ScaleTickBrush="{ThemeResource ApplicationPageBackgroundThemeBrush}"
-                  UnitBrush="Black"
-                  ValueBrush="Black" 
                   NeedleWidth="@[NeedleWidth:Slider:5:1-10]" 
                   TickLength="@[TickLength:Slider:18:0-30]" />
           </Grid>

--- a/Microsoft.Toolkit.Uwp.UI.Controls/RadialGauge/RadialGauge.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/RadialGauge/RadialGauge.cs
@@ -112,14 +112,16 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// <summary>
         /// Identifies the ValueBrush dependency property.
         /// </summary>
+        [Obsolete("This property has been deprecated. Use the Foreground property or the RadialGaugeForegroundBrush ThemeResource instead")]
         public static readonly DependencyProperty ValueBrushProperty =
-            DependencyProperty.Register(nameof(ValueBrush), typeof(Brush), typeof(RadialGauge), new PropertyMetadata(new SolidColorBrush(Colors.White)));
+            DependencyProperty.Register(nameof(ValueBrush), typeof(Brush), typeof(RadialGauge), new PropertyMetadata(new SolidColorBrush(Colors.White), OnValueBrushChanged));
 
         /// <summary>
         /// Identifies the UnitBrush dependency property.
         /// </summary>
+        [Obsolete("This property has been deprecated. Use the RadialGaugeAccentBrush ThemeResource instead")]
         public static readonly DependencyProperty UnitBrushProperty =
-            DependencyProperty.Register(nameof(UnitBrush), typeof(Brush), typeof(RadialGauge), new PropertyMetadata(new SolidColorBrush(Colors.White)));
+            DependencyProperty.Register(nameof(UnitBrush), typeof(Brush), typeof(RadialGauge), new PropertyMetadata(new SolidColorBrush(Colors.White), OnUnitBrushChanged));
 
         /// <summary>
         /// Identifies the ValueStringFormat dependency property.
@@ -348,6 +350,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// <summary>
         /// Gets or sets the brush for the displayed value.
         /// </summary>
+        [Obsolete("This property has been depracated. Use the Foreground property or the RadialGaugeForegroundBrush ThemeResource instead")]
         public Brush ValueBrush
         {
             get { return (Brush)GetValue(ValueBrushProperty); }
@@ -357,6 +360,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// <summary>
         /// Gets or sets the brush for the displayed unit measure.
         /// </summary>
+        [Obsolete("This property has been depracated. Use the RadialGaugeAccentBrush ThemeResource instead")]
         public Brush UnitBrush
         {
             get { return (Brush)GetValue(UnitBrushProperty); }
@@ -632,6 +636,18 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             {
                 OnFaceChanged(d);
             }
+        }
+
+        private static void OnValueBrushChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            var gauge = (RadialGauge)d;
+            gauge.Foreground = (Brush)e.NewValue;
+        }
+
+        private static void OnUnitBrushChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            var gauge = (RadialGauge)d;
+            gauge.Resources["RadialGaugeAccentBrush"] = (Brush)e.NewValue;
         }
 
         private static void OnFaceChanged(DependencyObject d)

--- a/Microsoft.Toolkit.Uwp.UI.Controls/RadialGauge/RadialGauge.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/RadialGauge/RadialGauge.xaml
@@ -2,8 +2,21 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:local="using:Microsoft.Toolkit.Uwp.UI.Controls">
 
+    <ResourceDictionary.ThemeDictionaries>
+        <ResourceDictionary x:Key="Default"/>
+        <ResourceDictionary x:Key="Light">
+            <SolidColorBrush x:Key="RadialGaugeForegroundBrush" Color="Black" />
+            <SolidColorBrush x:Key="RadialGaugeAccentBrush" Color="Black" />
+        </ResourceDictionary>
+        <ResourceDictionary x:Key="Dark">
+            <SolidColorBrush x:Key="RadialGaugeForegroundBrush" Color="White" />
+            <SolidColorBrush x:Key="RadialGaugeAccentBrush" Color="White" />
+        </ResourceDictionary>
+    </ResourceDictionary.ThemeDictionaries>
+    
     <Style TargetType="local:RadialGauge">
         <Setter Property="UseSystemFocusVisuals" Value="True"></Setter>
+        <Setter Property="Foreground" Value="{ThemeResource RadialGaugeForegroundBrush}"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="local:RadialGauge">
@@ -30,12 +43,12 @@
                                            Margin="0,0,0,2"
                                            FontSize="20"
                                            FontWeight="SemiBold"
-                                           Foreground="{TemplateBinding ValueBrush}"
+                                           Foreground="{TemplateBinding Foreground}"
                                            Text="{TemplateBinding Value}"
                                            TextAlignment="Center" />
                                 <TextBlock Margin="0"
                                            FontSize="16"
-                                           Foreground="{TemplateBinding UnitBrush}"
+                                           Foreground="{ThemeResource RadialGaugeAccentBrush}"
                                            Text="{TemplateBinding Unit}"
                                            TextAlignment="Center" />
                             </StackPanel>


### PR DESCRIPTION
Issue: #1766
<!-- Link to relevant issue. All PRs should be asociated with an issue -->

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[x] Sample app changes
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The RadialGauge text does not update properly when the theme changes

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://raw.githubusercontent.com/Microsoft/UWPCommunityToolkit/tree/master/docs/.template.md). (for bug fixes / features)
- [x] Sample in sample app has been added / updated (for bug fixes / features)

## What is the new behavior?
The text will update when the theme changes from light-dark or dark-light

## Does this PR introduce a breaking change?
```
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
Two properties were made obsolete with this change but still maintains functionality.