### PR TITLE
Remove is touch optimized

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls.Design/RangeSelectorMetadata.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.Design/RangeSelectorMetadata.cs
@@ -30,7 +30,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls.Design
                     b.AddCustomAttributes(nameof(RangeSelector.Maximum), new CategoryAttribute(Properties.Resources.CategoryCommon));
                     b.AddCustomAttributes(nameof(RangeSelector.RangeMin), new CategoryAttribute(Properties.Resources.CategoryCommon));
                     b.AddCustomAttributes(nameof(RangeSelector.RangeMax), new CategoryAttribute(Properties.Resources.CategoryCommon));
-                    b.AddCustomAttributes(nameof(RangeSelector.IsTouchOptimized), new CategoryAttribute(Properties.Resources.CategoryCommon));
                     b.AddCustomAttributes(new ToolboxCategoryAttribute(ToolboxCategoryPaths.Toolkit, false));
 				}
 			);

--- a/Microsoft.Toolkit.Uwp.UI.Controls/RangeSelector/RangeSelector.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/RangeSelector/RangeSelector.cs
@@ -61,11 +61,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         public static readonly DependencyProperty RangeMaxProperty = DependencyProperty.Register(nameof(RangeMax), typeof(double), typeof(RangeSelector), new PropertyMetadata(1.0, RangeMaxChangedCallback));
 
         /// <summary>
-        /// Identifies the IsTouchOptimized dependency property.
-        /// </summary>
-        public static readonly DependencyProperty IsTouchOptimizedProperty = DependencyProperty.Register(nameof(IsTouchOptimized), typeof(bool), typeof(RangeSelector), new PropertyMetadata(false, IsTouchOptimizedChangedCallback));
-
-        /// <summary>
         /// Identifies the StepFrequency dependency property.
         /// </summary>
         public static readonly DependencyProperty StepFrequencyProperty = DependencyProperty.Register(nameof(StepFrequency), typeof(double), typeof(RangeSelector), new PropertyMetadata(DefaultStepFrequency));
@@ -180,11 +175,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             VisualStateManager.GoToState(this, IsEnabled ? "Normal" : "Disabled", false);
 
             IsEnabledChanged += RangeSelector_IsEnabledChanged;
-
-            if (IsTouchOptimized)
-            {
-                ArrangeForTouch();
-            }
 
             base.OnApplyTemplate();
         }
@@ -595,36 +585,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
         }
 
         /// <summary>
-        /// Gets or sets a value indicating whether the control is optimized for touch use.
-        /// </summary>
-        /// <value>
-        /// The value for touch optimization.
-        /// </value>
-        public bool IsTouchOptimized
-        {
-            get
-            {
-                return (bool)GetValue(IsTouchOptimizedProperty);
-            }
-
-            set
-            {
-                SetValue(IsTouchOptimizedProperty, value);
-            }
-        }
-
-        private static void IsTouchOptimizedChangedCallback(DependencyObject d, DependencyPropertyChangedEventArgs e)
-        {
-            var rangeSelector = d as RangeSelector;
-            if (rangeSelector == null)
-            {
-                return;
-            }
-
-            rangeSelector.ArrangeForTouch();
-        }
-
-        /// <summary>
         /// Gets or sets the value part of a value range that steps should be created for.
         /// </summary>
         /// <value>
@@ -668,65 +628,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             else
             {
                 return newValue;
-            }
-        }
-
-        private void ArrangeForTouch()
-        {
-            if (_containerCanvas == null)
-            {
-                return;
-            }
-
-            if (IsTouchOptimized)
-            {
-                if (_controlGrid != null)
-                {
-                    _controlGrid.Height = 44;
-                }
-
-                if (_outOfRangeContentContainer != null)
-                {
-                    _outOfRangeContentContainer.Height = 44;
-                }
-
-                if (_minThumb != null)
-                {
-                    _minThumb.Width = _minThumb.Height = 44;
-                    _minThumb.Margin = new Thickness(-20, 0, 0, 0);
-                }
-
-                if (_maxThumb != null)
-                {
-                    _maxThumb.Width = _maxThumb.Height = 44;
-                    _maxThumb.Margin = new Thickness(-20, 0, 0, 0);
-                }
-            }
-            else
-            {
-                if (_controlGrid != null)
-                {
-                    _controlGrid.Height = 24;
-                }
-
-                if (_outOfRangeContentContainer != null)
-                {
-                    _outOfRangeContentContainer.Height = 24;
-                }
-
-                if (_minThumb != null)
-                {
-                    _minThumb.Width = 8;
-                    _minThumb.Height = 24;
-                    _minThumb.Margin = new Thickness(-8, 0, 0, 0);
-                }
-
-                if (_maxThumb != null)
-                {
-                    _maxThumb.Width = 8;
-                    _maxThumb.Height = 24;
-                    _maxThumb.Margin = new Thickness(-8, 0, 0, 0);
-                }
             }
         }
 

--- a/Microsoft.Toolkit.Uwp.UI.Controls/RangeSelector/RangeSelector.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/RangeSelector/RangeSelector.xaml
@@ -19,6 +19,7 @@
                                 <Setter Property="Background" Value="{ThemeResource SliderThumbBackground}"/>
                                 <Setter Property="Height" Value="24"/>
                                 <Setter Property="Width" Value="8"/>
+                                <Setter Property="FocusVisualMargin" Value="-14,-6,-14,-6"/>
                                 <Setter Property="Template">
                                     <Setter.Value>
                                         <ControlTemplate TargetType="Thumb">


### PR DESCRIPTION
Issue: #1615
<!-- Link to relevant issue. All PRs should be asociated with an issue -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

- Other... Please describe: Removing functionality


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The IsTouchOptimized property would allow the developer to make the thumbs really big

## What is the new behavior?
Removed the IsTouchOptimized property and added a bigger FocusVisualMargin. 

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/Microsoft/UWPCommunityToolkit/blob/master/docs/.template.md). (for bug fixes / features)
- [ ] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
Removes a property. 

## Other information
Should the property remain and be marked as deprecated but have no functionality? So if you set the IsTouchOptimized property it would do nothing, but wouldn't completely break your build?