### PR TITLE
Reset launch count

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/SystemInformation/SystemInformationCode.bind
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/SystemInformation/SystemInformationCode.bind
@@ -46,6 +46,12 @@
         // To get the time the app was previously launched, not including this instance.
         public DateTime LastLaunchTime => SystemInformation.LastLaunchTime;
 
+        // To get the time the launch count was reset, not including this instance
+        public string LastResetTime => SystemInformation.LastResetTime.ToString(Culture.DateTimeFormat);
+
+        // To get the number of times the app has been launched sicne the last reset.
+        public long LaunchCount => SystemInformation.LaunchCount;
+
         // To get the number of times the app has been launched.
         public long TotalLaunchCount => SystemInformation.TotalLaunchCount;
 

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/SystemInformation/SystemInformationCode.bind
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/SystemInformation/SystemInformationCode.bind
@@ -47,7 +47,7 @@
         public DateTime LastLaunchTime => SystemInformation.LastLaunchTime;
 
         // To get the number of times the app has been launched.
-        public long LaunchCount => SystemInformation.LaunchCount;
+        public long TotalLaunchCount => SystemInformation.TotalLaunchCount;
 
         // To get how long the app has been running
         public TimeSpan AppUptime => SystemInformation.AppUptime;

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/SystemInformation/SystemInformationPage.xaml
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/SystemInformation/SystemInformationPage.xaml
@@ -208,11 +208,11 @@
                             Orientation="Horizontal">
                     <TextBlock FontSize="18"
                                FontWeight="Bold"
-                               Text="Last launch time:"
+                               Text="Last reset time:"
                                TextWrapping="Wrap" />
                     <TextBlock Margin="20,0"
                                FontSize="18"
-                               Text="{x:Bind LastResetTime}"
+                               Text="{x:Bind LastResetTimeProp, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                TextWrapping="Wrap" />
                 </StackPanel>
                 <StackPanel x:Name="Stack17"
@@ -224,7 +224,7 @@
                                TextWrapping="Wrap" />
                     <TextBlock Margin="20,0"
                                FontSize="18"
-                               Text="{x:Bind LaunchCount}"
+                               Text="{x:Bind LaunchCountProp, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                TextWrapping="Wrap" />
                 </StackPanel>
                 <StackPanel x:Name="Stack18"

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/SystemInformation/SystemInformationPage.xaml
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/SystemInformation/SystemInformationPage.xaml
@@ -208,6 +208,30 @@
                             Orientation="Horizontal">
                     <TextBlock FontSize="18"
                                FontWeight="Bold"
+                               Text="Last launch time:"
+                               TextWrapping="Wrap" />
+                    <TextBlock Margin="20,0"
+                               FontSize="18"
+                               Text="{x:Bind LastResetTime}"
+                               TextWrapping="Wrap" />
+                </StackPanel>
+                <StackPanel x:Name="Stack17"
+                            Margin="10"
+                            Orientation="Horizontal">
+                    <TextBlock FontSize="18"
+                               FontWeight="Bold"
+                               Text="Current launch count:"
+                               TextWrapping="Wrap" />
+                    <TextBlock Margin="20,0"
+                               FontSize="18"
+                               Text="{x:Bind LaunchCount}"
+                               TextWrapping="Wrap" />
+                </StackPanel>
+                <StackPanel x:Name="Stack18"
+                            Margin="10"
+                            Orientation="Horizontal">
+                    <TextBlock FontSize="18"
+                               FontWeight="Bold"
                                Text="Total launch count:"
                                TextWrapping="Wrap" />
                     <TextBlock Margin="20,0"
@@ -215,7 +239,7 @@
                                Text="{x:Bind TotalLaunchCount}"
                                TextWrapping="Wrap" />
                 </StackPanel>
-                <StackPanel x:Name="Stack17"
+                <StackPanel x:Name="Stack19"
                             Margin="10"
                             Orientation="Horizontal">
                     <TextBlock FontSize="18"

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/SystemInformation/SystemInformationPage.xaml
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/SystemInformation/SystemInformationPage.xaml
@@ -212,7 +212,7 @@
                                TextWrapping="Wrap" />
                     <TextBlock Margin="20,0"
                                FontSize="18"
-                               Text="{x:Bind LastResetTimeProp, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                               Text="{x:Bind LastResetTime, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                TextWrapping="Wrap" />
                 </StackPanel>
                 <StackPanel x:Name="Stack17"
@@ -224,7 +224,7 @@
                                TextWrapping="Wrap" />
                     <TextBlock Margin="20,0"
                                FontSize="18"
-                               Text="{x:Bind LaunchCountProp, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                               Text="{x:Bind LaunchCount, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                TextWrapping="Wrap" />
                 </StackPanel>
                 <StackPanel x:Name="Stack18"

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/SystemInformation/SystemInformationPage.xaml
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/SystemInformation/SystemInformationPage.xaml
@@ -208,11 +208,11 @@
                             Orientation="Horizontal">
                     <TextBlock FontSize="18"
                                FontWeight="Bold"
-                               Text="Launch count:"
+                               Text="Total launch count:"
                                TextWrapping="Wrap" />
                     <TextBlock Margin="20,0"
                                FontSize="18"
-                               Text="{x:Bind LaunchCount}"
+                               Text="{x:Bind TotalLaunchCount}"
                                TextWrapping="Wrap" />
                 </StackPanel>
                 <StackPanel x:Name="Stack17"

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/SystemInformation/SystemInformationPage.xaml
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/SystemInformation/SystemInformationPage.xaml
@@ -212,7 +212,7 @@
                                TextWrapping="Wrap" />
                     <TextBlock Margin="20,0"
                                FontSize="18"
-                               Text="{x:Bind LastResetTime, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                               Text="{x:Bind LastResetTime, Mode=OneWay}"
                                TextWrapping="Wrap" />
                 </StackPanel>
                 <StackPanel x:Name="Stack17"
@@ -224,7 +224,7 @@
                                TextWrapping="Wrap" />
                     <TextBlock Margin="20,0"
                                FontSize="18"
-                               Text="{x:Bind LaunchCount, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                               Text="{x:Bind LaunchCount, Mode=OneWay}"
                                TextWrapping="Wrap" />
                 </StackPanel>
                 <StackPanel x:Name="Stack18"

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/SystemInformation/SystemInformationPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/SystemInformation/SystemInformationPage.xaml.cs
@@ -15,6 +15,7 @@ using System.Globalization;
 using System.Runtime.CompilerServices;
 using Microsoft.Toolkit.Uwp.Helpers;
 using Windows.System;
+using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Navigation;
 
@@ -23,7 +24,7 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
     /// <summary>
     /// An empty page that can be used on its own or navigated to within a Frame.
     /// </summary>
-    public sealed partial class SystemInformationPage : Page, INotifyPropertyChanged
+    public sealed partial class SystemInformationPage : Page
     {
         // To get application's name:
         public string ApplicationName => SystemInformation.ApplicationName;
@@ -74,14 +75,24 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
         public string LastLaunchTime => SystemInformation.LastLaunchTime.ToString(Culture.DateTimeFormat);
 
         // To get the time the launch count was reset, not including this instance
-        public string LastResetTime => SystemInformation.LastResetTime.ToString(Culture.DateTimeFormat);
+        public string LastResetTime
+        {
+            get { return (string)GetValue(LastResetTimeProperty); }
+            set { SetValue(LastResetTimeProperty, value); }
+        }
 
-        public string LastResetTimeProp { get; set; }
+        public static readonly DependencyProperty LastResetTimeProperty =
+            DependencyProperty.Register(nameof(LastResetTime), typeof(string), typeof(SystemInformationPage), new PropertyMetadata(string.Empty));
 
         // To get the number of times the app has been launched sicne the last reset.
-        public long LaunchCount => SystemInformation.LaunchCount;
+        public long LaunchCount
+        {
+            get { return (long)GetValue(LaunchCountProperty); }
+            set { SetValue(LaunchCountProperty, value); }
+        }
 
-        public long LaunchCountProp { get; set; }
+        public static readonly DependencyProperty LaunchCountProperty =
+            DependencyProperty.Register(nameof(LaunchCount), typeof(long), typeof(SystemInformationPage), new PropertyMetadata(0));
 
         // To get the number of times the app has been launched.
         public long TotalLaunchCount => SystemInformation.TotalLaunchCount;
@@ -93,8 +104,7 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
         {
             InitializeComponent();
 
-            LaunchCountProp = LaunchCount;
-            LastResetTimeProp = LastResetTime;
+            RefreshProperties();
         }
 
         protected override void OnNavigatedTo(NavigationEventArgs e)
@@ -104,20 +114,14 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
             Shell.Current.RegisterNewCommand("Reset launch count", (sender, args) =>
             {
                 SystemInformation.ResetLaunchCount();
-
-                LaunchCountProp = LaunchCount;
-                RaisePropertyChanged(nameof(LaunchCountProp));
-
-                LastResetTimeProp = LastResetTime;
-                RaisePropertyChanged(nameof(LastResetTimeProp));
+                RefreshProperties();
             });
         }
 
-        public event PropertyChangedEventHandler PropertyChanged;
-
-        public void RaisePropertyChanged([CallerMemberName]string propertyName = null)
+        private void RefreshProperties()
         {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+            LaunchCount = SystemInformation.LaunchCount;
+            LastResetTime = SystemInformation.LastResetTime.ToString(Culture.DateTimeFormat);
         }
     }
 }

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/SystemInformation/SystemInformationPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/SystemInformation/SystemInformationPage.xaml.cs
@@ -10,17 +10,20 @@
 // THE CODE OR THE USE OR OTHER DEALINGS IN THE CODE.
 // ******************************************************************
 
+using System.ComponentModel;
 using System.Globalization;
+using System.Runtime.CompilerServices;
 using Microsoft.Toolkit.Uwp.Helpers;
 using Windows.System;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Navigation;
 
 namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
 {
     /// <summary>
     /// An empty page that can be used on its own or navigated to within a Frame.
     /// </summary>
-    public sealed partial class SystemInformationPage : Page
+    public sealed partial class SystemInformationPage : Page, INotifyPropertyChanged
     {
         // To get application's name:
         public string ApplicationName => SystemInformation.ApplicationName;
@@ -70,6 +73,12 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
         // To get the time the app was previously launched, not including this instance
         public string LastLaunchTime => SystemInformation.LastLaunchTime.ToString(Culture.DateTimeFormat);
 
+        // To get the time the launch count was reset, not including this instance
+        public string LastResetTime => SystemInformation.LastResetTime.ToString(Culture.DateTimeFormat);
+
+        // To get the number of times the app has been launched sicne the last reset.
+        public long LaunchCount => SystemInformation.LaunchCount;
+
         // To get the number of times the app has been launched.
         public long TotalLaunchCount => SystemInformation.TotalLaunchCount;
 
@@ -79,6 +88,25 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
         public SystemInformationPage()
         {
             InitializeComponent();
+        }
+
+        protected override void OnNavigatedTo(NavigationEventArgs e)
+        {
+            base.OnNavigatedTo(e);
+
+            Shell.Current.RegisterNewCommand("Reset launch count", (sender, args) =>
+            {
+                SystemInformation.ResetLaunchCount();
+                RaisePropertyChanged(nameof(LaunchCount));
+                RaisePropertyChanged(nameof(LastResetTime));
+            });
+        }
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        public void RaisePropertyChanged([CallerMemberName]string propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
     }
 }

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/SystemInformation/SystemInformationPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/SystemInformation/SystemInformationPage.xaml.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
         public string LastLaunchTime => SystemInformation.LastLaunchTime.ToString(Culture.DateTimeFormat);
 
         // To get the number of times the app has been launched.
-        public long LaunchCount => SystemInformation.LaunchCount;
+        public long TotalLaunchCount => SystemInformation.TotalLaunchCount;
 
         // To get how long the app has been running
         public string AppUptime => SystemInformation.AppUptime.ToString();

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/SystemInformation/SystemInformationPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/SystemInformation/SystemInformationPage.xaml.cs
@@ -76,8 +76,12 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
         // To get the time the launch count was reset, not including this instance
         public string LastResetTime => SystemInformation.LastResetTime.ToString(Culture.DateTimeFormat);
 
+        public string LastResetTimeProp { get; set; }
+
         // To get the number of times the app has been launched sicne the last reset.
         public long LaunchCount => SystemInformation.LaunchCount;
+
+        public long LaunchCountProp { get; set; }
 
         // To get the number of times the app has been launched.
         public long TotalLaunchCount => SystemInformation.TotalLaunchCount;
@@ -88,6 +92,9 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
         public SystemInformationPage()
         {
             InitializeComponent();
+
+            LaunchCountProp = LaunchCount;
+            LastResetTimeProp = LastResetTime;
         }
 
         protected override void OnNavigatedTo(NavigationEventArgs e)
@@ -97,8 +104,12 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
             Shell.Current.RegisterNewCommand("Reset launch count", (sender, args) =>
             {
                 SystemInformation.ResetLaunchCount();
-                RaisePropertyChanged(nameof(LaunchCount));
-                RaisePropertyChanged(nameof(LastResetTime));
+
+                LaunchCountProp = LaunchCount;
+                RaisePropertyChanged(nameof(LaunchCountProp));
+
+                LastResetTimeProp = LastResetTime;
+                RaisePropertyChanged(nameof(LastResetTimeProp));
             });
         }
 

--- a/Microsoft.Toolkit.Uwp/Helpers/SystemInformation.cs
+++ b/Microsoft.Toolkit.Uwp/Helpers/SystemInformation.cs
@@ -189,6 +189,11 @@ namespace Microsoft.Toolkit.Uwp.Helpers
 
                 _localObjectStorageHelper.Save(nameof(LastLaunchTime), LaunchTime.ToFileTimeUtc());
                 _localObjectStorageHelper.Save(nameof(AppUptime), 0L);
+
+                var lastResetTime = _localObjectStorageHelper.Read<long>(nameof(LastResetTime));
+                LastResetTime = lastResetTime != default(long)
+                    ? DateTime.FromFileTimeUtc(lastResetTime)
+                    : DateTime.MinValue;
             }
 
             void App_VisibilityChanged(Windows.UI.Core.CoreWindow sender, Windows.UI.Core.VisibilityChangedEventArgs e)

--- a/Microsoft.Toolkit.Uwp/Helpers/SystemInformation.cs
+++ b/Microsoft.Toolkit.Uwp/Helpers/SystemInformation.cs
@@ -113,16 +113,28 @@ namespace Microsoft.Toolkit.Uwp.Helpers
         public static DateTime LastLaunchTime { get; private set; }
 
         /// <summary>
-        /// Gets the number of times the app has been launched.
+        /// Gets the number of times the app has been launched since the last reset.
         /// Will be zero if `TrackAppUse` has not been called.
         /// </summary>
         public static long LaunchCount { get; private set; }
+
+        /// <summary>
+        /// Gets the number of times the app has been launched.
+        /// Will be zero if `TrackAppUse` has not been called.
+        /// </summary>
+        public static long TotalLaunchCount { get; private set; }
 
         /// <summary>
         /// Gets the DateTime (in UTC) that this instance of the app was launched.
         /// Will be DateTime.MinValue if `TrackAppUse` has not been called.
         /// </summary>
         public static DateTime LaunchTime { get; private set; }
+
+        /// <summary>
+        /// Gets the DateTime (in UTC) when the launch count was previously reset, not including this instance.
+        /// Will be DateTime.MinValue if `TrackAppUse` has not been called.
+        /// </summary>
+        public static DateTime LastResetTime { get; private set; }
 
         /// <summary>
         /// Gets the length of time this instance of the app has been running.
@@ -157,8 +169,16 @@ namespace Microsoft.Toolkit.Uwp.Helpers
              || args.PreviousExecutionState == ApplicationExecutionState.NotRunning)
             {
                 LaunchCount = _localObjectStorageHelper.Read<long>(nameof(LaunchCount)) + 1;
+                TotalLaunchCount = _localObjectStorageHelper.Read<long>(nameof(TotalLaunchCount)) + 1;
+
+                // In case we upgraded the properties, make TotalLaunchCount is correct
+                if (TotalLaunchCount < LaunchCount)
+                {
+                    TotalLaunchCount = LaunchCount;
+                }
 
                 _localObjectStorageHelper.Save(nameof(LaunchCount), LaunchCount);
+                _localObjectStorageHelper.Save(nameof(TotalLaunchCount), TotalLaunchCount);
 
                 LaunchTime = DateTime.UtcNow;
 
@@ -321,7 +341,18 @@ namespace Microsoft.Toolkit.Uwp.Helpers
         {
             LaunchTime = DateTime.MinValue;
             LaunchCount = 0;
+            TotalLaunchCount = 0;
             LastLaunchTime = DateTime.MinValue;
+            LastResetTime = DateTime.MinValue;
+        }
+
+        private static void ResetLaunchCount()
+        {
+            LastResetTime = DateTime.UtcNow;
+            LaunchCount = 0;
+
+            _localObjectStorageHelper.Save(nameof(LastResetTime), LastResetTime.ToFileTimeUtc());
+            _localObjectStorageHelper.Save(nameof(LaunchCount), LaunchCount);
         }
     }
 }

--- a/Microsoft.Toolkit.Uwp/Helpers/SystemInformation.cs
+++ b/Microsoft.Toolkit.Uwp/Helpers/SystemInformation.cs
@@ -232,6 +232,18 @@ namespace Microsoft.Toolkit.Uwp.Helpers
         }
 
         /// <summary>
+        /// Reset launch count
+        /// </summary>
+        public static void ResetLaunchCount()
+        {
+            LastResetTime = DateTime.UtcNow;
+            LaunchCount = 0;
+
+            _localObjectStorageHelper.Save(nameof(LastResetTime), LastResetTime.ToFileTimeUtc());
+            _localObjectStorageHelper.Save(nameof(LaunchCount), LaunchCount);
+        }
+
+        /// <summary>
         /// Initializes static members of the <see cref="SystemInformation"/> class.
         /// </summary>
         static SystemInformation()
@@ -344,15 +356,6 @@ namespace Microsoft.Toolkit.Uwp.Helpers
             TotalLaunchCount = 0;
             LastLaunchTime = DateTime.MinValue;
             LastResetTime = DateTime.MinValue;
-        }
-
-        private static void ResetLaunchCount()
-        {
-            LastResetTime = DateTime.UtcNow;
-            LaunchCount = 0;
-
-            _localObjectStorageHelper.Save(nameof(LastResetTime), LastResetTime.ToFileTimeUtc());
-            _localObjectStorageHelper.Save(nameof(LaunchCount), LaunchCount);
         }
     }
 }

--- a/docs/helpers/SystemInformation.md
+++ b/docs/helpers/SystemInformation.md
@@ -28,7 +28,9 @@ The SystemInformation is a static utility class that provides properties with so
 |IsAppUpdated | Gets a value indicating whether the app is being used for the first time since being upgraded from an older version. |
 |LaunchTime | Gets the DateTime (in UTC) that this instance of the app was launched. |
 |LastLaunchTime | Gets the DateTime (in UTC) that this was previously launched. |
-|LaunchCount | Gets the number of times the app has been launched. |
+|LastResetTime | Gets the DateTime (in UTC) when the launch count was previously reset. |
+|LaunchCount | Gets the number of times the app has been launched since the last reset. |
+|TotalLaunchCount | Gets the number of times the app has been launched. |
 |AppUptime | Gets the length of time this instance of the app has been running. |
 |FirstVersionInstalled | Gets the first version of the app that was installed. |
 |FirstUseTime | Gets the DateTime (in UTC) that the app as first used. |
@@ -39,6 +41,7 @@ The SystemInformation is a static utility class that provides properties with so
 | ------ | ----------- |
 | LaunchStoreForReviewAsync() | Launch the store app so the user can leave a review. |
 | TrackAppUse() | Track app launch time and count. |
+| ResetLaunchCount() | Reset launch count so you can get launch count from a new perspective. |
 
 ## Requirements (Windows 10 Device Family)
 


### PR DESCRIPTION
Issue: #1741 

## PR Type
What kind of change does this PR introduce?

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build or CI related changes
[ ] Documentation content changes
[ ] Sample app changes
[ ] Other... Please describe:
```

## What is the current behavior?

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://raw.githubusercontent.com/Microsoft/UWPCommunityToolkit/tree/master/docs/.template.md). (for bug fixes / features)
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/Microsoft/UWPCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)


## What is the new behavior?

I added some code based on the discussion on #1741 : 

* the `TotalLaunchCount` which is the total of launch count, obviously
* `LaunchCount` property still exists and can be reset
* a `ResetLaunchCount()` method to reset the current launch count
* the `LaunchResetTime` stores the last time the property `LaunchCount` is reset

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information

@michael-hawker I know this was your idea. I hope you are not mad at me for doing the PR. :)