### PR TITLE
IncrementalLoadingCollection Refresh Fix

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Incremental Loading Collection/IncrementalLoadingCollectionPage.xaml
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Incremental Loading Collection/IncrementalLoadingCollectionPage.xaml
@@ -24,17 +24,12 @@
             <Grid.RowDefinitions>
                 <RowDefinition />
                 <RowDefinition />
-                <RowDefinition />
             </Grid.RowDefinitions>
             <TextBlock HorizontalAlignment="Center"
                        Text="{Binding IsLoading, Converter={StaticResource StringFormatConverter}, ConverterParameter='Is Loading: {0}'}" />
             <TextBlock Grid.Row="1"
                        HorizontalAlignment="Center"
                        Text="{Binding HasMoreItems, Converter={StaticResource StringFormatConverter}, ConverterParameter='Has More Items: {0}'}" />
-            <Button x:Name="RefreshIncrementalCollectionBtn" 
-                    Grid.Row="2"
-                    HorizontalAlignment="Center"
-                    Content="Refresh" Click="RefreshIncrementalCollectionBtn_Click"/>
         </Grid>
         <Grid Grid.Row="2"
               Margin="0,24,0,0"

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Incremental Loading Collection/IncrementalLoadingCollectionPage.xaml
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Incremental Loading Collection/IncrementalLoadingCollectionPage.xaml
@@ -24,12 +24,17 @@
             <Grid.RowDefinitions>
                 <RowDefinition />
                 <RowDefinition />
+                <RowDefinition />
             </Grid.RowDefinitions>
             <TextBlock HorizontalAlignment="Center"
                        Text="{Binding IsLoading, Converter={StaticResource StringFormatConverter}, ConverterParameter='Is Loading: {0}'}" />
             <TextBlock Grid.Row="1"
                        HorizontalAlignment="Center"
                        Text="{Binding HasMoreItems, Converter={StaticResource StringFormatConverter}, ConverterParameter='Has More Items: {0}'}" />
+            <Button x:Name="RefreshIncrementalCollectionBtn" 
+                    Grid.Row="2"
+                    HorizontalAlignment="Center"
+                    Content="Refresh" Click="RefreshIncrementalCollectionBtn_Click"/>
         </Grid>
         <Grid Grid.Row="2"
               Margin="0,24,0,0"

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Incremental Loading Collection/IncrementalLoadingCollectionPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Incremental Loading Collection/IncrementalLoadingCollectionPage.xaml.cs
@@ -47,5 +47,11 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
             // Binds the collection to the page DataContext in order to use its IsLoading and HasMoreItems properties.
             DataContext = collection;
         }
+
+        private void RefreshIncrementalCollectionBtn_Click(object sender, Windows.UI.Xaml.RoutedEventArgs e)
+        {
+            var collection = (IncrementalLoadingCollection<PeopleSource, Person>)PeopleListView.ItemsSource;
+            collection.Refresh();
+        }
     }
 }

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Incremental Loading Collection/IncrementalLoadingCollectionPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Incremental Loading Collection/IncrementalLoadingCollectionPage.xaml.cs
@@ -13,6 +13,7 @@
 using System;
 using System.Threading.Tasks;
 using Windows.UI.Core;
+using Windows.UI.Xaml;
 using Windows.UI.Xaml.Navigation;
 
 namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
@@ -40,6 +41,8 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
         {
             base.OnNavigatedTo(e);
 
+            Shell.Current.RegisterNewCommand("Refresh Collection", RefreshCollection);
+
             // IncrementalLoadingCollection can be bound to a GridView or a ListView. In this case it is a ListView called PeopleListView.
             var collection = new IncrementalLoadingCollection<PeopleSource, Person>();
             PeopleListView.ItemsSource = collection;
@@ -48,7 +51,7 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
             DataContext = collection;
         }
 
-        private void RefreshIncrementalCollectionBtn_Click(object sender, Windows.UI.Xaml.RoutedEventArgs e)
+        private void RefreshCollection(object sender, RoutedEventArgs e)
         {
             var collection = (IncrementalLoadingCollection<PeopleSource, Person>)PeopleListView.ItemsSource;
             collection.Refresh();

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Incremental Loading Collection/PeopleSource.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/Incremental Loading Collection/PeopleSource.cs
@@ -63,7 +63,16 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
                           select p).Skip(pageIndex * pageSize).Take(pageSize);
 
             // Simulates a longer request...
-            await Task.Delay(1000);
+            // Make sure the list is still in order after a refresh,
+            // even if the first page takes longer to load
+            if (pageIndex == 0)
+            {
+                await Task.Delay(2000);
+            }
+            else
+            {
+                await Task.Delay(1000);
+            }
 
             return result;
         }

--- a/Microsoft.Toolkit.Uwp/IncrementalLoadingCollection/IncrementalLoadingCollection.cs
+++ b/Microsoft.Toolkit.Uwp/IncrementalLoadingCollection/IncrementalLoadingCollection.cs
@@ -196,10 +196,10 @@ namespace Microsoft.Toolkit.Uwp
             => LoadMoreItemsAsync(count, new CancellationToken(false)).AsAsyncOperation();
 
         /// <summary>
-        /// Clears the collection and reloads data from the source
+        /// Clears the collection and resets the page index
+        /// which triggers an automatic reload of the first page
         /// </summary>
-        /// <returns>This method does not return a result</returns>
-        public async Task RefreshAsync()
+        public void Refresh()
         {
             if (IsLoading)
             {
@@ -210,7 +210,6 @@ namespace Microsoft.Toolkit.Uwp
                 Clear();
                 CurrentPageIndex = 0;
                 HasMoreItems = true;
-                await LoadMoreItemsAsync(1);
             }
         }
 
@@ -275,7 +274,7 @@ namespace Microsoft.Toolkit.Uwp
                 if (_refreshOnLoad)
                 {
                     _refreshOnLoad = false;
-                    await RefreshAsync();
+                    Refresh();
                 }
             }
 

--- a/Microsoft.Toolkit.Uwp/IncrementalLoadingCollection/IncrementalLoadingCollection.cs
+++ b/Microsoft.Toolkit.Uwp/IncrementalLoadingCollection/IncrementalLoadingCollection.cs
@@ -196,6 +196,16 @@ namespace Microsoft.Toolkit.Uwp
             => LoadMoreItemsAsync(count, new CancellationToken(false)).AsAsyncOperation();
 
         /// <summary>
+        /// Clears the collection and reloads data from the source
+        /// </summary>
+        /// <returns>This method does not return a result</returns>
+        [Obsolete("RefreshAsync is deprecated, please use Refresh instead.")]
+        public async Task RefreshAsync()
+        {
+            await Task.Run(() => Refresh());
+        }
+
+        /// <summary>
         /// Clears the collection and resets the page index
         /// which triggers an automatic reload of the first page
         /// </summary>


### PR DESCRIPTION
- Added Refresh Button to sample application
- Added additional delay for first page in PeopleSource.cs to verify the order of items returned is correct regardless.
- Removed unnecessary call to LoadMoreItemsAsync()
- Renamed RefreshAsync() to Refresh()

Issue: #
https://github.com/Microsoft/UWPCommunityToolkit/issues/1664

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build or CI related changes
[ ] Documentation content changes
[x] Sample app changes
[ ] Other... Please describe:
```


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When refreshing an IncrementalLoadingCollection there's an unnecessary call to LoadMoreItemsAsync() potentially resulting in an unordered list since the second request might finish before the first does.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://raw.githubusercontent.com/Microsoft/UWPCommunityToolkit/tree/master/docs/.template.md). (for bug fixes / features)
- [X] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/Microsoft/UWPCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)


## What is the new behavior?
No more parallel LoadMoreItemsAsync()-calls after refreshing the collection.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
Not sure if renaming RefreshAsync() to Refresh() is considered a "breaking change"...