### PR TITLE
Revert implicit animations on Expander control

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/Expander/Expander.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/Expander/Expander.xaml
@@ -282,8 +282,6 @@
                             <VisualStateGroup x:Name="DisplayModeAndDirectionStates">
                                 <VisualState x:Name="VisibleLeft">
                                     <VisualState.Setters>
-                                        <Setter Target="PART_MainContent.Visibility" Value="Visible" />
-
                                         <Setter Target="PART_LayoutTransformer.(Grid.Row)" Value="0" />
                                         <Setter Target="PART_LayoutTransformer.(Grid.RowSpan)" Value="2" />
                                         <Setter Target="PART_LayoutTransformer.(Grid.Column)" Value="1" />
@@ -293,7 +291,6 @@
                                         <Setter Target="PART_MainContent.(Grid.RowSpan)" Value="2" />
                                         <Setter Target="PART_MainContent.(Grid.Column)" Value="0" />
                                         <Setter Target="PART_MainContent.(Grid.ColumnSpan)" Value="1" />
-                                        <Setter Target="PART_MainContent.(extensions:VisualEx.NormalizedCenterPoint)" Value="1,0,0" />
 
                                         <Setter Target="PART_ContentOverlay.(Grid.Row)" Value="0" />
                                         <Setter Target="PART_ContentOverlay.(Grid.RowSpan)" Value="2" />
@@ -328,7 +325,6 @@
                                 </VisualState>
                                 <VisualState x:Name="VisibleDown">
                                     <VisualState.Setters>
-                                        <Setter Target="PART_MainContent.Visibility" Value="Visible" />
                                     </VisualState.Setters>
 
                                     <Storyboard>
@@ -350,8 +346,6 @@
                                 </VisualState>
                                 <VisualState x:Name="VisibleRight">
                                     <VisualState.Setters>
-                                        <Setter Target="PART_MainContent.Visibility" Value="Visible" />
-
                                         <Setter Target="PART_LayoutTransformer.(Grid.Row)" Value="0" />
                                         <Setter Target="PART_LayoutTransformer.(Grid.RowSpan)" Value="2" />
                                         <Setter Target="PART_LayoutTransformer.(Grid.Column)" Value="0" />
@@ -390,8 +384,6 @@
                                 </VisualState>
                                 <VisualState x:Name="VisibleUp">
                                     <VisualState.Setters>
-                                        <Setter Target="PART_MainContent.Visibility" Value="Visible" />
-
                                         <Setter Target="PART_LayoutTransformer.(Grid.Row)" Value="1" />
                                         <Setter Target="PART_LayoutTransformer.(Grid.RowSpan)" Value="1" />
                                         <Setter Target="PART_LayoutTransformer.(Grid.Column)" Value="0" />
@@ -411,6 +403,8 @@
                                         <Setter Target="RowTwo.Height" Value="Auto" />
 
                                         <Setter Target="RotateLayoutTransform.Angle" Value="0" />
+
+                                        <Setter Target="PART_MainContent.RenderTransformOrigin" Value="0.5, 1" />
                                     </VisualState.Setters>
 
                                     <Storyboard>
@@ -442,7 +436,6 @@
                                         <Setter Target="PART_MainContent.(Grid.RowSpan)" Value="2" />
                                         <Setter Target="PART_MainContent.(Grid.Column)" Value="0" />
                                         <Setter Target="PART_MainContent.(Grid.ColumnSpan)" Value="1" />
-                                        <Setter Target="PART_MainContent.(extensions:VisualEx.NormalizedCenterPoint)" Value="1,0,0" />
 
                                         <Setter Target="PART_ContentOverlay.(Grid.Row)" Value="0" />
                                         <Setter Target="PART_ContentOverlay.(Grid.RowSpan)" Value="2" />
@@ -453,6 +446,8 @@
 
                                         <Setter Target="ColumnOne.Width" Value="*" />
                                         <Setter Target="ColumnTwo.Width" Value="Auto" />
+
+                                        <Setter Target="PART_MainContent.RenderTransformOrigin" Value="1, 0.5" />
 
                                     </VisualState.Setters>
 
@@ -488,8 +483,6 @@
                                 </VisualState>
                                 <VisualState x:Name="CollapsedRight">
                                     <VisualState.Setters>
-                                        <Setter Target="PART_MainContent.Visibility" Value="Collapsed"></Setter>
-
                                         <Setter Target="PART_LayoutTransformer.(Grid.Row)" Value="0" />
                                         <Setter Target="PART_LayoutTransformer.(Grid.RowSpan)" Value="2" />
                                         <Setter Target="PART_LayoutTransformer.(Grid.Column)" Value="0" />
@@ -543,6 +536,8 @@
                                         <Setter Target="RowTwo.Height" Value="Auto" />
 
                                         <Setter Target="RotateLayoutTransform.Angle" Value="0" />
+
+                                        <Setter Target="PART_MainContent.RenderTransformOrigin" Value="0.5, 1" />
                                     </VisualState.Setters>
 
                                     <Storyboard>
@@ -589,8 +584,6 @@
                                   Grid.Column="0" 
                                   Grid.ColumnSpan="2"
                                   x:Name="PART_MainContent"
-                                  Visibility="Collapsed"
-                                  extensions:VisualEx.NormalizedCenterPoint="0"
                                   Background="{TemplateBinding Background}">
 
                                 <ContentPresenter x:Name="ContentPresenter"

--- a/Microsoft.Toolkit.Uwp.UI.Controls/Expander/Expander.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/Expander/Expander.xaml
@@ -462,6 +462,10 @@
                                         <DoubleAnimation Storyboard.TargetName="PART_MainContent"
                                                          Storyboard.TargetProperty="(UIElement.RenderTransform).(ScaleTransform.ScaleY)"
                                                          Duration="0:0:0.2" To="1" />
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PART_MainContent" 
+                                                                       Storyboard.TargetProperty="(UIElement.Visibility)">
+                                            <DiscreteObjectKeyFrame KeyTime="0:0:0.2" Value="Collapsed"/>
+                                        </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                 </VisualState>
                                 <VisualState x:Name="CollapsedDown">
@@ -479,6 +483,10 @@
                                         <DoubleAnimation Storyboard.TargetName="PART_MainContent"
                                                          Storyboard.TargetProperty="(UIElement.RenderTransform).(ScaleTransform.ScaleY)"
                                                          Duration="0:0:0.2" From="1" To="0" />
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PART_MainContent" 
+                                                                       Storyboard.TargetProperty="(UIElement.Visibility)">
+                                            <DiscreteObjectKeyFrame KeyTime="0:0:0.2" Value="Collapsed"/>
+                                        </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                 </VisualState>
                                 <VisualState x:Name="CollapsedRight">
@@ -513,6 +521,10 @@
                                         <DoubleAnimation Storyboard.TargetName="PART_MainContent"
                                                          Storyboard.TargetProperty="(UIElement.RenderTransform).(ScaleTransform.ScaleY)"
                                                          Duration="0:0:0.2" To="1" />
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PART_MainContent" 
+                                                                       Storyboard.TargetProperty="(UIElement.Visibility)">
+                                            <DiscreteObjectKeyFrame KeyTime="0:0:0.2" Value="Collapsed"/>
+                                        </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                 </VisualState>
                                 <VisualState x:Name="CollapsedUp">
@@ -551,6 +563,10 @@
                                         <DoubleAnimation Storyboard.TargetName="PART_MainContent"
                                                          Storyboard.TargetProperty="(UIElement.RenderTransform).(ScaleTransform.ScaleY)"
                                                          Duration="0:0:0.2" From="1" To="0" />
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PART_MainContent" 
+                                                                       Storyboard.TargetProperty="(UIElement.Visibility)">
+                                            <DiscreteObjectKeyFrame KeyTime="0:0:0.2" Value="Collapsed"/>
+                                        </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                 </VisualState>
                             </VisualStateGroup>

--- a/Microsoft.Toolkit.Uwp.UI.Controls/Expander/Expander.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/Expander/Expander.xaml
@@ -305,12 +305,48 @@
                                         <Setter Target="ColumnOne.Width" Value="*" />
                                         <Setter Target="ColumnTwo.Width" Value="Auto" />
 
+                                        <Setter Target="PART_MainContent.RenderTransformOrigin" Value="1, 0.5" />
+
                                     </VisualState.Setters>
+
+                                    <Storyboard>
+                                        <DoubleAnimation Storyboard.TargetName="ContentPresenter"
+                                                         Storyboard.TargetProperty="(UIElement.Opacity)"
+                                                         BeginTime="0:0:0.25" Duration="0:0:0.3" From="0" To="1" />
+
+                                        <DoubleAnimation Storyboard.TargetName="ContentPresenter"
+                                                         Storyboard.TargetProperty="(UIElement.RenderTransform).(TranslateTransform.Y)"
+                                                         BeginTime="0:0:0.25" Duration="0:0:0.3" From="20" To="0" />
+
+                                        <DoubleAnimation Storyboard.TargetName="PART_MainContent"
+                                                         Storyboard.TargetProperty="(UIElement.RenderTransform).(ScaleTransform.ScaleX)"
+                                                         Duration="0:0:0.3" From="0" To="1" />
+                                        <DoubleAnimation Storyboard.TargetName="PART_MainContent"
+                                                         Storyboard.TargetProperty="(UIElement.RenderTransform).(ScaleTransform.ScaleY)"
+                                                         Duration="0:0:0.3" From="1" To="1" />
+                                    </Storyboard>
                                 </VisualState>
                                 <VisualState x:Name="VisibleDown">
                                     <VisualState.Setters>
                                         <Setter Target="PART_MainContent.Visibility" Value="Visible" />
                                     </VisualState.Setters>
+
+                                    <Storyboard>
+                                        <DoubleAnimation Storyboard.TargetName="ContentPresenter"
+                                                         Storyboard.TargetProperty="(UIElement.Opacity)"
+                                                         BeginTime="0:0:0.25" Duration="0:0:0.3" From="0" To="1" />
+
+                                        <DoubleAnimation Storyboard.TargetName="ContentPresenter"
+                                                         Storyboard.TargetProperty="(UIElement.RenderTransform).(TranslateTransform.Y)"
+                                                         BeginTime="0:0:0.25" Duration="0:0:0.3" From="20" To="0" />
+
+                                        <DoubleAnimation Storyboard.TargetName="PART_MainContent"
+                                                         Storyboard.TargetProperty="(UIElement.RenderTransform).(ScaleTransform.ScaleX)"
+                                                         Duration="0:0:0.3" From="1" To="1" />
+                                        <DoubleAnimation Storyboard.TargetName="PART_MainContent"
+                                                         Storyboard.TargetProperty="(UIElement.RenderTransform).(ScaleTransform.ScaleY)"
+                                                         Duration="0:0:0.3" From="0" To="1" />
+                                    </Storyboard>
                                 </VisualState>
                                 <VisualState x:Name="VisibleRight">
                                     <VisualState.Setters>
@@ -335,6 +371,22 @@
 
                                     </VisualState.Setters>
 
+                                    <Storyboard>
+                                        <DoubleAnimation Storyboard.TargetName="ContentPresenter"
+                                                         Storyboard.TargetProperty="(UIElement.Opacity)"
+                                                         BeginTime="0:0:0.25" Duration="0:0:0.3" From="0" To="1" />
+
+                                        <DoubleAnimation Storyboard.TargetName="ContentPresenter"
+                                                         Storyboard.TargetProperty="(UIElement.RenderTransform).(TranslateTransform.Y)"
+                                                         BeginTime="0:0:0.25" Duration="0:0:0.3" From="20" To="0" />
+                                        
+                                        <DoubleAnimation Storyboard.TargetName="PART_MainContent"
+                                                         Storyboard.TargetProperty="(UIElement.RenderTransform).(ScaleTransform.ScaleX)"
+                                                         Duration="0:0:0.3" From="0" To="1" />
+                                        <DoubleAnimation Storyboard.TargetName="PART_MainContent"
+                                                         Storyboard.TargetProperty="(UIElement.RenderTransform).(ScaleTransform.ScaleY)"
+                                                         Duration="0:0:0.3" From="1" To="1" />
+                                    </Storyboard>
                                 </VisualState>
                                 <VisualState x:Name="VisibleUp">
                                     <VisualState.Setters>
@@ -360,6 +412,23 @@
 
                                         <Setter Target="RotateLayoutTransform.Angle" Value="0" />
                                     </VisualState.Setters>
+
+                                    <Storyboard>
+                                        <DoubleAnimation Storyboard.TargetName="ContentPresenter"
+                                                         Storyboard.TargetProperty="(UIElement.Opacity)"
+                                                         BeginTime="0:0:0.25" Duration="0:0:0.3" From="0" To="1" />
+
+                                        <DoubleAnimation Storyboard.TargetName="ContentPresenter"
+                                                         Storyboard.TargetProperty="(UIElement.RenderTransform).(TranslateTransform.Y)"
+                                                         BeginTime="0:0:0.25" Duration="0:0:0.3" From="20" To="0" />
+
+                                        <DoubleAnimation Storyboard.TargetName="PART_MainContent"
+                                                         Storyboard.TargetProperty="(UIElement.RenderTransform).(ScaleTransform.ScaleX)"
+                                                         Duration="0:0:0.3" From="1" To="1" />
+                                        <DoubleAnimation Storyboard.TargetName="PART_MainContent"
+                                                         Storyboard.TargetProperty="(UIElement.RenderTransform).(ScaleTransform.ScaleY)"
+                                                         Duration="0:0:0.3" From="0" To="1" />
+                                    </Storyboard>
                                 </VisualState>
 
                                 <VisualState x:Name="CollapsedLeft">
@@ -386,10 +455,36 @@
                                         <Setter Target="ColumnTwo.Width" Value="Auto" />
 
                                     </VisualState.Setters>
+
+                                    <Storyboard>
+                                        <DoubleAnimation Storyboard.TargetName="ContentPresenter"
+                                                         Storyboard.TargetProperty="(UIElement.Opacity)"
+                                                         Duration="0:0:0.2" From="1" To="0" />
+
+                                        <DoubleAnimation Storyboard.TargetName="PART_MainContent"
+                                                         Storyboard.TargetProperty="(UIElement.RenderTransform).(ScaleTransform.ScaleX)"
+                                                         Duration="0:0:0.2" To="0" />
+                                        <DoubleAnimation Storyboard.TargetName="PART_MainContent"
+                                                         Storyboard.TargetProperty="(UIElement.RenderTransform).(ScaleTransform.ScaleY)"
+                                                         Duration="0:0:0.2" To="1" />
+                                    </Storyboard>
                                 </VisualState>
                                 <VisualState x:Name="CollapsedDown">
                                     <VisualState.Setters>
                                     </VisualState.Setters>
+
+                                    <Storyboard>
+                                        <DoubleAnimation Storyboard.TargetName="ContentPresenter"
+                                                         Storyboard.TargetProperty="(UIElement.Opacity)"
+                                                         Duration="0:0:0.2" From="1" To="0" />
+
+                                        <DoubleAnimation Storyboard.TargetName="PART_MainContent"
+                                                         Storyboard.TargetProperty="(UIElement.RenderTransform).(ScaleTransform.ScaleX)"
+                                                         Duration="0:0:0.2" From="1" To="1" />
+                                        <DoubleAnimation Storyboard.TargetName="PART_MainContent"
+                                                         Storyboard.TargetProperty="(UIElement.RenderTransform).(ScaleTransform.ScaleY)"
+                                                         Duration="0:0:0.2" From="1" To="0" />
+                                    </Storyboard>
                                 </VisualState>
                                 <VisualState x:Name="CollapsedRight">
                                     <VisualState.Setters>
@@ -413,6 +508,19 @@
                                         <Setter Target="RotateLayoutTransform.Angle" Value="-90" />
 
                                     </VisualState.Setters>
+
+                                    <Storyboard>
+                                        <DoubleAnimation Storyboard.TargetName="ContentPresenter"
+                                                         Storyboard.TargetProperty="(UIElement.Opacity)"
+                                                         Duration="0:0:0.2" From="1" To="0" />
+
+                                        <DoubleAnimation Storyboard.TargetName="PART_MainContent"
+                                                         Storyboard.TargetProperty="(UIElement.RenderTransform).(ScaleTransform.ScaleX)"
+                                                         Duration="0:0:0.2" To="0" />
+                                        <DoubleAnimation Storyboard.TargetName="PART_MainContent"
+                                                         Storyboard.TargetProperty="(UIElement.RenderTransform).(ScaleTransform.ScaleY)"
+                                                         Duration="0:0:0.2" To="1" />
+                                    </Storyboard>
                                 </VisualState>
                                 <VisualState x:Name="CollapsedUp">
                                     <VisualState.Setters>
@@ -436,6 +544,19 @@
 
                                         <Setter Target="RotateLayoutTransform.Angle" Value="0" />
                                     </VisualState.Setters>
+
+                                    <Storyboard>
+                                        <DoubleAnimation Storyboard.TargetName="ContentPresenter"
+                                                         Storyboard.TargetProperty="(UIElement.Opacity)"
+                                                         Duration="0:0:0.2" From="1" To="0" />
+
+                                        <DoubleAnimation Storyboard.TargetName="PART_MainContent"
+                                                         Storyboard.TargetProperty="(UIElement.RenderTransform).(ScaleTransform.ScaleX)"
+                                                         Duration="0:0:0.2" From="1" To="1" />
+                                        <DoubleAnimation Storyboard.TargetName="PART_MainContent"
+                                                         Storyboard.TargetProperty="(UIElement.RenderTransform).(ScaleTransform.ScaleY)"
+                                                         Duration="0:0:0.2" From="1" To="0" />
+                                    </Storyboard>
                                 </VisualState>
                             </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>
@@ -464,19 +585,27 @@
                             </ContentControl>
 
                             <Grid Grid.Row="1" 
-                                      Grid.RowSpan="1" 
-                                      Grid.Column="0" 
-                                      Grid.ColumnSpan="2"
-                                      x:Name="PART_MainContent"
-                                      Visibility="Collapsed"
-                                      extensions:VisualEx.NormalizedCenterPoint="0"
-                                      Background="{TemplateBinding Background}">
+                                  Grid.RowSpan="1" 
+                                  Grid.Column="0" 
+                                  Grid.ColumnSpan="2"
+                                  x:Name="PART_MainContent"
+                                  Visibility="Collapsed"
+                                  extensions:VisualEx.NormalizedCenterPoint="0"
+                                  Background="{TemplateBinding Background}">
 
-                                <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                <ContentPresenter x:Name="ContentPresenter"
+                                                  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                                   HorizontalContentAlignment="Stretch"
                                                   VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                                  VerticalContentAlignment="Stretch" />
+                                                  VerticalContentAlignment="Stretch">
+                                    <ContentPresenter.RenderTransform>
+                                        <TranslateTransform />
+                                    </ContentPresenter.RenderTransform>
+                                </ContentPresenter>
 
+                                <Grid.RenderTransform>
+                                    <ScaleTransform />
+                                </Grid.RenderTransform>
                             </Grid>
 
                             <controls:LayoutTransformControl Grid.Row="0" Grid.RowSpan="1" Grid.Column="0" Grid.ColumnSpan="2"

--- a/Microsoft.Toolkit.Uwp.UI.Controls/Expander/Expander.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/Expander/Expander.xaml
@@ -305,8 +305,6 @@
                                         <Setter Target="ColumnOne.Width" Value="*" />
                                         <Setter Target="ColumnTwo.Width" Value="Auto" />
 
-                                        <Setter Target="PART_MainContentShowScaleAnimation.From" Value="0,1,0" />
-
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="VisibleDown">
@@ -334,8 +332,6 @@
                                         <Setter Target="PART_ContentOverlay.(Grid.ColumnSpan)" Value="1" />
 
                                         <Setter Target="RotateLayoutTransform.Angle" Value="-90" />
-
-                                        <Setter Target="PART_MainContentShowScaleAnimation.From" Value="0,1,0" />
 
                                     </VisualState.Setters>
 
@@ -389,8 +385,6 @@
                                         <Setter Target="ColumnOne.Width" Value="*" />
                                         <Setter Target="ColumnTwo.Width" Value="Auto" />
 
-                                        <Setter Target="PART_MainContentHideScaleAnimation.To" Value="0,1,0" />
-
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="CollapsedDown">
@@ -417,8 +411,6 @@
                                         <Setter Target="PART_ContentOverlay.(Grid.ColumnSpan)" Value="1" />
 
                                         <Setter Target="RotateLayoutTransform.Angle" Value="-90" />
-
-                                        <Setter Target="PART_MainContentHideScaleAnimation.To" Value="0,1,0" />
 
                                     </VisualState.Setters>
                                 </VisualState>
@@ -481,30 +473,15 @@
                                       Background="{TemplateBinding Background}">
 
                                 <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                                      HorizontalContentAlignment="Stretch"
-                                                      VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                                      VerticalContentAlignment="Stretch" >
-                                    <animations:Implicit.ShowAnimations>
-                                        <animations:OpacityAnimation Duration="0:0:0.3" From="0" To="1" Delay="0:0:0.25" SetInitialValueBeforeDelay="True"></animations:OpacityAnimation>
-                                        <animations:TranslationAnimation Duration="0:0:0.3" From="0, 20, 0" To="0" Delay="0:0:0.25"></animations:TranslationAnimation>
-                                    </animations:Implicit.ShowAnimations>
+                                                  HorizontalContentAlignment="Stretch"
+                                                  VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                                  VerticalContentAlignment="Stretch" />
 
-                                    <animations:Implicit.HideAnimations>
-                                        <animations:OpacityAnimation Duration="0:0:0.2" To="0"></animations:OpacityAnimation>
-                                    </animations:Implicit.HideAnimations>
-                                </ContentPresenter>
-                                <animations:Implicit.ShowAnimations>
-                                    <animations:ScaleAnimation x:Name="PART_MainContentShowScaleAnimation" Duration="0:0:0.3" From="1, 0, 0" To="1" ></animations:ScaleAnimation>
-                                </animations:Implicit.ShowAnimations>
-
-                                <animations:Implicit.HideAnimations>
-                                    <animations:ScaleAnimation x:Name="PART_MainContentHideScaleAnimation" Duration="0:0:0.2" To="1, 0, 0" ></animations:ScaleAnimation>
-                                </animations:Implicit.HideAnimations>
                             </Grid>
 
                             <controls:LayoutTransformControl Grid.Row="0" Grid.RowSpan="1" Grid.Column="0" Grid.ColumnSpan="2"
                                                              x:Name="PART_LayoutTransformer"
-                                                                 Background="{TemplateBinding Background}"
+                                                             Background="{TemplateBinding Background}"
                                                              RenderTransformOrigin="0.5,0.5">
                                 <controls:LayoutTransformControl.Transform>
                                     <RotateTransform x:Name="RotateLayoutTransform" Angle="0" />


### PR DESCRIPTION
Issue: #1724 

## PR Type
What kind of change does this PR introduce?

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting)
[x] Refactoring (no functional changes, no api changes)
[ ] Build or CI related changes
[ ] Documentation content changes
[ ] Sample app changes
[ ] Other... Please describe:
```


## What is the current behavior?

Linked to the issue: implicit animations should be removed in favor of VisualState animations in Expander control.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://raw.githubusercontent.com/Microsoft/UWPCommunityToolkit/tree/master/docs/.template.md). (for bug fixes / features)
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/Microsoft/UWPCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)


## What is the new behavior?

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information

@nmetulev I started by simply removing the implicit animations. I left the animations on the ToggleButton header because it is played when Expander orientation/direction is changed.

Should we left the control like this? Or should I add some animations in VisualStates?