### PR TITLE
Changed AdvancedCollectionView _source to IList

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI/AdvancedCollectionView/AdvancedCollectionView.cs
+++ b/Microsoft.Toolkit.Uwp.UI/AdvancedCollectionView/AdvancedCollectionView.cs
@@ -39,9 +39,7 @@ namespace Microsoft.Toolkit.Uwp.UI
 
         private readonly bool _liveShapingEnabled;
 
-        private IEnumerable _source;
-
-        private IList _sourceList;
+        private IList _source;
 
         private Predicate<object> _filter;
 
@@ -66,7 +64,7 @@ namespace Microsoft.Toolkit.Uwp.UI
         /// </summary>
         /// <param name="source">source IEnumerable</param>
         /// <param name="isLiveShaping">Denotes whether or not this ACV should re-filter/re-sort if a PropertyChanged is raised for an observed property.</param>
-        public AdvancedCollectionView(IEnumerable source, bool isLiveShaping = false)
+        public AdvancedCollectionView(IList source, bool isLiveShaping = false)
         {
             _liveShapingEnabled = isLiveShaping;
             _view = new List<object>();
@@ -79,7 +77,7 @@ namespace Microsoft.Toolkit.Uwp.UI
         /// <summary>
         /// Gets or sets the source
         /// </summary>
-        public IEnumerable Source
+        public IList Source
         {
             get
             {
@@ -101,7 +99,6 @@ namespace Microsoft.Toolkit.Uwp.UI
 
                 _source = value;
                 AttachPropertyChangedHandler(_source);
-                _sourceList = value as IList;
 
                 _sourceWeakEventListener?.Detach();
 
@@ -159,7 +156,7 @@ namespace Microsoft.Toolkit.Uwp.UI
                 throw new NotSupportedException("Collection is read-only.");
             }
 
-            _sourceList.Add(item);
+            _source.Add(item);
         }
 
         /// <inheritdoc />
@@ -170,7 +167,7 @@ namespace Microsoft.Toolkit.Uwp.UI
                 throw new NotSupportedException("Collection is read-only.");
             }
 
-            _sourceList.Clear();
+            _source.Clear();
         }
 
         /// <inheritdoc />
@@ -187,7 +184,7 @@ namespace Microsoft.Toolkit.Uwp.UI
                 throw new NotSupportedException("Collection is read-only.");
             }
 
-            _sourceList.Remove(item);
+            _source.Remove(item);
             return true;
         }
 
@@ -195,7 +192,7 @@ namespace Microsoft.Toolkit.Uwp.UI
         public int Count => _view.Count;
 
         /// <inheritdoc />
-        public bool IsReadOnly => _sourceList == null || _sourceList.IsReadOnly;
+        public bool IsReadOnly => _source == null || _source.IsReadOnly;
 
         /// <inheritdoc />
         public int IndexOf(object item) => _view.IndexOf(item);
@@ -208,7 +205,7 @@ namespace Microsoft.Toolkit.Uwp.UI
                 throw new NotSupportedException("Collection is read-only.");
             }
 
-            _sourceList.Insert(index, item);
+            _source.Insert(index, item);
         }
 
         /// <summary>
@@ -475,7 +472,7 @@ namespace Microsoft.Toolkit.Uwp.UI
                 }
                 else if (viewIndex == -1 && filterResult.Value)
                 {
-                    var index = _sourceList.IndexOf(item);
+                    var index = _source.IndexOf(item);
                     HandleItemAdded(index, item);
                 }
             }
@@ -548,9 +545,9 @@ namespace Microsoft.Toolkit.Uwp.UI
 
             var viewHash = new HashSet<object>(_view);
             var viewIndex = 0;
-            for (var index = 0; index < _sourceList.Count; index++)
+            for (var index = 0; index < _source.Count; index++)
             {
-                var item = _sourceList[index];
+                var item = _source[index];
                 if (viewHash.Contains(item))
                 {
                     viewIndex++;
@@ -659,7 +656,7 @@ namespace Microsoft.Toolkit.Uwp.UI
             }
             else if (_filter != null)
             {
-                if (_sourceList == null)
+                if (_source == null)
                 {
                     HandleSourceChanged();
                     return false;
@@ -669,7 +666,7 @@ namespace Microsoft.Toolkit.Uwp.UI
                 {
                     newViewIndex = 0;
                 }
-                else if (newStartingIndex == _sourceList.Count - 1)
+                else if (newStartingIndex == _source.Count - 1)
                 {
                     newViewIndex = _view.Count - 1;
                 }
@@ -679,7 +676,7 @@ namespace Microsoft.Toolkit.Uwp.UI
                 }
                 else
                 {
-                    for (int i = 0, j = 0; i < _sourceList.Count; i++)
+                    for (int i = 0, j = 0; i < _source.Count; i++)
                     {
                         if (i == newStartingIndex)
                         {
@@ -687,7 +684,7 @@ namespace Microsoft.Toolkit.Uwp.UI
                             break;
                         }
 
-                        if (_view[j] == _sourceList[i])
+                        if (_view[j] == _source[i])
                         {
                             j++;
                         }


### PR DESCRIPTION
Issue: #1940 

## PR Type
What kind of change does this PR introduce?
- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
Using `IEnumerable` with `AdvancedCollectionView` causes unexpected behaviors

## What is the new behavior?
`AdvancedCollectionView` now takes `IList` parameters.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/Microsoft/UWPCommunityToolkit/blob/master/docs/.template.md). (for bug fixes / features)
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/Microsoft/UWPCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [ ] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
This PR contains a breaking change. Every project using AdvancedCollectionView with IEnumerables will stop compiling, and will have to change their collection to implement IList.