### PR TITLE
Fix typo where doc refers Single-Process Model as MPM instead of SPM

### DIFF
--- a/docs/helpers/BackgroundTaskHelper.md
+++ b/docs/helpers/BackgroundTaskHelper.md
@@ -53,7 +53,7 @@ Once it is done, you can register your Background Tasks.
 
 ### Using Single-Process Model
 
-Using MPM (Single-Process Model) is the new and simple way of using Background Task.
+Using SPM (Single-Process Model) is the new and simple way of using Background Task.
 It is required to target Anniversary Update (SDK 14393) or later.
 
 Using SPM, you can declare your Background Tasks inside your own project, no need to create a Windows Runtime Component.


### PR DESCRIPTION
Issue: Fixes a small typo in doc for `Background Task` where it refers `Single-Process Model` as `MPM` instead of `SPM`

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build or CI related changes
[X] Documentation content changes
[ ] Sample app changes
[ ] Other... Please describe:
```


## What is the current behavior?
The doc says `Using MPM (Single-Process Model) is the new and simple way of using Background Task` instead of `Using SPM (Single-Process Model) is the new and simple way of using Background Task`

## PR Checklist
Please check if your PR fulfills the following requirements:

- [] Tested code with current [supported SDKs](../readme.md#supported)
- [] Docs have been added/updated which fit [documentation template](https://raw.githubusercontent.com/Microsoft/UWPCommunityToolkit/tree/master/docs/.template.md). (for bug fixes / features)
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/Microsoft/UWPCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)


## What is the new behavior?
The doc now says `Using SPM (Single-Process Model) is the new and simple way of using Background Task`

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
