### PR TITLE
sync thumbs on left/right arrow keys

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/RangeSelector/RangeSelector.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/RangeSelector/RangeSelector.cs
@@ -195,10 +195,12 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             {
                 case VirtualKey.Left:
                     RangeMin -= 1;
+                    SyncThumbs();
                     e.Handled = true;
                     break;
                 case VirtualKey.Right:
                     RangeMin += 1;
+                    SyncThumbs();
                     e.Handled = true;
                     break;
             }
@@ -210,10 +212,12 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             {
                 case VirtualKey.Left:
                     RangeMax -= 1;
+                    SyncThumbs();
                     e.Handled = true;
                     break;
                 case VirtualKey.Right:
                     RangeMax += 1;
+                    SyncThumbs();
                     e.Handled = true;
                     break;
             }

--- a/Microsoft.Toolkit.Uwp.UI.Controls/RangeSelector/RangeSelector.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/RangeSelector/RangeSelector.cs
@@ -194,12 +194,12 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             switch (e.Key)
             {
                 case VirtualKey.Left:
-                    RangeMin -= 1;
+                    RangeMin -= StepFrequency;
                     SyncThumbs();
                     e.Handled = true;
                     break;
                 case VirtualKey.Right:
-                    RangeMin += 1;
+                    RangeMin += StepFrequency;
                     SyncThumbs();
                     e.Handled = true;
                     break;
@@ -211,12 +211,12 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             switch (e.Key)
             {
                 case VirtualKey.Left:
-                    RangeMax -= 1;
+                    RangeMax -= StepFrequency;
                     SyncThumbs();
                     e.Handled = true;
                     break;
                 case VirtualKey.Right:
-                    RangeMax += 1;
+                    RangeMax += StepFrequency;
                     SyncThumbs();
                     e.Handled = true;
                     break;


### PR DESCRIPTION
Issue: #1356
<!-- Link to relevant issue. All PRs should be asociated with an issue -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When manipulating the thumbs using arrow keys the value is changed, but they thumbs don't move to the value position

## What is the new behavior?
The thumbs move to the correct position when manipulating the slider using keyboard

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x ] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/Microsoft/UWPCommunityToolkit/blob/master/docs/.template.md). (for bug fixes / features)
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/Microsoft/UWPCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ x] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
