### PR TITLE
Fix GridSplitter violating min width of columns

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/GridSplitter/GridSplitter.Events.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/GridSplitter/GridSplitter.Events.cs
@@ -194,6 +194,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             // if sibling row has fixed width then resize it
             else if (!IsStarRow(SiblingRow))
             {
+                // Would adding to this column make the current column violate the MinWidth?
+                if (IsValidRowHeight(CurrentRow, verticalChange) == false)
+                {
+                    return false;
+                }
                 if (!SetRowHeight(SiblingRow, verticalChange * -1, GridUnitType.Pixel))
                 {
                     return true;

--- a/Microsoft.Toolkit.Uwp.UI.Controls/GridSplitter/GridSplitter.Events.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/GridSplitter/GridSplitter.Events.cs
@@ -254,6 +254,12 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             // if sibling column has fixed width then resize it
             else if (!IsStarColumn(SiblingColumn))
             {
+                // Would adding to this column make the current column violate the MinWidth?
+                if (IsValidColumnWidth(CurrentColumn, horizontalChange) == false)
+                {
+                    return false;
+                }
+
                 if (!SetColumnWidth(SiblingColumn, horizontalChange * -1, GridUnitType.Pixel))
                 {
                     return true;


### PR DESCRIPTION
Issue: #1835
<!-- Link to relevant issue. All PRs should be asociated with an issue -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Adjusting the splitter will violate min width of the first column whensecond column is not star sized.

## What is the new behavior?
Splitter respects the min width

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [x] Contains **NO** breaking changes