### PR TITLE
PrintHelper Print Settings Customization

### DIFF
--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/PrintHelper/PrintHelperCode.bind
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/PrintHelper/PrintHelperCode.bind
@@ -1,7 +1,16 @@
+// Create a new PrintHelperOptions instance
+var defaultPrintHelperOptions = new PrintHelperOptions();
+ 
+//Add options that you want to be displayed on the print dialog
+defaultPrintHelperOptions.AddDisplayOption(StandardPrintTaskOptions.Orientation);
+ 
+//Set preselected settings
+defaultPrintHelperOptions.Orientation = PrintOrientation.Landscape;
+
 // Create a new PrintHelper instance
 // "container" is a XAML panel that will be used to host printable control. 
 // It needs to be in your visual tree but can be hidden with Opacity = 0
-var printHelper = new PrintHelper(container);
+var printHelper = new PrintHelper(container, defaultPrintHelperOptions);
 
 // Add controls that you want to print
 printHelper.AddFrameworkElementToPrint(await PrepareWebViewForPrintingAsync());

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/PrintHelper/PrintHelperPage.xaml
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/PrintHelper/PrintHelperPage.xaml
@@ -19,6 +19,8 @@
                 <RowDefinition />
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
             <Grid x:Name="Container"
                   Grid.RowSpan="2"
@@ -64,6 +66,12 @@
                         HorizontalAlignment="Center"
                         Orientation="Horizontal">
                 <CheckBox Margin="10,0,0,0" Name="ShowOrientationCheckBox">Show orientation in print dialog</CheckBox>
+            </StackPanel>
+            <StackPanel Grid.Row="4"
+                        Margin="20"
+                        HorizontalAlignment="Center"
+                        Orientation="Horizontal">
+                <TextBlock VerticalAlignment="Center">Default orientation setting</TextBlock>
                 <ComboBox Margin="10,0,0,0" Name="DefaultOrientationComboBox">
                 </ComboBox>
             </StackPanel>

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/PrintHelper/PrintHelperPage.xaml
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/PrintHelper/PrintHelperPage.xaml
@@ -59,6 +59,14 @@
                         Content="Direct Print Me!" />
             </StackPanel>
             <TextBlock Grid.Row="2" HorizontalAlignment="Center">Direct Print will print the content without removing it from the visual tree (in place).</TextBlock>
+            <StackPanel Grid.Row="3"
+                        Margin="20"
+                        HorizontalAlignment="Center"
+                        Orientation="Horizontal">
+                <CheckBox Margin="10,0,0,0" Name="ShowOrientationCheckBox">Show orientation in print dialog</CheckBox>
+                <ComboBox Margin="10,0,0,0" Name="DefaultOrientationComboBox">
+                </ComboBox>
+            </StackPanel>
         </Grid>
     </Grid>
 </Page>

--- a/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/PrintHelper/PrintHelperPage.xaml.cs
+++ b/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/PrintHelper/PrintHelperPage.xaml.cs
@@ -11,7 +11,9 @@
 // ******************************************************************
 
 using System;
+using System.Collections.Generic;
 using Microsoft.Toolkit.Uwp.Helpers;
+using Windows.Graphics.Printing;
 using Windows.UI.Popups;
 
 namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
@@ -23,6 +25,16 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
         public PrintHelperPage()
         {
             InitializeComponent();
+
+            ShowOrientationCheckBox.IsChecked = true;
+
+            DefaultOrientationComboBox.ItemsSource = new List<PrintOrientation>()
+            {
+                PrintOrientation.Default,
+                PrintOrientation.Portrait,
+                PrintOrientation.Landscape
+            };
+            DefaultOrientationComboBox.SelectedIndex = 0;
         }
 
         private async void Print_Click(object sender, Windows.UI.Xaml.RoutedEventArgs e)
@@ -38,7 +50,15 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
             _printHelper.OnPrintFailed += PrintHelper_OnPrintFailed;
             _printHelper.OnPrintSucceeded += PrintHelper_OnPrintSucceeded;
 
-            await _printHelper.ShowPrintUIAsync("UWP Community Toolkit Sample App");
+            var printHelperOptions = new PrintHelperOptions(false);
+            printHelperOptions.Orientation = (PrintOrientation)DefaultOrientationComboBox.SelectedItem;
+
+            if (ShowOrientationCheckBox.IsChecked.HasValue && ShowOrientationCheckBox.IsChecked.Value)
+            {
+                printHelperOptions.AddDisplayOption(StandardPrintTaskOptions.Orientation);
+            }
+
+            await _printHelper.ShowPrintUIAsync("UWP Community Toolkit Sample App", printHelperOptions);
         }
 
         private async void DirectPrint_Click(object sender, Windows.UI.Xaml.RoutedEventArgs e)
@@ -51,7 +71,15 @@ namespace Microsoft.Toolkit.Uwp.SampleApp.SamplePages
             _printHelper.OnPrintFailed += PrintHelper_OnPrintFailed;
             _printHelper.OnPrintSucceeded += PrintHelper_OnPrintSucceeded;
 
-            await _printHelper.ShowPrintUIAsync("UWP Community Toolkit Sample App", true);
+            var printHelperOptions = new PrintHelperOptions(false);
+            printHelperOptions.Orientation = (PrintOrientation)DefaultOrientationComboBox.SelectedItem;
+
+            if (ShowOrientationCheckBox.IsChecked.HasValue && ShowOrientationCheckBox.IsChecked.Value)
+            {
+                printHelperOptions.AddDisplayOption(StandardPrintTaskOptions.Orientation);
+            }
+
+            await _printHelper.ShowPrintUIAsync("UWP Community Toolkit Sample App", printHelperOptions, true);
         }
 
         private void ReleasePrintHelper()

--- a/Microsoft.Toolkit.Uwp/Helpers/PrintHelper/PrintHelper.cs
+++ b/Microsoft.Toolkit.Uwp/Helpers/PrintHelper/PrintHelper.cs
@@ -99,10 +99,16 @@ namespace Microsoft.Toolkit.Uwp.Helpers
         private PrintHelperOptions _printHelperOptions;
 
         /// <summary>
+        /// Gets the default options for the print dialog
+        /// </summary>
+        private PrintHelperOptions _defaultPrintHelperOptions;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="PrintHelper"/> class.
         /// </summary>
         /// <param name="canvasContainer">XAML panel used to attach printing canvas. Can be hidden in your UI with Opacity = 0 for instance</param>
-        public PrintHelper(Panel canvasContainer)
+        /// /// <param name="defaultPrintHelperOptions">Default settings for the print tasks</param>
+        public PrintHelper(Panel canvasContainer, PrintHelperOptions defaultPrintHelperOptions = null)
         {
             if (canvasContainer == null)
             {
@@ -116,6 +122,8 @@ namespace Microsoft.Toolkit.Uwp.Helpers
             _canvasContainer = canvasContainer;
 
             _elementsToPrint = new List<FrameworkElement>();
+
+            _defaultPrintHelperOptions = defaultPrintHelperOptions ?? new PrintHelperOptions();
 
             RegisterForPrinting();
         }
@@ -241,22 +249,7 @@ namespace Microsoft.Toolkit.Uwp.Helpers
             PrintTask printTask = null;
             printTask = e.Request.CreatePrintTask(_printTaskName, sourceRequested =>
             {
-                if (_printHelperOptions != null)
-                {
-                    IEnumerable<string> displayedOptionsToAdd = _printHelperOptions.DisplayedOptions;
-                    if (!_printHelperOptions.ExtendDisplayedOptions)
-                    {
-                        printTask.Options.DisplayedOptions.Clear();
-                    }
-                    else
-                    {
-                        displayedOptionsToAdd = displayedOptionsToAdd.Where(option => !printTask.Options.DisplayedOptions.Contains(option));
-                    }
-                    foreach (var displayedOption in displayedOptionsToAdd)
-                    {
-                        printTask.Options.DisplayedOptions.Add(displayedOption);
-                    }
-                }
+                ApplyPrintSettings(printTask);
 
                 // Print Task event handler is invoked when the print job is completed.
                 printTask.Completed += async (s, args) =>
@@ -295,6 +288,40 @@ namespace Microsoft.Toolkit.Uwp.Helpers
 
                 sourceRequested.SetSource(_printDocumentSource);
             });
+        }
+
+        private void ApplyPrintSettings(PrintTask printTask)
+        {
+            _printHelperOptions = _printHelperOptions ?? _defaultPrintHelperOptions;
+
+            IEnumerable<string> displayedOptionsToAdd = _printHelperOptions.DisplayedOptions;
+
+            if (!_printHelperOptions.ExtendDisplayedOptions)
+            {
+                printTask.Options.DisplayedOptions.Clear();
+            }
+
+            foreach (var displayedOption in displayedOptionsToAdd)
+            {
+                if (!printTask.Options.DisplayedOptions.Contains(displayedOption))
+                {
+                    printTask.Options.DisplayedOptions.Add(displayedOption);
+                }
+            }
+
+            printTask.Options.Binding = _printHelperOptions.Binding == PrintBinding.Default ? printTask.Options.Binding : _printHelperOptions.Binding;
+            printTask.Options.Bordering = _printHelperOptions.Bordering == PrintBordering.Default ? printTask.Options.Bordering : _printHelperOptions.Bordering;
+            printTask.Options.MediaType = _printHelperOptions.MediaType == PrintMediaType.Default ? printTask.Options.MediaType : _printHelperOptions.MediaType;
+            printTask.Options.MediaSize = _printHelperOptions.MediaSize == PrintMediaSize.Default ? printTask.Options.MediaSize : _printHelperOptions.MediaSize;
+            printTask.Options.HolePunch = _printHelperOptions.HolePunch == PrintHolePunch.Default ? printTask.Options.HolePunch : _printHelperOptions.HolePunch;
+            printTask.Options.Duplex = _printHelperOptions.Duplex == PrintDuplex.Default ? printTask.Options.Duplex : _printHelperOptions.Duplex;
+            printTask.Options.ColorMode = _printHelperOptions.ColorMode == PrintColorMode.Default ? printTask.Options.ColorMode : _printHelperOptions.ColorMode;
+            printTask.Options.Collation = _printHelperOptions.Collation == PrintCollation.Default ? printTask.Options.Collation : _printHelperOptions.Collation;
+            printTask.Options.PrintQuality = _printHelperOptions.PrintQuality == PrintQuality.Default ? printTask.Options.PrintQuality : _printHelperOptions.PrintQuality;
+            printTask.Options.Staple = _printHelperOptions.Staple == PrintStaple.Default ? printTask.Options.Staple : _printHelperOptions.Staple;
+            printTask.Options.Orientation = _printHelperOptions.Orientation == PrintOrientation.Default ? printTask.Options.Orientation : _printHelperOptions.Orientation;
+
+            _printHelperOptions = null;
         }
 
         /// <summary>

--- a/Microsoft.Toolkit.Uwp/Helpers/PrintHelper/PrintHelperOptions.cs
+++ b/Microsoft.Toolkit.Uwp/Helpers/PrintHelper/PrintHelperOptions.cs
@@ -21,9 +21,9 @@ using Windows.Graphics.Printing;
 namespace Microsoft.Toolkit.Uwp.Helpers
 {
     /// <summary>
-    /// Public class to store settings applyable to a print task
+    /// Public class to store settings applicable to a print task
     /// </summary>
-    public class PrintHelperOptions : IPrintTaskOptionsCoreProperties
+    public class PrintHelperOptions
     {
         /// <summary>
         /// Gets or sets the bordering option for the print task.
@@ -79,21 +79,6 @@ namespace Microsoft.Toolkit.Uwp.Helpers
         /// Gets or sets the orientation option for the print task.
         /// </summary>
         public PrintOrientation Orientation { get; set; }
-
-        /// <summary>
-        /// Gets or sets the value for the number of copies for the print task.
-        /// </summary>
-        public uint NumberOfCopies { get; set; }
-
-        /// <summary>
-        /// Gets the minimum number of copies allowed for the print task.
-        /// </summary>
-        public uint MinCopies { get; }
-
-        /// <summary>
-        /// Gets the maximum number of copies supported for the print task.
-        /// </summary>
-        public uint MaxCopies { get; }
 
         /// <summary>
         /// Gets the options that will be displayed in the printing dialog
@@ -170,7 +155,6 @@ namespace Microsoft.Toolkit.Uwp.Helpers
 
         private void InitializeDefaultOptions()
         {
-            NumberOfCopies = 0;
             Bordering = PrintBordering.Default;
             MediaSize = PrintMediaSize.Default;
             MediaType = PrintMediaType.Default;

--- a/Microsoft.Toolkit.Uwp/Helpers/PrintHelper/PrintHelperOptions.cs
+++ b/Microsoft.Toolkit.Uwp/Helpers/PrintHelper/PrintHelperOptions.cs
@@ -167,5 +167,21 @@ namespace Microsoft.Toolkit.Uwp.Helpers
                                                                       .Where(p => p.PropertyType == typeof(string))
                                                                       .Select(p => (string)p.GetValue(null));
         }
+
+        private void InitializeDefaultOptions()
+        {
+            NumberOfCopies = 0;
+            Bordering = PrintBordering.Default;
+            MediaSize = PrintMediaSize.Default;
+            MediaType = PrintMediaType.Default;
+            HolePunch = PrintHolePunch.Default;
+            Binding = PrintBinding.Default;
+            Duplex = PrintDuplex.Default;
+            ColorMode = PrintColorMode.Default;
+            Collation = PrintCollation.Default;
+            PrintQuality = PrintQuality.Default;
+            Staple = PrintStaple.Default;
+            Orientation = PrintOrientation.Default;
+        }
     }
 }

--- a/Microsoft.Toolkit.Uwp/Helpers/PrintHelper/PrintHelperOptions.cs
+++ b/Microsoft.Toolkit.Uwp/Helpers/PrintHelper/PrintHelperOptions.cs
@@ -1,0 +1,171 @@
+﻿// ******************************************************************
+// Copyright (c) Microsoft. All rights reserved.
+// This code is licensed under the MIT License (MIT).
+// THE CODE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH
+// THE CODE OR THE USE OR OTHER DEALINGS IN THE CODE.
+// ******************************************************************
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.Graphics.Printing;
+
+namespace Microsoft.Toolkit.Uwp.Helpers
+{
+    /// <summary>
+    /// Public class to store settings applyable to a print task
+    /// </summary>
+    public class PrintHelperOptions : IPrintTaskOptionsCoreProperties
+    {
+        /// <summary>
+        /// Gets or sets the bordering option for the print task.
+        /// </summary>
+        public PrintBordering Bordering { get; set; }
+
+        /// <summary>
+        /// Gets or sets the media type option for the print task.
+        /// </summary>
+        public PrintMediaType MediaType { get; set; }
+
+        /// <summary>
+        /// Gets or sets the media size option of the print task.
+        /// </summary>
+        public PrintMediaSize MediaSize { get; set; }
+
+        /// <summary>
+        /// Gets or sets the hole punch option of the print task.
+        /// </summary>
+        public PrintHolePunch HolePunch { get; set; }
+
+        /// <summary>
+        /// Gets or sets the binding option for the print task.
+        /// </summary>
+        public PrintBinding Binding { get; set; }
+
+        /// <summary>
+        /// Gets or sets the duplex option of the print task.
+        /// </summary>
+        public PrintDuplex Duplex { get; set; }
+
+        /// <summary>
+        /// Gets or sets the color mode option of the print task.
+        /// </summary>
+        public PrintColorMode ColorMode { get; set; }
+
+        /// <summary>
+        /// Gets or sets the collation option of the print tasks.
+        /// </summary>
+        public PrintCollation Collation { get; set; }
+
+        /// <summary>
+        /// Gets or sets the print quality option for the print task.
+        /// </summary>
+        public PrintQuality PrintQuality { get; set; }
+
+        /// <summary>
+        /// Gets or sets the staple option for the print task.
+        /// </summary>
+        public PrintStaple Staple { get; set; }
+
+        /// <summary>
+        /// Gets or sets the orientation option for the print task.
+        /// </summary>
+        public PrintOrientation Orientation { get; set; }
+
+        /// <summary>
+        /// Gets or sets the value for the number of copies for the print task.
+        /// </summary>
+        public uint NumberOfCopies { get; set; }
+
+        /// <summary>
+        /// Gets the minimum number of copies allowed for the print task.
+        /// </summary>
+        public uint MinCopies { get; }
+
+        /// <summary>
+        /// Gets the maximum number of copies supported for the print task.
+        /// </summary>
+        public uint MaxCopies { get; }
+
+        /// <summary>
+        /// Gets the options that will be displayed in the printing dialog
+        /// </summary>
+        public IList<string> DisplayedOptions { get; private set; }
+
+        /// <summary>
+        /// Gets the possible display options
+        /// </summary>
+        private IEnumerable<string> _possibleDisplayOptions;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the default displayed options should be kept.
+        /// Defaults to true
+        /// </summary>
+        public bool ExtendDisplayedOptions { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PrintHelperOptions"/> class.
+        /// </summary>
+        /// <param name="extendDisplayedOptions">Boolean used to set up the <see cref="ExtendDisplayedOptions"/> property</param>
+        public PrintHelperOptions(bool extendDisplayedOptions = true)
+        {
+            ExtendDisplayedOptions = extendDisplayedOptions;
+            DisplayedOptions = new List<string>();
+
+            InitializePossibleDisplayOptions();
+        }
+
+        /// <summary>
+        /// Adds a display option
+        /// </summary>
+        /// <param name="displayOption">Display option to add. Must be a part of the <see cref="StandardPrintTaskOptions"/> class</param>
+        public void AddDisplayOption(string displayOption)
+        {
+            if (!_possibleDisplayOptions.Contains(displayOption))
+            {
+                throw new ArgumentException("The display option must be a part of the StandardPrintTaskOptions class");
+            }
+
+            if (DisplayedOptions.Contains(displayOption))
+            {
+                return;
+            }
+
+            DisplayedOptions.Add(displayOption);
+        }
+
+        /// <summary>
+        /// Removes a display option
+        /// </summary>
+        /// <param name="displayOption">Display option to add. Must be a part of the <see cref="StandardPrintTaskOptions"/> class</param>
+        public void RemoveDisplayOption(string displayOption)
+        {
+            if (!_possibleDisplayOptions.Contains(displayOption))
+            {
+                throw new ArgumentException("The display option must be a part of the StandardPrintTaskOptions class");
+            }
+
+            if (!DisplayedOptions.Contains(displayOption))
+            {
+                return;
+            }
+
+            DisplayedOptions.Remove(displayOption);
+        }
+
+        private void InitializePossibleDisplayOptions()
+        {
+            _possibleDisplayOptions = typeof(StandardPrintTaskOptions).GetProperties(BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy)
+                                                                      .Where(p => p.PropertyType == typeof(string))
+                                                                      .Select(p => (string)p.GetValue(null));
+        }
+    }
+}

--- a/docs/helpers/PrintHelper.md
+++ b/docs/helpers/PrintHelper.md
@@ -11,20 +11,22 @@ The PrintHelper is a class used to simplify document printing.
 It allows you to render a framework element per page.
 
 To use it, you only have to instantiate a `PrintHelper` object and call `AddFrameworkElementToPrint` method to add the XAML controls you want to print.
-Please note that controls cannot be linked to a visual tree. This means that their parent property has to be null. 
+Please note that controls cannot be linked to a visual tree. This means that their parent property has to be null.
 If you want to use a control from your current XAML page, you can disconnect it before sending it to print (by removing it from its container) or you can create just create a new one from scratch.
 
-Please check the sample app code to see how to disconnect/reconnect a control that you want to print: 
-https://github.com/Microsoft/UWPCommunityToolkit/blob/master/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/PrintHelper/PrintHelperPage.xaml.cs 
+Please check the sample app code to see how to disconnect/reconnect a control that you want to print:
+https://github.com/Microsoft/UWPCommunityToolkit/blob/master/Microsoft.Toolkit.Uwp.SampleApp/SamplePages/PrintHelper/PrintHelperPage.xaml.cs
 
 Several events are available to control the printing process:
 * OnPrintFailed will be triggered if the user cancels the print or if something goes wrong
 * OnPrintSucceeded will be triggered after a successful print
 * OnPreviewPagesCreated will be triggered after print preview pages are generated. This allows you to control the look and feel of your page before they are sent to the spooler.
 
+In addition, you can customize the printing dialog using the `PrintHelperOptions` class. To use it, create an instance of the class, add the options you'd like to display on the printing dialog and set the default options. Then, you can use it as a parameter in the `PrintHelper` class constructor to set them as the default for the instance, or send them as parameters to `ShowPrintUIAsync` to use them for a single print job.
+
 **Please note that page breaks are not supported. Every control will be printed on a single page**
 
-Since version 1.3, you can also call `ShowPrintUIAsync` with a second parameter to determine that the list of controls to print should directly be taken from the content of the container passed to the PrintHelper constructor. 
+Since version 1.3, you can also call `ShowPrintUIAsync` with a second parameter to determine that the list of controls to print should directly be taken from the content of the container passed to the PrintHelper constructor.
 In this mode you are responsible for the sizing and the layout.
 
 ## Example
@@ -32,7 +34,7 @@ In this mode you are responsible for the sizing and the layout.
 ```csharp
 
 // Create a new PrintHelper instance
-// "container" is a XAML panel that will be used to host printable control. 
+// "container" is a XAML panel that will be used to host printable control.
 // It needs to be in your visual tree but can be hidden with Opacity = 0
 var printHelper = new PrintHelper(container);
 
@@ -69,12 +71,50 @@ Direct print example:
 ```csharp
 
 // Create a new PrintHelper instance
-// "container" is a XAML panel that will be used to get the list of printable controls. 
+// "container" is a XAML panel that will be used to get the list of printable controls.
 var printHelper = new PrintHelper(container);
 
 // Start printing process
 await printHelper.ShowPrintUIAsync("UWP Community Toolkit Sample App", true);
 
+```
+
+Using custom default settings:
+
+```csharp
+// Create a new PrintHelperOptions instance
+var defaultPrintHelperOptions = new PrintHelperOptions();
+
+//Add options that you want to be displayed on the print dialog
+defaultPrintHelperOptions.AddDisplayOption(StandardPrintTaskOptions.Orientation);
+
+//Set preselected settings
+defaultPrintHelperOptions.Orientation = PrintOrientation.Landscape;
+
+// Create a new PrintHelper instance
+// "container" is a XAML panel that will be used to get the list of printable controls.
+var printHelper = new PrintHelper(container, defaultPrintHelperOptions);
+```
+
+Using custom settings for one print job:
+
+```csharp
+// Create a new PrintHelper instance
+// "container" is a XAML panel that will be used to get the list of printable controls.
+// "defaultPrintHelperOptions" is a PrintHelperOptions instance that will be used to get the default options for printing.
+var printHelper = new PrintHelper(container, defaultPrintHelperOptions);
+
+// Create a new PrintHelperOptions instance
+var printHelperOptions = new PrintHelperOptions();
+
+//Add options that you want to be displayed on the print dialog
+printHelperOptions.AddDisplayOption(StandardPrintTaskOptions.Orientation);
+
+//Set preselected settings
+printHelperOptions.Orientation = PrintOrientation.Landscape;
+
+// Start printing process
+await _printHelper.ShowPrintUIAsync("UWP Community Toolkit Sample App", printHelperOptions);
 ```
 
 ## Requirements (Windows 10 Device Family)
@@ -85,4 +125,3 @@ await printHelper.ShowPrintUIAsync("UWP Community Toolkit Sample App", true);
 
 ## API
 * [Print Helper source code](https://github.com/Microsoft/UWPCommunityToolkit/blob/master/Microsoft.Toolkit.Uwp/Helpers/PrintHelper/)
-


### PR DESCRIPTION
Issue: #1152 PrintHelper Horizontal Orientation

## PR Type
What kind of change does this PR introduce?

- Feature
- Documentation content changes 
- Sample app changes 


## What is the current behavior?
There's no way to set up from code the print orientation, along with several other configurations.


## What is the new behavior?
You can setup from code which options will be shown in the print dialog, along with their default values, using the `PrintHelperOptions` class. To use the specified options, you can send them to the `PrintHelper` constructor to be used in every print job of that instance, or send them to the `PrintHelper.ShowPrintUIAsync` method to use them only for that print job. Note that the previous behavior is untouched.

The options to display on the print dialog are stored in the `DisplayedOptions` property. To add or remove an option, you have to use the methods `AddDisplayOption` or `RemoveDisplayOption`. Note that these methods receive strings, but inside they validate that the strings come from the `StandardPrintTaskOptions` class, which contains the allowed options. Also, the property `ExtendDisplayedOptions` (set in the constructor and modifiable at any time) determines if the options set up will be added to the predefined options of the OS (true), or replace the predefined options of the OS (false). 

The default options can be set by changing the value of each enum property in the `PrintHelperOptions` instance. Unless changed, the predefined OS values will be used. You may notice the `NumberOfCopies` setting isn't available, as setting any value or trying to get the current one would throw an exception.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../readme.md#supported)
- [X] Docs have been added/updated which fit [documentation template](https://github.com/Microsoft/UWPCommunityToolkit/blob/master/docs/.template.md). (for bug fixes / features)
- [X] Sample in sample app has been added / updated (for bug fixes / features
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/Microsoft/UWPCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Contains **NO** breaking changes