### PR TITLE
Fixed a NullReferenceException in AdvancedCollectionView Filter

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI/AdvancedCollectionView/AdvancedCollectionView.cs
+++ b/Microsoft.Toolkit.Uwp.UI/AdvancedCollectionView/AdvancedCollectionView.cs
@@ -534,16 +534,19 @@ namespace Microsoft.Toolkit.Uwp.UI
 
         private void HandleFilterChanged()
         {
-            for (var index = 0; index < _view.Count; index++)
+            if (_filter != null)
             {
-                var item = _view.ElementAt(index);
-                if (_filter(item))
+                for (var index = 0; index < _view.Count; index++)
                 {
-                    continue;
-                }
+                    var item = _view.ElementAt(index);
+                    if (_filter(item))
+                    {
+                        continue;
+                    }
 
-                RemoveFromView(index, item);
-                index--;
+                    RemoveFromView(index, item);
+                    index--;
+                }
             }
 
             var viewHash = new HashSet<object>(_view);


### PR DESCRIPTION
When setting a filter, then resetting it to null,
an exception occured. This has been fixed.

Issue:   https://github.com/Microsoft/UWPCommunityToolkit/issues/1938

## PR Type
What kind of change does this PR introduce?
- Bugfix

Please check if your PR fulfills the following requirements:

- [ x ] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/Microsoft/UWPCommunityToolkit/blob/master/docs/.template.md). (for bug fixes / features)
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/Microsoft/UWPCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [ x ] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
