### PR TITLE
Fix NavigationViewExtensions for build 17134

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI/Extensions/NavigationView/NavigationViewExtensions.cs
+++ b/Microsoft.Toolkit.Uwp.UI/Extensions/NavigationView/NavigationViewExtensions.cs
@@ -25,6 +25,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions
         // Name of Content area in NavigationView Template.
         private const string CONTENT_GRID = "ContentGrid";
 
+        // Name of the 'Unselected' item we use to track null selection to workaround NavigationView behavior change in 17134.
+        private const string UNSELECTED_ITEM_NAME = "UWPT_NVE_UNSELECTED";
+
         /// <summary>
         /// Gets the index of the selected <see cref="NavigationViewItem"/>.
         /// </summary>
@@ -102,6 +105,21 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions
         public static readonly DependencyProperty CollapseOnClickProperty =
             DependencyProperty.RegisterAttached("CollapseOnClick", typeof(bool), typeof(NavigationViewExtensions), new PropertyMetadata(false, OnCollapseOnClickChanged));
 
+        // Private helper to mark a hidden object for 'unselected' state to work around not being able to set SelectedItem to null in 17134.
+        private static NavigationViewItem GetSelectionPlaceholder(NavigationView obj)
+        {
+            return (NavigationViewItem)obj.GetValue(SelectionPlaceholderProperty);
+        }
+
+        private static void SetSelectionPlaceholder(NavigationView obj, NavigationViewItem value)
+        {
+            obj.SetValue(SelectionPlaceholderProperty, value);
+        }
+
+        // Using a DependencyProperty as the backing store for SelectionPlaceholder.  This enables animation, styling, binding, etc...
+        private static readonly DependencyProperty SelectionPlaceholderProperty =
+            DependencyProperty.RegisterAttached("SelectionPlaceholder", typeof(NavigationViewItem), typeof(NavigationViewItem), new PropertyMetadata(null));
+
         private static void OnCollapseOnClickChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             // This should always be a NavigationView.
@@ -128,8 +146,14 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions
 
         private static void Navview_ItemInvoked(NavigationView sender, NavigationViewItemInvokedEventArgs args)
         {
+            // We're doing this here instead of on property initialization
+            // so that we add our 'dummy' item at the end of the list
+            // and don't disrupt the order of the list.
+            InjectSelectionPlaceholder(sender);
+
             var content = sender.FindDescendantByName(CONTENT_GRID);
 
+            var unselected = GetSelectionPlaceholder(sender);
             if (content != null)
             {
                 // If we click the item we already have selected, we want to collapse our content
@@ -138,17 +162,17 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions
                     args.InvokedItem == sender.SelectedItem :
                     args.InvokedItem.Equals(((NavigationViewItem)sender.SelectedItem).Content))
                  */
-                if (sender.SelectedItem != null &&
+                if (sender.SelectedItem != null && sender.SelectedItem != unselected &&
                     args.InvokedItem.Equals(((NavigationViewItem)sender.SelectedItem).Content))
                 {
                     // We need to dispatch this so the underlying selection event from our invoke processes.
                     // Otherwise, we just end up back where we started.  We don't care about waiting for this to finish.
-#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+                    #pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
                     sender.Dispatcher.RunIdleAsync((e) =>
                     {
-                        sender.SelectedItem = null;
+                        sender.SelectedItem = unselected;
                     });
-#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+                    #pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
 
                     content.Visibility = Visibility.Collapsed;
                 }
@@ -159,9 +183,32 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions
             }
         }
 
+        // Check if we've injected our workaround or not yet for 17134 (prevents setting SelectedItem back to null).
+        private static void InjectSelectionPlaceholder(NavigationView sender)
+        {
+            if (sender != null && GetSelectionPlaceholder(sender) == null)
+            {
+                var temp = new NavigationViewItem()
+                {
+                    Content = UNSELECTED_ITEM_NAME,
+                    Visibility = Visibility.Collapsed
+                };
+
+                sender.MenuItems.Add(temp);
+                SetSelectionPlaceholder(sender, temp);
+            }
+        }
+
         private static void OnSelectedIndexChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             var navview = (NavigationView)d;
+
+            // If we're trying to unselect something, inject then.
+            // Otherwise we'll mess up starting order of items and indices.
+            if (e.NewValue as int? == -1)
+            {
+                InjectSelectionPlaceholder(navview);
+            }
 
             navview.Loaded -= Navview_Loaded;
             Navview_Loaded(d, null); // For changes
@@ -193,6 +240,18 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions
 
             if (value >= 0 && value < navview.MenuItems.Count)
             {
+                // Skip over our hidden item, if needed.
+                if (navview.MenuItems[value] == GetSelectionPlaceholder(navview))
+                {
+                    value++;
+                    if (value >= navview.MenuItems.Count)
+                    {
+                        navview.SelectedItem = GetSelectionPlaceholder(navview);
+
+                        return;
+                    }
+                }
+
                 // Only update if we need to.
                 if (navview.SelectedItem == null || !navview.SelectedItem.Equals(navview.MenuItems[value] as NavigationViewItem))
                 {
@@ -205,7 +264,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions
             }
             else
             {
-                navview.SelectedItem = null;
+                navview.SelectedItem = GetSelectionPlaceholder(navview);
             }
         }
 
@@ -214,7 +273,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Extensions
             // Store state of settings selected.
             SetIsSettingsSelected(sender, args.IsSettingsSelected);
 
-            if (!args.IsSettingsSelected && args.SelectedItem != null)
+            if (!args.IsSettingsSelected && args.SelectedItem != null &&
+                args.SelectedItem != GetSelectionPlaceholder(sender))
             {
                 var index = sender.MenuItems.IndexOf(args.SelectedItem);
                 if (index != GetSelectedIndex(sender))


### PR DESCRIPTION
Issue: #1949 
<!-- Link to relevant issue. All PRs should be associated with an issue -->

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
On the new windows release, the NavigationView prevents setting `SelectedItem` back to null, this breaks the `CollapseOnClick` feature added in the Toolkit.

## What is the new behavior?
This fix introduces a hidden menu item which is used to emulate deselecting all other menu items.

It also fixes another selection issue that was happening with the Settings menu.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/Microsoft/UWPCommunityToolkit/blob/master/docs/.template.md). (for bug fixes / features)
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/Microsoft/UWPCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes

## Other information
I've tested on RS4, but need to find an RS3 machine to test on.  There shouldn't be a problem, it's just a bit more overhead.

I may add some unit tests for the initial parsing/value selections, but not sure how that'll work without a visual test.