### PR TITLE
Strectch the content of the expander header to allow for other content

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/Expander/Expander.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/Expander/Expander.xaml
@@ -12,8 +12,9 @@
         <Setter Property="BorderBrush" Value="{ThemeResource SystemControlForegroundTransparentBrush}" />
         <Setter Property="BorderThickness" Value="{ThemeResource ToggleButtonBorderThemeThickness}" />
         <Setter Property="Padding" Value="8,4,8,4" />
-        <Setter Property="HorizontalAlignment" Value="Left" />
-        <Setter Property="VerticalAlignment" Value="Center" />
+        <Setter Property="HorizontalAlignment" Value="Stretch" />
+        <Setter Property="HorizontalContentAlignment" Value="Left" />
+        <Setter Property="VerticalAlignment" Value="Stretch" />
         <Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}" />
         <Setter Property="FontWeight" Value="Normal" />
         <Setter Property="FontSize" Value="{ThemeResource ControlContentThemeFontSize}" />
@@ -251,10 +252,11 @@
                                           ContentTemplate="{TemplateBinding ContentTemplate}"
                                           ContentTransitions="{TemplateBinding ContentTransitions}"
                                           Content="{TemplateBinding Content}"
+                                          HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
                                           HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                                           Padding="{TemplateBinding Padding}"
+                                          VerticalAlignment="{TemplateBinding VerticalAlignment}"
                                           VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                                          HorizontalAlignment="Left"
                                           RenderTransformOrigin="0.5,0.5" />
                     </Grid>
                 </ControlTemplate>
@@ -584,7 +586,6 @@
                                               TabIndex="0"
                                               AutomationProperties.Name="Expand"
                                               Style="{StaticResource HeaderToggleButtonStyle}" 
-                                              VerticalAlignment="Bottom" HorizontalAlignment="Stretch" 
                                               Foreground="{TemplateBinding Foreground}"
                                               ContentTemplate="{TemplateBinding HeaderTemplate}" Content="{TemplateBinding Header}"
                                               IsChecked="{Binding IsExpanded, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}" />


### PR DESCRIPTION
Issue: #1904
<!-- Link to relevant issue. All PRs should be asociated with an issue -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
- Feature 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
You can only place content for the header to the left because the alignment of the header is to the left

## What is the new behavior?
The header now stretches allowing you to place content to the left and right easily

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [x] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
This doesn't directly address the issue in #1904, which is requesting multiple header properties, but it does allow for content to be placed to the left and right on the header by styling your template
```
<control:Expander Header="Expand Me!">
    <controls:Expander.HeaderTemplate>
        <DataTemplate>
            <Grid>
                <Grid.ColumnDefinitions>
                    <ColumnDefinition Width="*">
                    <ColumnDefinition Width="Auto">
                </Grid.ColumnDefinitions>
            </Grid>
            <TextBlock Text="{Binding}"/>
            <Button Content="Click Me!"/>
        </DataTemplate>
    </controls:Expander.HeaderTemplate>
</control:Expander>
```