### PR TITLE
Fixes #1803 for AdaptiveGridView flicker on 125% DPI.

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveGridView.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveGridView.cs
@@ -164,7 +164,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         {
             // If we are in center alignment, we only care about relayout if the number of columns we can display changes
             // Fixes #1737
-            if (HorizontalAlignment == HorizontalAlignment.Center)
+            if (HorizontalAlignment != HorizontalAlignment.Stretch)
             {
                 var prevColumns = CalculateColumns(e.PreviousSize.Width, DesiredWidth);
                 var newColumns = CalculateColumns(e.NewSize.Width, DesiredWidth);

--- a/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveGridView.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/AdaptiveGridView/AdaptiveGridView.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 _needContainerMarginForLayout = true;
             }
 
-            return (containerWidth / columns) - itemMargin.Left - itemMargin.Right;
+            return (containerWidth / columns) - itemMargin.Left - itemMargin.Right - 1;
         }
 
         /// <summary>


### PR DESCRIPTION
Issue: #1803

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
When DPI is set to 125% the AdaptiveGridView will flicker as its resizing.

## What is the new behavior?
No flicker when resizing.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/Microsoft/UWPCommunityToolkit/blob/master/docs/.template.md). (for bug fixes / features)
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/Microsoft/UWPCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
Not the best fix, but it works.  There seems to be some conflict between our resizing calculations and the internal panel layout.
