### PR TITLE
Fix layout when Margin of GridViewItem is not zero

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveGridView.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveGridView.cs
@@ -49,14 +49,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             Items.VectorChanged += ItemsOnVectorChanged;
             Loaded += OnLoaded;
             Unloaded += OnUnloaded;
-
-            // Define ItemContainerStyle in code rather than using the DefaultStyle
-            // to avoid having to define the entire style of a GridView. This can still
-            // be set by the enduser to values of their chosing
-            var style = new Style(typeof(GridViewItem));
-            style.Setters.Add(new Setter(HorizontalContentAlignmentProperty, HorizontalAlignment.Stretch));
-            style.Setters.Add(new Setter(VerticalContentAlignmentProperty, VerticalAlignment.Stretch));
-            ItemContainerStyle = style;
         }
 
         /// <summary>
@@ -85,6 +77,12 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
 
                 element.SetBinding(HeightProperty, heightBinding);
                 element.SetBinding(WidthProperty, widthBinding);
+            }
+
+            if (obj is ContentControl contentControl)
+            {
+                contentControl.HorizontalContentAlignment = HorizontalAlignment.Stretch;
+                contentControl.VerticalContentAlignment = VerticalAlignment.Stretch;
             }
         }
 

--- a/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveGridView.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveGridView.cs
@@ -107,7 +107,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 columns = Items.Count;
             }
 
-            return containerWidth / columns;
+            // subtract the margin from the width so we place the correct width for placement
+            var itemMargin = AdaptiveHeightValueConverter.GetItemMargin(this, new Thickness(0, 0, 4, 4));
+            return (containerWidth / columns) - itemMargin.Left - itemMargin.Right;
         }
 
         /// <summary>

--- a/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveGridView.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveGridView.cs
@@ -116,7 +116,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             if (itemMargin == fallbackThickness)
             {
                 // No style explicitly defined, or no items or no container for the items
-                // We need to get an actual for proper layout
+                // We need to get an actual margin for proper layout
                 _needContainerMarginForLayout = true;
             }
 

--- a/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveGridView.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveGridView.cs
@@ -56,8 +56,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             var style = new Style(typeof(GridViewItem));
             style.Setters.Add(new Setter(HorizontalContentAlignmentProperty, HorizontalAlignment.Stretch));
             style.Setters.Add(new Setter(VerticalContentAlignmentProperty, VerticalAlignment.Stretch));
-            style.Setters.Add(new Setter(MarginProperty, new Thickness(0, 0, 0, 4)));
-            style.Setters.Add(new Setter(PaddingProperty, new Thickness(2, 0, 2, 0)));
             ItemContainerStyle = style;
         }
 

--- a/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveGridView.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveGridView.cs
@@ -37,6 +37,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         private ScrollBarVisibility _savedHorizontalScrollBarVisibility;
         private Orientation _savedOrientation;
         private bool _needToRestoreScrollStates;
+        private bool _needContainerMarginForLayout;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AdaptiveGridView"/> class.
@@ -84,6 +85,12 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 contentControl.HorizontalContentAlignment = HorizontalAlignment.Stretch;
                 contentControl.VerticalContentAlignment = VerticalAlignment.Stretch;
             }
+
+            if (_needContainerMarginForLayout)
+            {
+                _needContainerMarginForLayout = false;
+                RecalculateLayout(ActualWidth);
+            }
         }
 
         /// <summary>
@@ -104,7 +111,15 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             }
 
             // subtract the margin from the width so we place the correct width for placement
-            var itemMargin = AdaptiveHeightValueConverter.GetItemMargin(this, new Thickness(0, 0, 4, 4));
+            var fallbackThickness = default(Thickness);
+            var itemMargin = AdaptiveHeightValueConverter.GetItemMargin(this, fallbackThickness);
+            if (itemMargin == fallbackThickness)
+            {
+                // No style explicitly defined, or no items or no container for the items
+                // We need to get an actual for proper layout
+                _needContainerMarginForLayout = true;
+            }
+
             return (containerWidth / columns) - itemMargin.Left - itemMargin.Right;
         }
 

--- a/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveHeightValueConverter.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveHeightValueConverter.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 double.TryParse(value.ToString(), out double height);
 
                 var padding = gridView.Padding;
-                var margin = GetItemMargin(gridView);
+                var margin = GetItemMargin(gridView, DefaultItemMargin);
                 height = height + margin.Top + margin.Bottom + padding.Top + padding.Bottom;
 
                 return height;
@@ -55,7 +55,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             throw new NotImplementedException();
         }
 
-        private Thickness GetItemMargin(GridView view)
+        internal static Thickness GetItemMargin(GridView view, Thickness fallback = default(Thickness))
         {
             var setter = view.ItemContainerStyle?.Setters.OfType<Setter>().FirstOrDefault(s => s.Property == FrameworkElement.MarginProperty);
             if (setter != null)
@@ -74,7 +74,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 }
 
                 // Use the default thickness for a GridViewItem
-                return DefaultItemMargin;
+                return fallback;
             }
         }
     }


### PR DESCRIPTION
Issue: #1739
<!-- Link to relevant issue. All PRs should be asociated with an issue -->

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[x] Feature
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
If you define an ItemContainerStyle for the AdaptiveGridView and do not define a Margin, or if the Margin is different from what is defined by the AdaptiveGridView then items will not span the entire width of the control.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://raw.githubusercontent.com/Microsoft/UWPCommunityToolkit/tree/master/docs/.template.md). (for bug fixes / features)

## What is the new behavior?
You can now define an ItemContainerStyle that does not define a Margin or a Margin different from the default and items will still layout properly

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
NOTE: This change has an added benefit that the AdaptiveGridView can now take advantage of an implicit style defined for a GridViewItem. This change removes the hard coded ItemContainerStyle which was preventing implicit styles to be used.