### PR TITLE
Change Expander to Inherit from HeaderedContentControl

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/Expander/Expander.Properties.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/Expander/Expander.Properties.cs
@@ -20,18 +20,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
     public partial class Expander
     {
         /// <summary>
-        /// Identifies the <see cref="Header"/> dependency property.
-        /// </summary>
-        public static readonly DependencyProperty HeaderProperty =
-            DependencyProperty.Register(nameof(Header), typeof(string), typeof(Expander), new PropertyMetadata(null));
-
-        /// <summary>
-        /// Identifies the <see cref="HeaderTemplate"/> dependency property.
-        /// </summary>
-        public static readonly DependencyProperty HeaderTemplateProperty =
-            DependencyProperty.Register(nameof(HeaderTemplate), typeof(DataTemplate), typeof(Expander), new PropertyMetadata(null));
-
-        /// <summary>
         /// Identifies the <see cref="IsExpanded"/> dependency property.
         /// </summary>
         public static readonly DependencyProperty IsExpandedProperty =
@@ -48,24 +36,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         /// </summary>
         public static readonly DependencyProperty ContentOverlayProperty =
             DependencyProperty.Register(nameof(ContentOverlay), typeof(UIElement), typeof(Expander), new PropertyMetadata(default(UIElement)));
-
-        /// <summary>
-        /// Gets or sets a value indicating whether the Header of the control.
-        /// </summary>
-        public string Header
-        {
-            get { return (string)GetValue(HeaderProperty); }
-            set { SetValue(HeaderProperty, value); }
-        }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether the HeaderTemplate of the control.
-        /// </summary>
-        public DataTemplate HeaderTemplate
-        {
-            get { return (DataTemplate)GetValue(HeaderTemplateProperty); }
-            set { SetValue(HeaderTemplateProperty, value); }
-        }
 
         /// <summary>
         /// Gets or sets a value indicating whether the content of the control is opened/visible or closed/hidden.

--- a/Microsoft.Toolkit.Uwp.UI.Controls/Expander/Expander.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/Expander/Expander.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
     [TemplatePart(Name = LayoutTransformerPart, Type = typeof(LayoutTransformControl))]
     [TemplatePart(Name = ContentOverlayPart, Type = typeof(ContentPresenter))]
     [ContentProperty(Name = "Content")]
-    public partial class Expander : ContentControl
+    public partial class Expander : HeaderedContentControl
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Expander"/> class.


### PR DESCRIPTION
Issue: #1615
<!-- Link to relevant issue. All PRs should be asociated with an issue -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
- Feature

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The Header property only accepts string which limits what can be shown

## What is the new behavior?
The Expander now inherits from HeaderedContentControl which brings along the ability to set content to any object

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/Microsoft/UWPCommunityToolkit/blob/master/docs/.template.md). (for bug fixes / features)
- [ ] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
This changes the return type of Header from string to object. This breaks the following if someone was doing it
```
string header = expander.Header;
```

## Other information
