### PR TITLE
Remove duplicate compositeTransform.CenterY

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/Carousel/Carousel.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/Carousel/Carousel.cs
@@ -512,7 +512,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
             var compositeTransform = new CompositeTransform();
             compositeTransform.CenterX = 0.5;
             compositeTransform.CenterY = 0.5;
-            compositeTransform.CenterY = 0.5;
 
             carouselItem.Projection = planeProjection;
             carouselItem.RenderTransform = compositeTransform;


### PR DESCRIPTION
Issue: #1935 
<!-- Link to relevant issue. All PRs should be asociated with an issue -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
code 'compositeTransform.CenterY = 0.5;' with line 515 in Carousel class file is duplicate.

## What is the new behavior?
removed the duplicate code.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/Microsoft/UWPCommunityToolkit/blob/master/docs/.template.md). (for bug fixes / features)
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/Microsoft/UWPCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [ ] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
Just remove one line in Carousel class of duplicate code.