### PR TITLE
Fix XAML Connected Animation crash (fixes #1913).

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Animations/ConnectedAnimations/ConnectedAnimationHelper.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Animations/ConnectedAnimations/ConnectedAnimationHelper.cs
@@ -66,7 +66,14 @@ namespace Microsoft.Toolkit.Uwp.UI.Animations
                         if (listAnimProperty.ListViewBase.ItemsSource is IEnumerable<object> items &&
                             items.Contains(e.Parameter))
                         {
-                            listAnimProperty.ListViewBase.PrepareConnectedAnimation(props.Key, e.Parameter, listAnimProperty.ElementName);
+                            try
+                            {
+                                listAnimProperty.ListViewBase.PrepareConnectedAnimation(props.Key, e.Parameter, listAnimProperty.ElementName);
+                            }
+                            catch
+                            {
+                                // Ignore
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Issue: #1913 

## PR Type
What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?
The app crashes if there are two lists with the same instance of an object on one page and you add the xaml connected animations that animates the view to a different page.
This simple catch, avoids the app from crashing, if the item instances are the same.

## What is the new behavior?
No crash.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/Microsoft/UWPCommunityToolkit/blob/master/docs/.template.md). (for bug fixes / features)
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/Microsoft/UWPCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [X] Contains **NO** breaking changes



## Other information
