### PR TITLE
AdaptiveGridView fix when HorizontalAlignment is not stretch

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveGridView.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveGridView.cs
@@ -233,7 +233,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             if (containerWidth > 0)
             {
                 var newWidth = CalculateItemWidth(containerWidth);
-                ItemWidth = Math.Floor(newWidth - 1);
+                ItemWidth = Math.Floor(newWidth);
             }
         }
     }


### PR DESCRIPTION
Issue: #1737
<!-- Link to relevant issue. All PRs should be asociated with an issue -->

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
```


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Application will crash when HorizontalAlignment is set to anything but stretch

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)

## What is the new behavior?
Do not subtract one from the new width. This causes the SizeChanged event to endlessly fire when the HorizontalAlignment is not Stretch because the width is continually shrinking.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
Related to and caused by #1552