### PR TITLE
Disable context continuation for ImageCache

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI/Cache/CacheBase.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Cache/CacheBase.cs
@@ -32,6 +32,7 @@ namespace Microsoft.Toolkit.Uwp.UI
         /// <summary>
         /// Gets or sets a value indicating whether context should be maintained until type has been instantiated or not.
         /// </summary>
+        [Obsolete("This property will be removed in future releases.")]
         protected bool MaintainContext { get; set; }
 
         private class ConcurrentRequest
@@ -356,7 +357,7 @@ namespace Microsoft.Toolkit.Uwp.UI
             // if similar request exists check if it was preCacheOnly and validate that current request isn't preCacheOnly
             if (request != null && request.EnsureCachedCopy && !preCacheOnly)
             {
-                await request.Task.ConfigureAwait(MaintainContext);
+                await request.Task.ConfigureAwait(false);
                 request = null;
             }
 
@@ -373,7 +374,7 @@ namespace Microsoft.Toolkit.Uwp.UI
 
             try
             {
-                instance = await request.Task.ConfigureAwait(MaintainContext);
+                instance = await request.Task.ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -411,12 +412,12 @@ namespace Microsoft.Toolkit.Uwp.UI
                 return instance;
             }
 
-            var folder = await GetCacheFolderAsync().ConfigureAwait(MaintainContext);
-            baseFile = await folder.TryGetItemAsync(fileName).AsTask().ConfigureAwait(MaintainContext) as StorageFile;
+            var folder = await GetCacheFolderAsync().ConfigureAwait(false);
+            baseFile = await folder.TryGetItemAsync(fileName).AsTask().ConfigureAwait(false) as StorageFile;
 
-            if (baseFile == null || await IsFileOutOfDateAsync(baseFile, CacheDuration).ConfigureAwait(MaintainContext))
+            if (baseFile == null || await IsFileOutOfDateAsync(baseFile, CacheDuration).ConfigureAwait(false))
             {
-                baseFile = await folder.CreateFileAsync(fileName, CreationCollisionOption.ReplaceExisting).AsTask().ConfigureAwait(MaintainContext);
+                baseFile = await folder.CreateFileAsync(fileName, CreationCollisionOption.ReplaceExisting).AsTask().ConfigureAwait(false);
 
                 uint retries = 0;
                 try
@@ -425,7 +426,7 @@ namespace Microsoft.Toolkit.Uwp.UI
                     {
                         try
                         {
-                            instance = await DownloadFileAsync(uri, baseFile, preCacheOnly, cancellationToken, initializerKeyValues).ConfigureAwait(MaintainContext);
+                            instance = await DownloadFileAsync(uri, baseFile, preCacheOnly, cancellationToken, initializerKeyValues).ConfigureAwait(false);
 
                             if (instance != null)
                             {
@@ -448,7 +449,7 @@ namespace Microsoft.Toolkit.Uwp.UI
 
             if (EqualityComparer<T>.Default.Equals(instance, default(T)) && !preCacheOnly)
             {
-                instance = await InitializeTypeAsync(baseFile, initializerKeyValues).ConfigureAwait(MaintainContext);
+                instance = await InitializeTypeAsync(baseFile, initializerKeyValues).ConfigureAwait(false);
 
                 if (_inMemoryFileStorage.MaxItemCount > 0)
                 {

--- a/Microsoft.Toolkit.Uwp.UI/Cache/ImageCache.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Cache/ImageCache.cs
@@ -10,6 +10,7 @@
 // THE CODE OR THE USE OR OTHER DEALINGS IN THE CODE.
 // ******************************************************************
 
+using Microsoft.Toolkit.Uwp.Helpers;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -47,7 +48,6 @@ namespace Microsoft.Toolkit.Uwp.UI
         public ImageCache()
         {
             _extendedPropertyNames.Add(DateAccessedProperty);
-            MaintainContext = true;
         }
 
         /// <summary>
@@ -63,29 +63,32 @@ namespace Microsoft.Toolkit.Uwp.UI
                 throw new FileNotFoundException();
             }
 
-            BitmapImage image = new BitmapImage();
-
-            if (initializerKeyValues != null && initializerKeyValues.Count > 0)
+            return await DispatcherHelper.ExecuteOnUIThreadAsync(async () =>
             {
-                foreach (var kvp in initializerKeyValues)
+                BitmapImage image = new BitmapImage();
+
+                if (initializerKeyValues != null && initializerKeyValues.Count > 0)
                 {
-                    if (string.IsNullOrWhiteSpace(kvp.Key))
+                    foreach (var kvp in initializerKeyValues)
                     {
-                        continue;
-                    }
+                        if (string.IsNullOrWhiteSpace(kvp.Key))
+                        {
+                            continue;
+                        }
 
-                    var propInfo = image.GetType().GetProperty(kvp.Key, BindingFlags.Public | BindingFlags.Instance);
+                        var propInfo = image.GetType().GetProperty(kvp.Key, BindingFlags.Public | BindingFlags.Instance);
 
-                    if (propInfo != null && propInfo.CanWrite)
-                    {
-                        propInfo.SetValue(image, kvp.Value);
+                        if (propInfo != null && propInfo.CanWrite)
+                        {
+                            propInfo.SetValue(image, kvp.Value);
+                        }
                     }
                 }
-            }
 
-            await image.SetSourceAsync(stream.AsRandomAccessStream()).AsTask().ConfigureAwait(false);
+                await image.SetSourceAsync(stream.AsRandomAccessStream()).AsTask().ConfigureAwait(false);
 
-            return image;
+                return image;
+            });
         }
 
         /// <summary>
@@ -96,9 +99,9 @@ namespace Microsoft.Toolkit.Uwp.UI
         /// <returns>awaitable task</returns>
         protected override async Task<BitmapImage> InitializeTypeAsync(StorageFile baseFile, List<KeyValuePair<string, object>> initializerKeyValues = null)
         {
-            using (var stream = await baseFile.OpenStreamForReadAsync().ConfigureAwait(MaintainContext))
+            using (var stream = await baseFile.OpenStreamForReadAsync().ConfigureAwait(false))
             {
-                return await InitializeTypeAsync(stream, initializerKeyValues).ConfigureAwait(MaintainContext);
+                return await InitializeTypeAsync(stream, initializerKeyValues).ConfigureAwait(false);
             }
         }
 


### PR DESCRIPTION
Do not use MaintainContext property.
Execute Bitmap rendering code on Dispatcher thread.

Issue: #1870<!-- Link to relevant issue. All PRs should be asociated with an issue -->

## PR Type
What kind of change does this PR introduce?

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
ImageCache maintains the thread context across async tasks to ensure that Bitmap is rendered without issues

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/Microsoft/UWPCommunityToolkit/blob/master/docs/.template.md). (for bug fixes / features)
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/Microsoft/UWPCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
