### PR TITLE
Fix SlidableListItem multi-window crash: Specify brushes in XAML

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/SlidableListItem/SlidableListItem.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/SlidableListItem/SlidableListItem.cs
@@ -452,7 +452,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 _commandContainer = GetTemplateChild(PartCommandContainer) as Grid;
                 if (_commandContainer != null)
                 {
-                    _commandContainer.Background = LeftBackground as SolidColorBrush;
+                    _commandContainer.Background = LeftBackground as Brush;
                     _commandContainer.Clip = new RectangleGeometry();
                     _commandContainerTransform = new CompositeTransform();
                     _commandContainer.Clip.Transform = _commandContainerTransform;
@@ -631,7 +631,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 // If swiping from left to right, show left command panel.
                 _rightCommandPanel.Opacity = 0;
 
-                _commandContainer.Background = LeftBackground as SolidColorBrush;
+                _commandContainer.Background = LeftBackground as Brush;
                 _commandContainer.Opacity = 1;
                 _leftCommandPanel.Opacity = 1;
 
@@ -672,7 +672,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls
                 // If swiping from right to left, show right command panel.
                 _leftCommandPanel.Opacity = 0;
 
-                _commandContainer.Background = RightBackground as SolidColorBrush;
+                _commandContainer.Background = RightBackground as Brush;
                 _commandContainer.Opacity = 1;
                 _rightCommandPanel.Opacity = 1;
 

--- a/Microsoft.Toolkit.Uwp.UI.Controls/SlidableListItem/SlidableListItem.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/SlidableListItem/SlidableListItem.xaml
@@ -51,6 +51,8 @@
     <Style TargetType="controls:SlidableListItem">
         <Setter Property="LeftForeground" Value="White" />
         <Setter Property="RightForeground" Value="White" />
+        <Setter Property="LeftBackground" Value="LightGray" />
+        <Setter Property="RightBackground" Value="DarkGray" />
         <Setter Property="VerticalAlignment" Value="Stretch" />
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="ActivationWidth" Value="80" />

--- a/Microsoft.Toolkit.Uwp.UI.Controls/SlidableListItem/SlidableListItem.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/SlidableListItem/SlidableListItem.xaml
@@ -51,8 +51,8 @@
     <Style TargetType="controls:SlidableListItem">
         <Setter Property="LeftForeground" Value="White" />
         <Setter Property="RightForeground" Value="White" />
-        <Setter Property="LeftBackground" Value="LightGray" />
-        <Setter Property="RightBackground" Value="DarkGray" />
+        <!--<Setter Property="LeftBackground" Value="LightGray" />
+        <Setter Property="RightBackground" Value="DarkGray" />-->
         <Setter Property="VerticalAlignment" Value="Stretch" />
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="ActivationWidth" Value="80" />

--- a/Microsoft.Toolkit.Uwp.UI.Controls/SlidableListItem/SlidableListItem.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/SlidableListItem/SlidableListItem.xaml
@@ -51,8 +51,8 @@
     <Style TargetType="controls:SlidableListItem">
         <Setter Property="LeftForeground" Value="White" />
         <Setter Property="RightForeground" Value="White" />
-        <!--<Setter Property="LeftBackground" Value="LightGray" />
-        <Setter Property="RightBackground" Value="DarkGray" />-->
+        <Setter Property="LeftBackground" Value="LightGray" />
+        <Setter Property="RightBackground" Value="DarkGray" />
         <Setter Property="VerticalAlignment" Value="Stretch" />
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="ActivationWidth" Value="80" />


### PR DESCRIPTION
Issue: #
https://github.com/Microsoft/UWPCommunityToolkit/issues/1923

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->
- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
LeftBackground & WhiteBackground Brushes are only created in Code behind - because these are DependencyObjects they can't actually be shared between different `CoreDispatcher`s so when used in multiple Windows whilst using the default brushes, thread marshalling errors occur as the brush is trying to set itself on a Dispatcher thread that did not create it.


## What is the new behavior?
Specify LeftBackground and RightBackground properties in default XAML style. 

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/Microsoft/UWPCommunityToolkit/blob/master/docs/.template.md). (for bug fixes / features)
- [x] Sample in sample app has been added / updated (for bug fixes / features)
    - [x] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/Microsoft/UWPCommunityToolkit-design-assets)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes
