### PR TITLE
Added check to prevent exceptions when AdaptiveGridView parent availalbe size is Inf

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveGridView.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveGridView.cs
@@ -100,6 +100,13 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// <returns>The calculated item width.</returns>
         protected virtual double CalculateItemWidth(double containerWidth)
         {
+            // quick check for containerWidth to avoid cyclic cases where size
+            // of the container is changed by the size of the items (availableSize == Inf)
+            if (containerWidth > Window.Current.Bounds.Width * 2)
+            {
+                containerWidth = Window.Current.Bounds.Width;
+            }
+
             double desiredWidth = double.IsNaN(DesiredWidth) ? containerWidth : DesiredWidth;
 
             var columns = CalculateColumns(containerWidth, desiredWidth);

--- a/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveGridView.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveGridView.cs
@@ -100,16 +100,12 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// <returns>The calculated item width.</returns>
         protected virtual double CalculateItemWidth(double containerWidth)
         {
-            // quick check for containerWidth to avoid cyclic cases where size
-            // of the container is changed by the size of the items (availableSize == Inf)
-            if (containerWidth > Window.Current.Bounds.Width * 2)
+            if (double.IsNaN(DesiredWidth))
             {
-                containerWidth = Window.Current.Bounds.Width;
+                return DesiredWidth;
             }
 
-            double desiredWidth = double.IsNaN(DesiredWidth) ? containerWidth : DesiredWidth;
-
-            var columns = CalculateColumns(containerWidth, desiredWidth);
+            var columns = CalculateColumns(containerWidth, DesiredWidth);
 
             // If there's less items than there's columns, reduce the column count (if requested);
             if (Items != null && Items.Count > 0 && Items.Count < columns && StretchContentForSingleRow)


### PR DESCRIPTION
Issue: #1321
<!-- Link to relevant issue. All PRs should be asociated with an issue -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When AdaptiveGridView's parent has infinite available size, the control throws an exceptions

## What is the new behavior?
The AdaptiveGridView no longer crashes and sets the desired width of the items to the width of the Window


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [x] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
