### PR TITLE
Fix for HamburgerMenu SelectedItem on control loading

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/HamburgerMenu/HamburgerMenu.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/HamburgerMenu/HamburgerMenu.cs
@@ -124,6 +124,15 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 _navigationView = navView;
 
                 OnItemsSourceChanged(this, null);
+
+                if (SelectedItem != null)
+                {
+                    NavViewSetSelectedItem(SelectedItem);
+                }
+                else if (SelectedOptionsItem != null)
+                {
+                    NavViewSetSelectedItem(SelectedOptionsItem);
+                }
             }
         }
 

--- a/Microsoft.Toolkit.Uwp.UI.Controls/HamburgerMenu/HamburgerMenuTemplate.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/HamburgerMenu/HamburgerMenuTemplate.xaml
@@ -119,7 +119,6 @@
                                               ScrollViewer.VerticalScrollBarVisibility="Auto"
                                               SelectedIndex="{Binding SelectedIndex, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
                                               SelectedItem="{Binding SelectedItem, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
-                                              SelectionMode="Single"
                                               TabIndex="1">
                         </ListView>
                         <ListView x:Name="OptionsListView"
@@ -135,7 +134,6 @@
                                               ScrollViewer.VerticalScrollBarVisibility="Disabled"
                                               SelectedIndex="{Binding SelectedOptionsIndex, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
                                               SelectedItem="{Binding SelectedOptionsItem, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
-                                              SelectionMode="Single"
                                               TabIndex="2"
                                               Margin="0,20,0,8">
                         </ListView>


### PR DESCRIPTION
Issue: #1730
<!-- Link to relevant issue. All PRs should be asociated with an issue -->

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
```


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
See Issue: #1730

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)

## What is the new behavior?
The initial item is selected when the control loads.

For the non-NavView template. No idea why the SelectionMode was causing the selectedItem to be set to null on loading. I verified the issue with a minimal repro (templated control with an empty listview), seems like a platform bug, especially since the default value for SelectionMode is the same.

For the NavView template, the control was attempting to set the value of SelectedItem before OnApplyTemplate.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
