### PR TITLE
Connected animations fix for cached pages

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Animations/ConnectedAnimations/ConnectedAnimationHelper.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Animations/ConnectedAnimations/ConnectedAnimationHelper.cs
@@ -26,9 +26,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
     /// </summary>
     internal class ConnectedAnimationHelper
     {
-        private readonly Dictionary<string, ConnectedAnimationProperties> _connectedAnimationsProps = new Dictionary<string, ConnectedAnimationProperties>();
         private readonly Dictionary<string, ConnectedAnimationProperties> _previousPageConnectedAnimationProps = new Dictionary<string, ConnectedAnimationProperties>();
-        private readonly Dictionary<UIElement, List<UIElement>> _coordinatedAnimationElements = new Dictionary<UIElement, List<UIElement>>();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ConnectedAnimationHelper"/> class.
@@ -50,120 +48,16 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
             frame.Navigated += Frame_Navigated;
         }
 
-        /// <summary>
-        /// Registers an element with the given key with the <see cref="ConnectedAnimationService"/>
-        /// </summary>
-        /// <param name="key">The key to be used with the <see cref="ConnectedAnimationService"/></param>
-        /// <param name="element">The element to be animated</param>
-        public void RegisterKey(string key, UIElement element)
-        {
-            if (key != null)
-            {
-                var animation = new ConnectedAnimationProperties()
-                {
-                    Key = key,
-                    Element = element,
-                };
-
-                _connectedAnimationsProps[key] = animation;
-            }
-        }
-
-        /// <summary>
-        /// Unregisters a key from participating in the connected animation
-        /// </summary>
-        /// <param name="key">The connected animation key to unregister</param>
-        public void RemoveKey(string key)
-        {
-            if (key != null)
-            {
-                _connectedAnimationsProps.Remove(key);
-            }
-        }
-
-        /// <summary>
-        /// Anchors an element to another element (anchor) that is registered to element
-        /// </summary>
-        /// <param name="element">The element that should animate together with the anchor</param>
-        /// <param name="anchor">An element that is already registered with a key to animate</param>
-        public void AttachElementToAnimatingElement(UIElement element, UIElement anchor)
-        {
-            if (anchor != null)
-            {
-                if (!_coordinatedAnimationElements.TryGetValue(anchor, out var list))
-                {
-                    list = new List<UIElement>();
-                    _coordinatedAnimationElements[anchor] = list;
-                }
-
-                list.Add(element);
-            }
-        }
-
-        /// <summary>
-        /// Removes an element from animating alongside the anchor element
-        /// </summary>
-        /// <param name="element">The element that was previously anchored to the anchor element</param>
-        /// <param name="anchor">An element that is registered with a key to animate</param>
-        public void RemoveAnchoredElement(UIElement element, UIElement anchor)
-        {
-            if (anchor != null)
-            {
-                if (_coordinatedAnimationElements.TryGetValue(anchor, out var oldElementList))
-                {
-                    oldElementList.Remove(element);
-                }
-            }
-        }
-
-        /// <summary>
-        /// Registers the ListViewBase element items to participate in a connected animation
-        /// When page is navigated, the parameter used in the navigation is used to decide
-        /// which item to animate
-        /// </summary>
-        /// <param name="listViewBase">The <see cref="ListViewBase"/></param>
-        /// <param name="key">The connected animation key to register with the <see cref="ConnectedAnimationService"/></param>
-        /// <param name="elementName">The name of the element in the <see cref="DataTemplate"/> to animate</param>
-        public void RegisterListItem(ListViewBase listViewBase, string key, string elementName)
-        {
-            if (listViewBase == null || string.IsNullOrWhiteSpace(key) || string.IsNullOrWhiteSpace(elementName))
-            {
-                return;
-            }
-
-            var props = new ConnectedAnimationProperties()
-            {
-                Key = key,
-                IsListAnimation = true,
-                ElementName = elementName,
-                ListViewBase = listViewBase
-            };
-
-            _connectedAnimationsProps[key] = props;
-        }
-
-        /// <summary>
-        /// Unregisters the ListViewBase element items from participating in the connected animation
-        /// <seealso cref="RegisterListItem(ListViewBase, string, string)"/>
-        /// </summary>
-        /// <param name="listViewBase">The <see cref="ListViewBase"/></param>
-        /// <param name="key">The connected animation key to unregister</param>
-        public void RemoveListItem(ListViewBase listViewBase, string key)
-        {
-            if (listViewBase == null || string.IsNullOrWhiteSpace(key))
-            {
-                return;
-            }
-
-            _connectedAnimationsProps.Remove(key);
-        }
-
         private void Frame_Navigating(object sender, Windows.UI.Xaml.Navigation.NavigatingCancelEventArgs e)
         {
             var parameter = e.Parameter != null && !(e.Parameter is string str && string.IsNullOrEmpty(str)) ? e.Parameter : null;
 
             var cas = ConnectedAnimationService.GetForCurrentView();
-            foreach (var props in _connectedAnimationsProps.Values)
+
+            var page = (sender as Frame).Content as Page;
+            var connectedAnimationsProps = Connected.GetPageConnectedAnimationProperties(page);
+
+            foreach (var props in connectedAnimationsProps.Values)
             {
                 if (props.IsListAnimation && parameter != null && ApiInformationHelper.IsCreatorsUpdateOrAbove)
                 {
@@ -180,9 +74,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
 
                 _previousPageConnectedAnimationProps[props.Key] = props;
             }
-
-            _connectedAnimationsProps.Clear();
-            _coordinatedAnimationElements.Clear();
         }
 
         private void Frame_Navigated(object sender, Windows.UI.Xaml.Navigation.NavigationEventArgs e)
@@ -212,7 +103,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
 
                 var cas = ConnectedAnimationService.GetForCurrentView();
 
-                foreach (var props in _connectedAnimationsProps.Values)
+                var connectedAnimationsProps = Connected.GetPageConnectedAnimationProperties(page);
+                var coordinatedAnimationElements = Connected.GetPageCoordinatedAnimationElements(page);
+
+                foreach (var props in connectedAnimationsProps.Values)
                 {
                     var connectedAnimation = cas.GetAnimation(props.Key);
                     var animationHandled = false;
@@ -239,7 +133,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
                         }
                         else if (!props.IsListAnimation)
                         {
-                            if (ApiInformationHelper.IsCreatorsUpdateOrAbove && _coordinatedAnimationElements.TryGetValue(props.Element, out var coordinatedElements))
+                            if (ApiInformationHelper.IsCreatorsUpdateOrAbove && coordinatedAnimationElements.TryGetValue(props.Element, out var coordinatedElements))
                             {
                                 connectedAnimation.TryStart(props.Element, coordinatedElements);
                             }


### PR DESCRIPTION
Issue: #1716
<!-- Link to relevant issue. All PRs should be asociated with an issue -->

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
```


## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)

## What is the new behavior?
The Connected animations extension will now work as expected when caching is turned on for pages

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

