### PR TITLE
Alternate color of items when items are added or removed

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI/Extensions/ListViewBase/ListViewExtensions.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/ListViewBase/ListViewExtensions.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions
     public static class ListViewExtensions
     {
         private static Dictionary<IObservableVector<object>, Windows.UI.Xaml.Controls.ListViewBase> _itemsForList = new Dictionary<IObservableVector<object>, Windows.UI.Xaml.Controls.ListViewBase>();
-    
+
         /// <summary>
         /// Attached <see cref="DependencyProperty"/> for binding a <see cref="Brush"/> as an alternate background color to a <see cref="Windows.UI.Xaml.Controls.ListViewBase"/>
         /// </summary>
@@ -112,12 +112,14 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions
 
             listViewBase.ContainerContentChanging -= ColorContainerContentChanging;
             listViewBase.Items.VectorChanged -= ColorItemsVectorChanged;
+            listViewBase.Unloaded -= OnListViewBaseUnloaded;
 
             _itemsForList[listViewBase.Items] = listViewBase;
             if (AlternateColorProperty != null)
             {
                 listViewBase.ContainerContentChanging += ColorContainerContentChanging;
                 listViewBase.Items.VectorChanged += ColorItemsVectorChanged;
+                listViewBase.Unloaded += OnListViewBaseUnloaded;
             }
         }
 
@@ -234,6 +236,16 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions
             {
                 itemContainer.HorizontalContentAlignment = HorizontalAlignment.Stretch;
             }
+        }
+
+        private static void OnListViewBaseUnloaded(object sender, RoutedEventArgs e)
+        {
+            Windows.UI.Xaml.Controls.ListViewBase listViewBase = sender as Windows.UI.Xaml.Controls.ListViewBase;
+            _itemsForList.Remove(listViewBase.Items);
+
+            listViewBase.ContainerContentChanging -= ColorContainerContentChanging;
+            listViewBase.Items.VectorChanged -= ColorItemsVectorChanged;
+            listViewBase.Unloaded -= OnListViewBaseUnloaded;
         }
     }
 }

--- a/Microsoft.Toolkit.Uwp.UI/Extensions/ListViewBase/ListViewExtensions.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/ListViewBase/ListViewExtensions.cs
@@ -123,6 +123,12 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions
 
         private static void ColorItemsVectorChanged(IObservableVector<object> sender, IVectorChangedEventArgs args)
         {
+            // If the index is at the end we can ignore
+            if (args.Index == (sender.Count - 1))
+            {
+                return;
+            }
+
             // Only need to handle Inserted and Removed because we'll handle everything else in the
             // ColorContainerContentChanging method
             if ((args.CollectionChange == CollectionChange.ItemInserted) || (args.CollectionChange == CollectionChange.ItemRemoved))

--- a/Microsoft.Toolkit.Uwp.UI/Extensions/ListViewBase/ListViewExtensions.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/ListViewBase/ListViewExtensions.cs
@@ -126,9 +126,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions
         private static void ColorContainerContentChanging(Windows.UI.Xaml.Controls.ListViewBase sender, ContainerContentChangingEventArgs args)
         {
             var itemContainer = args.ItemContainer as Control;
-            var itemIndex = sender.IndexFromContainer(itemContainer);
 
-            SetItemContainerBackground(sender, itemContainer, itemIndex);
+            SetItemContainerBackground(sender, itemContainer, args.ItemIndex);
         }
 
         private static void OnAlternateItemTemplatePropertyChanged(DependencyObject sender, DependencyPropertyChangedEventArgs args)
@@ -153,9 +152,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions
         private static void ItemTemplateContainerContentChanging(Windows.UI.Xaml.Controls.ListViewBase sender, ContainerContentChangingEventArgs args)
         {
             var itemContainer = args.ItemContainer as SelectorItem;
-            var itemIndex = sender.IndexFromContainer(itemContainer);
 
-            if (itemIndex % 2 == 0)
+            if (args.ItemIndex % 2 == 0)
             {
                 itemContainer.ContentTemplate = GetAlternateItemTemplate(sender);
             }

--- a/Microsoft.Toolkit.Uwp.UI/Extensions/ListViewBase/ListViewExtensions.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/ListViewBase/ListViewExtensions.cs
@@ -138,14 +138,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions
                     var itemContainer = listViewBase.ContainerFromIndex(i) as Control;
                     if (itemContainer != null)
                     {
-                        if (i % 2 == 0)
-                        {
-                            itemContainer.Background = GetAlternateColor(listViewBase);
-                        }
-                        else
-                        {
-                            itemContainer.Background = null;
-                        }
+                        SetItemContainerBackground(listViewBase, itemContainer, i);
                     }
                 }
             }
@@ -153,9 +146,14 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions
 
         private static void ColorContainerContentChanging(Windows.UI.Xaml.Controls.ListViewBase sender, ContainerContentChangingEventArgs args)
         {
-            var itemContainer = args.ItemContainer as SelectorItem;
+            var itemContainer = args.ItemContainer as Control;
             var itemIndex = sender.IndexFromContainer(itemContainer);
 
+            SetItemContainerBackground(sender, itemContainer, itemIndex);
+        }
+
+        private static void SetItemContainerBackground(Windows.UI.Xaml.Controls.ListViewBase sender, Control itemContainer, int itemIndex)
+        {
             if (itemIndex % 2 == 0)
             {
                 itemContainer.Background = GetAlternateColor(sender);

--- a/Microsoft.Toolkit.Uwp.UI/Extensions/ListViewBase/ListViewExtensions.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/ListViewBase/ListViewExtensions.cs
@@ -123,54 +123,12 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions
             }
         }
 
-        private static void ColorItemsVectorChanged(IObservableVector<object> sender, IVectorChangedEventArgs args)
-        {
-            // If the index is at the end we can ignore
-            if (args.Index == (sender.Count - 1))
-            {
-                return;
-            }
-
-            // Only need to handle Inserted and Removed because we'll handle everything else in the
-            // ColorContainerContentChanging method
-            if ((args.CollectionChange == CollectionChange.ItemInserted) || (args.CollectionChange == CollectionChange.ItemRemoved))
-            {
-                _itemsForList.TryGetValue(sender, out Windows.UI.Xaml.Controls.ListViewBase listViewBase);
-                if (listViewBase == null)
-                {
-                    return;
-                }
-
-                int index = (int)args.Index;
-                for (int i = index; i < sender.Count; i++)
-                {
-                    var itemContainer = listViewBase.ContainerFromIndex(i) as Control;
-                    if (itemContainer != null)
-                    {
-                        SetItemContainerBackground(listViewBase, itemContainer, i);
-                    }
-                }
-            }
-        }
-
         private static void ColorContainerContentChanging(Windows.UI.Xaml.Controls.ListViewBase sender, ContainerContentChangingEventArgs args)
         {
             var itemContainer = args.ItemContainer as Control;
             var itemIndex = sender.IndexFromContainer(itemContainer);
 
             SetItemContainerBackground(sender, itemContainer, itemIndex);
-        }
-
-        private static void SetItemContainerBackground(Windows.UI.Xaml.Controls.ListViewBase sender, Control itemContainer, int itemIndex)
-        {
-            if (itemIndex % 2 == 0)
-            {
-                itemContainer.Background = GetAlternateColor(sender);
-            }
-            else
-            {
-                itemContainer.Background = null;
-            }
         }
 
         private static void OnAlternateItemTemplatePropertyChanged(DependencyObject sender, DependencyPropertyChangedEventArgs args)
@@ -246,6 +204,48 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions
             listViewBase.ContainerContentChanging -= ColorContainerContentChanging;
             listViewBase.Items.VectorChanged -= ColorItemsVectorChanged;
             listViewBase.Unloaded -= OnListViewBaseUnloaded;
+        }
+
+        private static void ColorItemsVectorChanged(IObservableVector<object> sender, IVectorChangedEventArgs args)
+        {
+            // If the index is at the end we can ignore
+            if (args.Index == (sender.Count - 1))
+            {
+                return;
+            }
+
+            // Only need to handle Inserted and Removed because we'll handle everything else in the
+            // ColorContainerContentChanging method
+            if ((args.CollectionChange == CollectionChange.ItemInserted) || (args.CollectionChange == CollectionChange.ItemRemoved))
+            {
+                _itemsForList.TryGetValue(sender, out Windows.UI.Xaml.Controls.ListViewBase listViewBase);
+                if (listViewBase == null)
+                {
+                    return;
+                }
+
+                int index = (int)args.Index;
+                for (int i = index; i < sender.Count; i++)
+                {
+                    var itemContainer = listViewBase.ContainerFromIndex(i) as Control;
+                    if (itemContainer != null)
+                    {
+                        SetItemContainerBackground(listViewBase, itemContainer, i);
+                    }
+                }
+            }
+        }
+
+        private static void SetItemContainerBackground(Windows.UI.Xaml.Controls.ListViewBase sender, Control itemContainer, int itemIndex)
+        {
+            if (itemIndex % 2 == 0)
+            {
+                itemContainer.Background = GetAlternateColor(sender);
+            }
+            else
+            {
+                itemContainer.Background = null;
+            }
         }
     }
 }

--- a/Microsoft.Toolkit.Uwp.UI/Extensions/ListViewBase/ListViewExtensions.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/ListViewBase/ListViewExtensions.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions
     public static class ListViewExtensions
     {
         private static Dictionary<IObservableVector<object>, Windows.UI.Xaml.Controls.ListViewBase> _itemsForList = new Dictionary<IObservableVector<object>, Windows.UI.Xaml.Controls.ListViewBase>();
-
+    
         /// <summary>
         /// Attached <see cref="DependencyProperty"/> for binding a <see cref="Brush"/> as an alternate background color to a <see cref="Windows.UI.Xaml.Controls.ListViewBase"/>
         /// </summary>
@@ -133,7 +133,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions
                     return;
                 }
 
-                for (int i = 0; i < sender.Count; i++)
+                int index = (int)args.Index;
+                for (int i = index; i < sender.Count; i++)
                 {
                     var itemContainer = listViewBase.ContainerFromIndex(i) as Control;
                     if (itemContainer != null)

--- a/Microsoft.Toolkit.Uwp.UI/Extensions/ListViewBase/ListViewExtensions.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/ListViewBase/ListViewExtensions.cs
@@ -141,10 +141,12 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions
             }
 
             listViewBase.ContainerContentChanging -= ItemTemplateContainerContentChanging;
+            listViewBase.Unloaded -= OnListViewBaseUnloaded;
 
             if (AlternateItemTemplateProperty != null)
             {
                 listViewBase.ContainerContentChanging += ItemTemplateContainerContentChanging;
+                listViewBase.Unloaded += OnListViewBaseUnloaded;
             }
         }
 
@@ -173,10 +175,12 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions
             }
 
             listViewBase.ContainerContentChanging -= StretchItemContainerDirectionChanging;
+            listViewBase.Unloaded -= OnListViewBaseUnloaded;
 
             if (StretchItemContainerDirectionProperty != null)
             {
                 listViewBase.ContainerContentChanging += StretchItemContainerDirectionChanging;
+                listViewBase.Unloaded += OnListViewBaseUnloaded;
             }
         }
 
@@ -201,6 +205,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions
             Windows.UI.Xaml.Controls.ListViewBase listViewBase = sender as Windows.UI.Xaml.Controls.ListViewBase;
             _itemsForList.Remove(listViewBase.Items);
 
+            listViewBase.ContainerContentChanging -= StretchItemContainerDirectionChanging;
+            listViewBase.ContainerContentChanging -= ItemTemplateContainerContentChanging;
             listViewBase.ContainerContentChanging -= ColorContainerContentChanging;
             listViewBase.Items.VectorChanged -= ColorItemsVectorChanged;
             listViewBase.Unloaded -= OnListViewBaseUnloaded;


### PR DESCRIPTION
Issue: #1837
<!-- Link to relevant issue. All PRs should be asociated with an issue -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When an item is added or removed from a list, the item itself gets the correct color but items below it do not update

## What is the new behavior?
When an item is inserted or removed the background color will update for that item and all items below it

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [x] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
Change also unsubscribes from all events for the ListViewBase control. 