### PR TITLE
Don't obtain a GazeInputSourcePreview instance until it is known that…

### DIFF
--- a/Microsoft.Toolkit.Uwp.Input.GazeInteraction/GazePointer.cpp
+++ b/Microsoft.Toolkit.Uwp.Input.GazeInteraction/GazePointer.cpp
@@ -69,8 +69,7 @@ GazePointer::GazePointer()
 
     InitializeHistogram();
 
-    auto view = GazeInputSourcePreview::GetForCurrentView();
-    _watcher = view->CreateWatcher();
+    _watcher = GazeInputSourcePreview::CreateWatcher();
     _watcher->Added += ref new TypedEventHandler<GazeDeviceWatcherPreview^, GazeDeviceWatcherAddedPreviewEventArgs^>(this, &GazePointer::OnDeviceAdded);
     _watcher->Removed += ref new TypedEventHandler<GazeDeviceWatcherPreview^, GazeDeviceWatcherRemovedPreviewEventArgs^>(this, &GazePointer::OnDeviceRemoved);
     _watcher->Start();
@@ -83,6 +82,8 @@ void GazePointer::OnDeviceAdded(GazeDeviceWatcherPreview^ sender, GazeDeviceWatc
     if (_deviceCount == 1)
     {
         IsDeviceAvailableChanged(nullptr, nullptr);
+
+        InitializeGazeInputSource();
     }
 }
 
@@ -171,15 +172,18 @@ void GazePointer::InitializeHistogram()
 
 void GazePointer::InitializeGazeInputSource()
 {
-    _gazeInputSource = GazeInputSourcePreview::GetForCurrentView();
-    if (_gazeInputSource != nullptr)
+    if (_gazeInputSource == nullptr && _roots->Size != 0 && _deviceCount != 0)
     {
-        _gazeEnteredToken = _gazeInputSource->GazeEntered += ref new TypedEventHandler<
-            GazeInputSourcePreview^, GazeEnteredPreviewEventArgs^>(this, &GazePointer::OnGazeEntered);
-        _gazeMovedToken = _gazeInputSource->GazeMoved += ref new TypedEventHandler<
-            GazeInputSourcePreview^, GazeMovedPreviewEventArgs^>(this, &GazePointer::OnGazeMoved);
-        _gazeExitedToken = _gazeInputSource->GazeExited += ref new TypedEventHandler<
-            GazeInputSourcePreview^, GazeExitedPreviewEventArgs^>(this, &GazePointer::OnGazeExited);
+        _gazeInputSource = GazeInputSourcePreview::GetForCurrentView();
+        if (_gazeInputSource != nullptr)
+        {
+            _gazeEnteredToken = _gazeInputSource->GazeEntered += ref new TypedEventHandler<
+                GazeInputSourcePreview^, GazeEnteredPreviewEventArgs^>(this, &GazePointer::OnGazeEntered);
+            _gazeMovedToken = _gazeInputSource->GazeMoved += ref new TypedEventHandler<
+                GazeInputSourcePreview^, GazeMovedPreviewEventArgs^>(this, &GazePointer::OnGazeMoved);
+            _gazeExitedToken = _gazeInputSource->GazeExited += ref new TypedEventHandler<
+                GazeInputSourcePreview^, GazeExitedPreviewEventArgs^>(this, &GazePointer::OnGazeExited);
+        }
     }
 }
 


### PR DESCRIPTION
… an eye tracker is present, and hence do not show the privacy dialog until it is relevant. (Also probably fixed an issue where events would be multiply subscribed if an eye tracker was removed and added back.)

Issue: #
<!-- Link to relevant issue. All PRs should be asociated with an issue -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/Microsoft/UWPCommunityToolkit/blob/master/docs/.template.md). (for bug fixes / features)
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/Microsoft/UWPCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [ ] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
