### PR TITLE
Added support for connected animations from multiple ListViewBases.

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Animations/ConnectedAnimations/ConnectedAnimationHelper.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Animations/ConnectedAnimations/ConnectedAnimationHelper.cs
@@ -61,7 +61,14 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
             {
                 if (props.IsListAnimation && parameter != null && ApiInformationHelper.IsCreatorsUpdateOrAbove)
                 {
-                    props.ListViewBase.PrepareConnectedAnimation(props.Key, e.Parameter, props.ElementName);
+                    foreach (var listAnimProperty in props.ListAnimProperties)
+                    {
+                        if (listAnimProperty.ListViewBase.ItemsSource is IEnumerable<object> items &&
+                            items.Contains(e.Parameter))
+                        {
+                            listAnimProperty.ListViewBase.PrepareConnectedAnimation(props.Key, e.Parameter, listAnimProperty.ElementName);
+                        }
+                    }
                 }
                 else if (!props.IsListAnimation)
                 {
@@ -114,22 +121,28 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
                     {
                         if (props.IsListAnimation && parameter != null && ApiInformationHelper.IsCreatorsUpdateOrAbove)
                         {
-                            props.ListViewBase.ScrollIntoView(parameter);
-
-                            // give time to the UI thread to scroll the list
-                            var t = props.ListViewBase.Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, async () =>
+                            foreach (var listAnimProperty in props.ListAnimProperties)
                             {
-                                try
+                                if (listAnimProperty.ListViewBase.ItemsSource is IEnumerable<object> items && items.Contains(parameter))
                                 {
-                                    var success = await props.ListViewBase.TryStartConnectedAnimationAsync(connectedAnimation, parameter, props.ElementName);
-                                }
-                                catch (Exception)
-                                {
-                                    connectedAnimation.Cancel();
-                                }
-                            });
+                                    listAnimProperty.ListViewBase.ScrollIntoView(parameter);
 
-                            animationHandled = true;
+                                    // give time to the UI thread to scroll the list
+                                    var t = listAnimProperty.ListViewBase.Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, async () =>
+                                    {
+                                        try
+                                        {
+                                            var success = await listAnimProperty.ListViewBase.TryStartConnectedAnimationAsync(connectedAnimation, parameter, listAnimProperty.ElementName);
+                                        }
+                                        catch (Exception)
+                                        {
+                                            connectedAnimation.Cancel();
+                                        }
+                                    });
+
+                                    animationHandled = true;
+                                }
+                            }
                         }
                         else if (!props.IsListAnimation)
                         {

--- a/Microsoft.Toolkit.Uwp.UI.Animations/ConnectedAnimations/ConnectedAnimationListProperty.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Animations/ConnectedAnimations/ConnectedAnimationListProperty.cs
@@ -1,4 +1,4 @@
-// ******************************************************************
+﻿// ******************************************************************
 // Copyright (c) Microsoft. All rights reserved.
 // This code is licensed under the MIT License (MIT).
 // THE CODE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
@@ -10,19 +10,12 @@
 // THE CODE OR THE USE OR OTHER DEALINGS IN THE CODE.
 // ******************************************************************
 
-using System.Collections.Generic;
-using Windows.UI.Xaml;
-
 namespace Microsoft.Toolkit.Uwp.UI.Animations
 {
-    internal class ConnectedAnimationProperties
+    internal class ConnectedAnimationListProperty
     {
-        public string Key { get; set; }
+        public string ElementName { get; set; }
 
-        public UIElement Element { get; set; }
-
-        public List<ConnectedAnimationListProperty> ListAnimProperties { get; set; }
-
-        public bool IsListAnimation => ListAnimProperties != null;
+        public Windows.UI.Xaml.Controls.ListViewBase ListViewBase { get; set; }
     }
 }


### PR DESCRIPTION
Issue: #1774

## PR Type
What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build or CI related changes
[ ] Documentation content changes
[ ] Sample app changes
[ ] Other... Please describe:
```


## What is the current behavior?
#1774


## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://raw.githubusercontent.com/Microsoft/UWPCommunityToolkit/tree/master/docs/.template.md). (for bug fixes / features)
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/Microsoft/UWPCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)


## What is the new behavior?
The scenario now is supported. You can use the same key for any ListViewBase and it will animate to the correct one.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
