### PR TITLE
Implementing Tapped on Images in MarkdownTextBlock

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp/Shell.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/Shell.xaml.cs
@@ -520,7 +520,10 @@ namespace Microsoft.Toolkit.Uwp.SampleApp
         private async void DocumentationTextblock_OnLinkClicked(object sender, LinkClickedEventArgs e)
         {
             TrackingManager.TrackEvent("Link", e.Link);
-            await Launcher.LaunchUriAsync(new Uri(e.Link));
+            if (Uri.TryCreate(e.Link, UriKind.Absolute, out Uri result))
+            {
+                await Launcher.LaunchUriAsync(new Uri(e.Link));
+            }
         }
 
         private async void DocumentationTextblock_ImageResolving(object sender, ImageResolvingEventArgs e)

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/LinkClickedEventArgs.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/LinkClickedEventArgs.cs
@@ -19,14 +19,20 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
     /// </summary>
     public class LinkClickedEventArgs : EventArgs
     {
-        internal LinkClickedEventArgs(string link)
+        internal LinkClickedEventArgs(string link, string type)
         {
             Link = link;
+            Type = type;
         }
 
         /// <summary>
         /// Gets the link that was tapped.
         /// </summary>
         public string Link { get; }
+
+        /// <summary>
+        /// Gets the type of link that was tapped.(Image/Link)
+        /// </summary>
+        public string Type { get; }
     }
 }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/LinkReturnType.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/LinkReturnType.cs
@@ -1,4 +1,4 @@
-﻿// ******************************************************************
+// ******************************************************************
 // Copyright (c) Microsoft. All rights reserved.
 // This code is licensed under the MIT License (MIT).
 // THE CODE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
@@ -9,7 +9,6 @@
 // TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH
 // THE CODE OR THE USE OR OTHER DEALINGS IN THE CODE.
 // ******************************************************************
-
 
 namespace Microsoft.Toolkit.Uwp.UI.Controls
 {

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/LinkReturnType.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/LinkReturnType.cs
@@ -10,29 +10,22 @@
 // THE CODE OR THE USE OR OTHER DEALINGS IN THE CODE.
 // ******************************************************************
 
-using System;
 
 namespace Microsoft.Toolkit.Uwp.UI.Controls
 {
     /// <summary>
-    /// Arguments for the OnLinkClicked event which is fired then the user presses a link.
+    /// Return type for Clicked Event
     /// </summary>
-    public class LinkClickedEventArgs : EventArgs
+    public enum LinkReturnType
     {
-        internal LinkClickedEventArgs(string link, LinkReturnType type)
-        {
-            Link = link;
-            Type = type;
-        }
+        /// <summary>
+        /// Returns when Link Clicked is Hyperlink
+        /// </summary>
+        Hyperlink,
 
         /// <summary>
-        /// Gets the link that was tapped.
+        /// Returns when Link Clicked is Image
         /// </summary>
-        public string Link { get; }
-
-        /// <summary>
-        /// Gets the type of link that was tapped.(Image/Link)
-        /// </summary>
-        public LinkReturnType Type { get; }
+        Image
     }
 }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/MarkdownTextBlock.Events.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/MarkdownTextBlock.Events.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// </summary>
         private void Hyperlink_Click(Hyperlink sender, HyperlinkClickEventArgs args)
         {
-            LinkHandled((string)sender.GetValue(HyperlinkUrlProperty), "Hyperlink");
+            LinkHandled((string)sender.GetValue(HyperlinkUrlProperty), LinkReturnType.Hyperlink);
         }
 
         /// <summary>
@@ -57,7 +57,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// </summary>
         private void NewImagelink_Tapped(object sender, Windows.UI.Xaml.Input.TappedRoutedEventArgs e)
         {
-            LinkHandled((string)(sender as Image).GetValue(HyperlinkUrlProperty), "Image");
+            LinkHandled((string)(sender as Image).GetValue(HyperlinkUrlProperty), LinkReturnType.Image);
         }
 
         /// <summary>

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/MarkdownTextBlock.Events.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/MarkdownTextBlock.Events.cs
@@ -15,6 +15,7 @@ using System.Linq;
 using System.Reflection;
 using Windows.UI.Core;
 using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Documents;
 
 namespace Microsoft.Toolkit.Uwp.UI.Controls
@@ -46,29 +47,17 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// <summary>
         /// Fired when a user taps one of the link elements
         /// </summary>
-        private async void Hyperlink_Click(Hyperlink sender, HyperlinkClickEventArgs args)
+        private void Hyperlink_Click(Hyperlink sender, HyperlinkClickEventArgs args)
         {
-            // Links that are nested within superscript elements cause the Click event to fire multiple times.
-            // e.g. this markdown "[^bot](http://www.reddit.com/r/youtubefactsbot/wiki/index)"
-            // Therefore we detect and ignore multiple clicks.
-            if (multiClickDetectionTriggered)
-            {
-                return;
-            }
+            LinkHandled((string)sender.GetValue(HyperlinkUrlProperty), "Hyperlink");
+        }
 
-            multiClickDetectionTriggered = true;
-            await Dispatcher.RunAsync(CoreDispatcherPriority.High, () => multiClickDetectionTriggered = false);
-
-            // Get the hyperlink URL.
-            var url = (string)sender.GetValue(HyperlinkUrlProperty);
-            if (url == null)
-            {
-                return;
-            }
-
-            // Fire off the event.
-            var eventArgs = new LinkClickedEventArgs(url);
-            LinkClicked?.Invoke(this, eventArgs);
+        /// <summary>
+        /// Fired when a user taps one of the image elements
+        /// </summary>
+        private void NewImagelink_Tapped(object sender, Windows.UI.Xaml.Input.TappedRoutedEventArgs e)
+        {
+            LinkHandled((string)(sender as Image).GetValue(HyperlinkUrlProperty), "Image");
         }
 
         /// <summary>

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/MarkdownTextBlock.Methods.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/MarkdownTextBlock.Methods.cs
@@ -166,9 +166,16 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         private void UnhookListeners()
         {
             // Clear any hyper link events if we have any
-            foreach (Hyperlink link in _listeningHyperlinks)
+            foreach (object link in _listeningHyperlinks)
             {
-                link.Click -= Hyperlink_Click;
+                if (link is Hyperlink)
+                {
+                    (link as Hyperlink).Click -= Hyperlink_Click;
+                }
+                else if (link is Image)
+                {
+                    (link as Image).Tapped -= NewImagelink_Tapped;
+                }
             }
 
             // Clear everything that exists.

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/MarkdownTextBlock.Methods.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/MarkdownTextBlock.Methods.cs
@@ -298,7 +298,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// <summary>
         /// Called when a link needs to be handled
         /// </summary>
-        internal async void LinkHandled(string url, string type)
+        internal async void LinkHandled(string url, LinkReturnType type)
         {
             // Links that are nested within superscript elements cause the Click event to fire multiple times.
             // e.g. this markdown "[^bot](http://www.reddit.com/r/youtubefactsbot/wiki/index)"

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/MarkdownTextBlock.Methods.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/MarkdownTextBlock.Methods.cs
@@ -168,13 +168,13 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             // Clear any hyper link events if we have any
             foreach (object link in _listeningHyperlinks)
             {
-                if (link is Hyperlink)
+                if (link is Hyperlink hyperlink)
                 {
-                    (link as Hyperlink).Click -= Hyperlink_Click;
+                    hyperlink.Click -= Hyperlink_Click;
                 }
-                else if (link is Image)
+                else if (link is Image image)
                 {
-                    (link as Image).Tapped -= NewImagelink_Tapped;
+                    image.Tapped -= NewImagelink_Tapped;
                 }
             }
 

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/MarkdownTextBlock.Methods.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/MarkdownTextBlock.Methods.cs
@@ -17,7 +17,9 @@ using System.Threading.Tasks;
 using ColorCode;
 using Microsoft.Toolkit.Parsers.Markdown;
 using Microsoft.Toolkit.Uwp.UI.Controls.Markdown.Render;
+using Windows.UI.Core;
 using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Documents;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Media.Imaging;
@@ -189,6 +191,21 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         }
 
         /// <summary>
+        /// Called when the render has a link we need to listen to.
+        /// </summary>
+        public void RegisterNewHyperLink(Image newImagelink, string linkUrl)
+        {
+            // Setup a listener for clicks.
+            newImagelink.Tapped += NewImagelink_Tapped;
+
+            // Associate the URL with the hyperlink.
+            newImagelink.SetValue(HyperlinkUrlProperty, linkUrl);
+
+            // Add it to our list
+            _listeningHyperlinks.Add(newImagelink);
+        }
+
+        /// <summary>
         /// Called when the renderer needs to display a image.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
@@ -276,6 +293,33 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             {
                 return false;
             }
+        }
+
+        /// <summary>
+        /// Called when a link needs to be handled
+        /// </summary>
+        internal async void LinkHandled(string url, string type)
+        {
+            // Links that are nested within superscript elements cause the Click event to fire multiple times.
+            // e.g. this markdown "[^bot](http://www.reddit.com/r/youtubefactsbot/wiki/index)"
+            // Therefore we detect and ignore multiple clicks.
+            if (multiClickDetectionTriggered)
+            {
+                return;
+            }
+
+            multiClickDetectionTriggered = true;
+            await Dispatcher.RunAsync(CoreDispatcherPriority.High, () => multiClickDetectionTriggered = false);
+
+            // Get the hyperlink URL.
+            if (url == null)
+            {
+                return;
+            }
+
+            // Fire off the event.
+            var eventArgs = new LinkClickedEventArgs(url, type);
+            LinkClicked?.Invoke(this, eventArgs);
         }
     }
 }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/MarkdownTextBlock.Properties.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/MarkdownTextBlock.Properties.cs
@@ -625,7 +625,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// <summary>
         /// Holds a list of hyperlinks we are listening to.
         /// </summary>
-        private readonly List<Hyperlink> _listeningHyperlinks = new List<Hyperlink>();
+        private readonly List<object> _listeningHyperlinks = new List<object>();
 
         /// <summary>
         /// The root element for our rendering.

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/Render/ILinkRegister.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/Render/ILinkRegister.cs
@@ -10,6 +10,7 @@
 // THE CODE OR THE USE OR OTHER DEALINGS IN THE CODE.
 // ******************************************************************
 
+using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Documents;
 
 namespace Microsoft.Toolkit.Uwp.UI.Controls.Markdown.Render
@@ -25,5 +26,12 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls.Markdown.Render
         /// <param name="newHyperlink">Hyperlink to Register.</param>
         /// <param name="linkUrl">Url to Register.</param>
         void RegisterNewHyperLink(Hyperlink newHyperlink, string linkUrl);
+
+        /// <summary>
+        /// Registers a Hyperlink with a LinkUrl.
+        /// </summary>
+        /// <param name="newImagelink">ImageLink to Register.</param>
+        /// <param name="linkUrl">Url to Register.</param>
+        void RegisterNewHyperLink(Image newImagelink, string linkUrl);
     }
 }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/Render/MarkdownRenderer.Inlines.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MarkdownTextBlock/Render/MarkdownRenderer.Inlines.cs
@@ -252,6 +252,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls.Markdown.Render
             var image = new Image();
             var imageContainer = new InlineUIContainer() { Child = image };
 
+            LinkRegister.RegisterNewHyperLink(image, element.Url);
+
             image.Source = resolvedImage;
             image.HorizontalAlignment = HorizontalAlignment.Left;
             image.VerticalAlignment = VerticalAlignment.Top;

--- a/docs/controls/MarkdownTextBlock.md
+++ b/docs/controls/MarkdownTextBlock.md
@@ -28,6 +28,7 @@ Here are some limitations you may encounter:
 
 - Images cannot be embedded inside a hyperlink
 - All images are stretched with the same stretch value (defined by ImageStretch property)
+- Relative Links & Relative Images needs to be handled manually using `LinkClicked` event.
 
 ## Example Image
 Note: scrolling is smooth, the gif below is not.
@@ -95,7 +96,7 @@ The MarkdownTextBlock control is highly customizable to blend with any theme. Cu
 
 ### LinkClicked
 
-Use this event to handle clicking on links for Markdown, by default the MarkdownTextBlock does not handle Clicking on Links.
+Use this event to handle clicking on links or images for Markdown, by default the MarkdownTextBlock does not handle Clicking on Links or Images.
 
 ```c#
 private async void MarkdownText_LinkClicked(object sender, LinkClickedEventArgs e)

--- a/docs/controls/MarkdownTextBlock.md
+++ b/docs/controls/MarkdownTextBlock.md
@@ -108,6 +108,9 @@ private async void MarkdownText_LinkClicked(object sender, LinkClickedEventArgs 
 }
 ```
 
+> [!NOTE]
+The **LinkClicked** event will be raised when either a Hyperlink or an Image is Tapped and will return element Type in **e.LinkType** on **LinkClickedEventArgs**.
+
 
 ### ImageResolving
 


### PR DESCRIPTION
Issue: #1091
<!-- Link to relevant issue. All PRs should be asociated with an issue -->

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build or CI related changes
[ ] Documentation content changes
[ ] Sample app changes
[ ] Other... Please describe:
```


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Images cannot be clicked with current implementation

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://raw.githubusercontent.com/Microsoft/UWPCommunityToolkit/tree/master/docs/.template.md). (for bug fixes / features)
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/Microsoft/UWPCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)


## What is the new behavior?
Images can be tapped and will work as regular Hyperlink giving user option to Handle them in `LinkClicked` event

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->