### PR TITLE
Fixed Twitter home query

### DIFF
--- a/Microsoft.Toolkit.Uwp.Services/Services/Twitter/TwitterDataProvider.cs
+++ b/Microsoft.Toolkit.Uwp.Services/Services/Twitter/TwitterDataProvider.cs
@@ -507,11 +507,11 @@ namespace Microsoft.Toolkit.Uwp.Services.Twitter
                     items = await SearchAsync(config.Query, maxRecords, parser);
                     break;
 
-                case TwitterQueryType.Home:
                 case TwitterQueryType.Custom:
                     items = await GetCustomSearch(config.Query, parser);
                     break;
 
+                case TwitterQueryType.Home:
                 default:
                     items = await GetHomeTimeLineAsync(maxRecords, parser);
                     break;


### PR DESCRIPTION
Issue: #1872 
<!-- Link to relevant issue. All PRs should be asociated with an issue -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix 
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
#1872 


## What is the new behavior?
Calling the RequestAsync method of the TwitterService like the following snippet
```
var twitterDataConfig = new TwitterDataConfig()
            {
                QueryType = TwitterQueryType.Home
            };

await TwitterService.Instance.RequestAsync(twitterDataConfig, 5);
```
returns the tweets from the logged user's home timeline.
## PR Checklist

Please check if your PR fulfills the following requirements:
- [X] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->